### PR TITLE
fix submission script for POSYDON v2

### DIFF
--- a/bin/posydon-run-grid
+++ b/bin/posydon-run-grid
@@ -172,6 +172,9 @@ def create_working_directory(grid_param_dict, args):
     # first name directories which we do not need to log
     directory_name_from_dict_no_log =  '_'.join(['{0}_{1:.4f}'.format(k, v) for k, v in grid_param_dict.items() if k not in variable_names_to_log])
     directory_name_from_dict_log = '_'.join(['{0}_{1:.4e}'.format(k, v) for k, v in grid_param_dict.items() if k in variable_names_to_log])
+    # drop parenthesis
+    directory_name_from_dict_no_log = directory_name_from_dict_no_log.replace('(','')
+    directory_name_from_dict_no_log = directory_name_from_dict_no_log.replace(')','')
 
     # combine and add on what grid number we are running if exists
     directory_name_from_dict = '{0}_{1}'.format(directory_name_from_dict_no_log, directory_name_from_dict_log)
@@ -242,6 +245,11 @@ def create_binary_inlists(binary_controls, binary_job,
                     inlist_grid_points.write("\t{0} = {1:.10f}d0\n".format(k, v))
                 elif (type(v) == float) and (v.is_integer()):
                     inlist_grid_points.write("\t{0} = {1}\n".format(k, int(v)))
+                elif type(v) == bool:
+                    if v:
+                        inlist_grid_points.write("\t{0} = .true.\n".format(k))
+                    else:
+                        inlist_grid_points.write("\t{0} = .fale.\n".format(k))
                 else:
                     inlist_grid_points.write("{0} = {1}\n".format(k, v))
             inlist_grid_points.write("/ ! end of binary_controls namelist\n")
@@ -254,6 +262,11 @@ def create_binary_inlists(binary_controls, binary_job,
                     inlist_grid_points.write("\t{0} = {1:.10f}d0\n".format(k, v))
                 elif (type(v) == float) and (v.is_integer()):
                     inlist_grid_points.write("\t{0} = {1}\n".format(k, int(v)))
+                elif type(v) == bool:
+                    if v:
+                        inlist_grid_points.write("\t{0} = .true.\n".format(k))
+                    else:
+                        inlist_grid_points.write("\t{0} = .fale.\n".format(k))
                 else:
                     inlist_grid_points.write("{0} = {1}\n".format(k, v))
             inlist_grid_points.write("/ ! end of binary_job namelist\n")
@@ -267,6 +280,11 @@ def create_binary_inlists(binary_controls, binary_job,
                     inlist_grid_points.write("\t{0} = {1:.10f}d0\n".format(k, v))
                 elif (type(v) == float) and (v.is_integer()):
                     inlist_grid_points.write("\t{0} = {1}\n".format(k, int(v)))
+                elif type(v) == bool:
+                    if v:
+                        inlist_grid_points.write("\t{0} = .true.\n".format(k))
+                    else:
+                        inlist_grid_points.write("\t{0} = .fale.\n".format(k))
                 else:
                     inlist_grid_points.write("{0} = {1}\n".format(k, v))
             inlist_grid_points.write("/ ! end of controls namelist\n")
@@ -280,6 +298,11 @@ def create_binary_inlists(binary_controls, binary_job,
                     inlist_grid_points.write("\t{0} = {1:.10f}d0\n".format(k, v))
                 elif (type(v) == float) and (v.is_integer()):
                     inlist_grid_points.write("\t{0} = {1}\n".format(k, int(v)))
+                elif type(v) == bool:
+                    if v:
+                        inlist_grid_points.write("\t{0} = .true.\n".format(k))
+                    else:
+                        inlist_grid_points.write("\t{0} = .fale.\n".format(k))
                 else:
                     inlist_grid_points.write("{0} = {1}\n".format(k, v))
             inlist_grid_points.write("/ ! end of controls namelist\n")
@@ -293,6 +316,11 @@ def create_binary_inlists(binary_controls, binary_job,
                     inlist_grid_points.write("\t{0} = {1:.10f}d0\n".format(k, v))
                 elif (type(v) == float) and (v.is_integer()):
                     inlist_grid_points.write("\t{0} = {1}\n".format(k, int(v)))
+                elif type(v) == bool:
+                    if v:
+                        inlist_grid_points.write("\t{0} = .true.\n".format(k))
+                    else:
+                        inlist_grid_points.write("\t{0} = .fale.\n".format(k))
                 else:
                     inlist_grid_points.write("{0} = {1}\n".format(k, v))
             inlist_grid_points.write("/ ! end of star_job namelist\n")
@@ -306,6 +334,11 @@ def create_binary_inlists(binary_controls, binary_job,
                     inlist_grid_points.write("\t{0} = {1:.10f}d0\n".format(k, v))
                 elif (type(v) == float) and (v.is_integer()):
                     inlist_grid_points.write("\t{0} = {1}\n".format(k, int(v)))
+                elif type(v) == bool:
+                    if v:
+                        inlist_grid_points.write("\t{0} = .true.\n".format(k))
+                    else:
+                        inlist_grid_points.write("\t{0} = .fale.\n".format(k))
                 else:
                     inlist_grid_points.write("{0} = {1}\n".format(k, v))
             inlist_grid_points.write("/ ! end of star_job namelist\n")

--- a/bin/posydon-run-grid
+++ b/bin/posydon-run-grid
@@ -345,7 +345,7 @@ def create_binary_inlists(binary_controls, binary_job,
 
     return
 
-def create_star_formation(mass, work_dir, star_inlist_project, new_Z=None):
+def create_star_formation(mass, work_dir, star_inlist_project, initial_z=None, new_Z=False):
     """Create the inlist and inlist grid points needed to run this part of grid
     """
 
@@ -379,12 +379,13 @@ def create_star_formation(mass, work_dir, star_inlist_project, new_Z=None):
     with open(os.path.join(work_dir, 'inlist_grid_points'), 'w') as inlist_grid_points:
         inlist_grid_points.write("&controls\n")
         inlist_grid_points.write("initial_mass = {0:.10f}d0\n".format(mass))
-        if new_Z is not None:
-            inlist_grid_points.write("Zbase = {0:.10f}d0\n".format(new_Z))
+        if initial_z is not None:
+            inlist_grid_points.write("initial_z = {0:.10f}d0\n".format(initial_z))
+            inlist_grid_points.write("Zbase = {0:.10f}d0\n".format(initial_z))
         inlist_grid_points.write("/ ! end of star_controls namelist\n")
         inlist_grid_points.write("&star_job\n")
-        if new_Z is not None:
-            inlist_grid_points.write("new_Z = {0:.10f}d0\n".format(new_Z))
+        if new_Z:
+            inlist_grid_points.write("new_Z = {0:.10f}d0\n".format(initial_z))
         inlist_grid_points.write("/ ! end of star_job namelist\n")
         inlist_grid_points.close()
 
@@ -643,10 +644,12 @@ def run_grid_point(grid, star1_formation, star2_formation,
         # if yes then create inlists specific to this grid points
         # moreover we should loop over all the star1 formation steps
         for index, inlist_step in enumerate(args.mesa_star1_inlist_project):
+            # this is only called to create single HeMS stars, only second step1
+            # requires metallicity
             if index == 0:
                 create_star_formation(grid_param_dict['m1'], work_dir, inlist_step)
             elif index == 1:
-                create_star_formation(grid_param_dict['m1'], work_dir, inlist_step, grid_param_dict['new_Z'])
+                create_star_formation(grid_param_dict['m1'], work_dir, inlist_step, grid_param_dict['initial_z'], True)
             run_mesa(args.mesa_star1_executable, work_dir, final_dir,
                      outfile_name='out_star1_formation_step{0}.txt'.format(index))
 
@@ -655,10 +658,12 @@ def run_grid_point(grid, star1_formation, star2_formation,
         # if yes then create inlists specific to this grid points
         # moreover we should loop over all the star1 formation steps
         for index, inlist_step in enumerate(args.mesa_star2_inlist_project):
+            # this is only called to create single HeMS stars, only second step1
+            # requires metallicity
             if index == 0:
                 create_star_formation(grid_param_dict['m2'], work_dir, inlist_step)
             elif index == 1:
-                create_star_formation(grid_param_dict['m2'], work_dir, inlist_step, grid_param_dict['new_Z'])
+                create_star_formation(grid_param_dict['m2'], work_dir, inlist_step, grid_param_dict['initial_z'], True)
             run_mesa(args.mesa_star2_executable, work_dir, final_dir,
                      outfile_name='out_star2_formation_step{0}.txt'.format(index))
 
@@ -792,11 +797,17 @@ if __name__ == '__main__':
         work_dir, final_dir = create_working_directory(grid_param_dict, args)
 
         # run the single star grid
+        last_step = len(args.mesa_star1_inlist_project) - 1
         for index, inlist_step in enumerate(args.mesa_star1_inlist_project):
-            if index == 0:
-                create_star_formation(grid_param_dict['initial_mass'], work_dir, inlist_step)
+            # single_HMS star has only step0, metallicity is required but not new_Z
+            # single_HeMS star has step0, step1, step2, last two steps require metallicity
+            # but only step1 requires new_Z
+            if index == last_step:
+                create_star_formation(grid_param_dict['initial_mass'], work_dir, inlist_step, grid_param_dict['initial_z'], False)
             elif index == 1:
-                create_star_formation(grid_param_dict['initial_mass'], work_dir, inlist_step, grid_param_dict['new_Z'])
+                create_star_formation(grid_param_dict['initial_mass'], work_dir, inlist_step, grid_param_dict['initial_z'], True)
+            else :
+                create_star_formation(grid_param_dict['initial_mass'], work_dir, inlist_step)
             run_mesa(args.mesa_star1_executable, work_dir, final_dir,
                      outfile_name='out_star1_formation_step{0}.txt'.format(index))
 

--- a/bin/posydon-run-grid
+++ b/bin/posydon-run-grid
@@ -117,6 +117,12 @@ def parse_commandline():
     parser.add_argument("--verbose", action="store_true", default=False,
                         help="Run in Verbose Mode")
 
+    parser.add_argument("--keep_profiles", action="store_true", default=False,
+                        help="Do not delete profiles at run completion")
+
+    parser.add_argument("--keep_photos", action="store_true", default=False,
+                        help="Do not delete photos at run completion")
+
     args = parser.parse_args()
 
     if args.grid_type not in ['fixed', 'dynamic']:
@@ -401,21 +407,28 @@ def run_mesa(mesa_executable, work_dir, final_dir, **kwargs):
         final_dir:
             When completed where would you like the output to go
     """
+
     outfile_name = kwargs.pop('outfile_name', 'out.txt')
+    keep_profiles = kwargs.pop('keep_profiles', False)
+    keep_photos = kwargs.pop('keep_photos', False)
+
     os.chdir(work_dir)
     os.system("{0} &> {1}".format(mesa_executable, os.path.join(work_dir, outfile_name)))
 
-    if os.path.exists(os.path.join(work_dir, 'LOGS')):
-        os.chmod(os.path.join(work_dir, 'LOGS'), stat.S_IRWXU  | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH )
-        os.system("rm LOGS/profile*")
-    if os.path.exists(os.path.join(work_dir, 'LOGS1')):
-        os.chmod(os.path.join(work_dir, 'LOGS1'), stat.S_IRWXU  | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH )
-        os.system("rm LOGS1/profile*")
-    if os.path.exists(os.path.join(work_dir, 'LOGS2')):
-        os.chmod(os.path.join(work_dir, 'LOGS2'), stat.S_IRWXU  | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH )
-        os.system("rm LOGS2/profile*")
+    if not keep_profiles:
+        if os.path.exists(os.path.join(work_dir, 'LOGS')):
+            os.chmod(os.path.join(work_dir, 'LOGS'), stat.S_IRWXU  | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH )
+            os.system("rm LOGS/profile*")
+        if os.path.exists(os.path.join(work_dir, 'LOGS1')):
+            os.chmod(os.path.join(work_dir, 'LOGS1'), stat.S_IRWXU  | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH )
+            os.system("rm LOGS1/profile*")
+        if os.path.exists(os.path.join(work_dir, 'LOGS2')):
+            os.chmod(os.path.join(work_dir, 'LOGS2'), stat.S_IRWXU  | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH )
+            os.system("rm LOGS2/profile*")
     if os.path.exists(os.path.join(work_dir, '.mesa_temp_cache')): os.system("rm -rf .mesa_temp_cache")
-    os.system("rm -rf photos*")
+
+    if not keep_photos:
+        os.system("rm -rf photos*")
 
     if not work_dir == final_dir:
         if os.path.isdir(final_dir):
@@ -674,7 +687,9 @@ def run_grid_point(grid, star1_formation, star2_formation,
                           work_dir, args.mesa_binary_inlist_project)
 
     # run the binary exectuable
-    run_mesa(args.mesa_binary_executable, work_dir, final_dir)
+    run_mesa(args.mesa_binary_executable, work_dir, final_dir,
+             keep_profiles=args.keep_profiles,
+             keep_photos=args.keep_photos)
 
     # find out what happened
     mesa_result = extract_mesa_results(final_dir)
@@ -809,7 +824,9 @@ if __name__ == '__main__':
             else :
                 create_star_formation(grid_param_dict['initial_mass'], work_dir, inlist_step)
             run_mesa(args.mesa_star1_executable, work_dir, final_dir,
-                     outfile_name='out_star1_formation_step{0}.txt'.format(index))
+                     outfile_name='out_star1_formation_step{0}.txt'.format(index),
+                     keep_profiles=args.keep_profiles,
+                     keep_photos=args.keep_photos)
 
         sys.exit(0)
 

--- a/bin/posydon-run-grid
+++ b/bin/posydon-run-grid
@@ -312,7 +312,7 @@ def create_binary_inlists(binary_controls, binary_job,
 
     return
 
-def create_star_formation(mass, work_dir, star_inlist_project, initial_z=None):
+def create_star_formation(mass, work_dir, star_inlist_project, new_Z=None):
     """Create the inlist and inlist grid points needed to run this part of grid
     """
 
@@ -332,6 +332,8 @@ def create_star_formation(mass, work_dir, star_inlist_project, initial_z=None):
 
       read_extra_star_job_inlist1 = .true.
       extra_star_job_inlist1_name = '{0}'
+      read_extra_star_job_inlist2 = .true.
+      extra_star_job_inlist2_name = 'inlist_grid_points'
 
 / ! end of job namelist
                         """.format(star_inlist_project)
@@ -344,9 +346,13 @@ def create_star_formation(mass, work_dir, star_inlist_project, initial_z=None):
     with open(os.path.join(work_dir, 'inlist_grid_points'), 'w') as inlist_grid_points:
         inlist_grid_points.write("&controls\n")
         inlist_grid_points.write("initial_mass = {0}d0\n".format(mass))
-        if initial_z is not None:
-            inlist_grid_points.write("initial_z = {0}d0\n".format(initial_z))
-        inlist_grid_points.write("/ ! end of binary_controls namelist\n")
+        if new_Z is not None:
+            inlist_grid_points.write("Zbase = {0}d0\n".format(new_Z))
+        inlist_grid_points.write("/ ! end of star_controls namelist\n")
+        inlist_grid_points.write("&star_job\n")
+        if new_Z is not None:
+            inlist_grid_points.write("new_Z = {0}d0\n".format(new_Z))
+        inlist_grid_points.write("/ ! end of star_job namelist\n")
         inlist_grid_points.close()
 
     return
@@ -604,7 +610,10 @@ def run_grid_point(grid, star1_formation, star2_formation,
         # if yes then create inlists specific to this grid points
         # moreover we should loop over all the star1 formation steps
         for index, inlist_step in enumerate(args.mesa_star1_inlist_project):
-            create_star_formation(grid_param_dict['m1'], work_dir, inlist_step)
+            if index == 0:
+                create_star_formation(grid_param_dict['m1'], work_dir, inlist_step)
+            elif index == 1:
+                create_star_formation(grid_param_dict['m1'], work_dir, inlist_step, grid_param_dict['new_Z'])
             run_mesa(args.mesa_star1_executable, work_dir, final_dir,
                      outfile_name='out_star1_formation_step{0}.txt'.format(index))
 
@@ -613,7 +622,10 @@ def run_grid_point(grid, star1_formation, star2_formation,
         # if yes then create inlists specific to this grid points
         # moreover we should loop over all the star1 formation steps
         for index, inlist_step in enumerate(args.mesa_star2_inlist_project):
-            create_star_formation(grid_param_dict['m2'], work_dir, inlist_step)
+            if index == 0:
+                create_star_formation(grid_param_dict['m2'], work_dir, inlist_step)
+            elif index == 1:
+                create_star_formation(grid_param_dict['m2'], work_dir, inlist_step, grid_param_dict['new_Z'])
             run_mesa(args.mesa_star2_executable, work_dir, final_dir,
                      outfile_name='out_star2_formation_step{0}.txt'.format(index))
 
@@ -748,7 +760,10 @@ if __name__ == '__main__':
 
         # run the single star grid
         for index, inlist_step in enumerate(args.mesa_star1_inlist_project):
-            create_star_formation(grid_param_dict['initial_mass'], work_dir, inlist_step)
+            if index == 0:
+                create_star_formation(grid_param_dict['initial_mass'], work_dir, inlist_step)
+            elif index == 1:
+                create_star_formation(grid_param_dict['initial_mass'], work_dir, inlist_step, grid_param_dict['new_Z'])
             run_mesa(args.mesa_star1_executable, work_dir, final_dir,
                      outfile_name='out_star1_formation_step{0}.txt'.format(index))
 

--- a/bin/posydon-run-grid
+++ b/bin/posydon-run-grid
@@ -239,7 +239,7 @@ def create_binary_inlists(binary_controls, binary_job,
             inlist_grid_points.write("&binary_controls\n")
             for k, v in binary_controls.items():
                 if (type(v) == float) and (not v.is_integer()):
-                    inlist_grid_points.write("\t{0} = {1}d0\n".format(k, v))
+                    inlist_grid_points.write("\t{0} = {1:.10f}d0\n".format(k, v))
                 elif (type(v) == float) and (v.is_integer()):
                     inlist_grid_points.write("\t{0} = {1}\n".format(k, int(v)))
                 else:
@@ -251,7 +251,7 @@ def create_binary_inlists(binary_controls, binary_job,
             inlist_grid_points.write("&binary_job\n")
             for k, v in binary_job.items():
                 if (type(v) == float) and (not v.is_integer()):
-                    inlist_grid_points.write("\t{0} = {1}d0\n".format(k, v))
+                    inlist_grid_points.write("\t{0} = {1:.10f}d0\n".format(k, v))
                 elif (type(v) == float) and (v.is_integer()):
                     inlist_grid_points.write("\t{0} = {1}\n".format(k, int(v)))
                 else:
@@ -264,7 +264,7 @@ def create_binary_inlists(binary_controls, binary_job,
             inlist_grid_points.write("&controls\n")
             for k, v in star1_binary_controls.items():
                 if (type(v) == float) and (not v.is_integer()):
-                    inlist_grid_points.write("\t{0} = {1}d0\n".format(k, v))
+                    inlist_grid_points.write("\t{0} = {1:.10f}d0\n".format(k, v))
                 elif (type(v) == float) and (v.is_integer()):
                     inlist_grid_points.write("\t{0} = {1}\n".format(k, int(v)))
                 else:
@@ -277,7 +277,7 @@ def create_binary_inlists(binary_controls, binary_job,
             inlist_grid_points.write("&controls\n")
             for k, v in star2_binary_controls.items():
                 if (type(v) == float) and (not v.is_integer()):
-                    inlist_grid_points.write("\t{0} = {1}d0\n".format(k, v))
+                    inlist_grid_points.write("\t{0} = {1:.10f}d0\n".format(k, v))
                 elif (type(v) == float) and (v.is_integer()):
                     inlist_grid_points.write("\t{0} = {1}\n".format(k, int(v)))
                 else:
@@ -290,7 +290,7 @@ def create_binary_inlists(binary_controls, binary_job,
             inlist_grid_points.write("&star_job\n")
             for k, v in star1_binary_job.items():
                 if (type(v) == float) and (not v.is_integer()):
-                    inlist_grid_points.write("\t{0} = {1}d0\n".format(k, v))
+                    inlist_grid_points.write("\t{0} = {1:.10f}d0\n".format(k, v))
                 elif (type(v) == float) and (v.is_integer()):
                     inlist_grid_points.write("\t{0} = {1}\n".format(k, int(v)))
                 else:
@@ -303,7 +303,7 @@ def create_binary_inlists(binary_controls, binary_job,
             inlist_grid_points.write("&star_job\n")
             for k, v in star2_binary_job.items():
                 if (type(v) == float) and (not v.is_integer()):
-                    inlist_grid_points.write("\t{0} = {1}d0\n".format(k, v))
+                    inlist_grid_points.write("\t{0} = {1:.10f}d0\n".format(k, v))
                 elif (type(v) == float) and (v.is_integer()):
                     inlist_grid_points.write("\t{0} = {1}\n".format(k, int(v)))
                 else:
@@ -345,13 +345,13 @@ def create_star_formation(mass, work_dir, star_inlist_project, new_Z=None):
 
     with open(os.path.join(work_dir, 'inlist_grid_points'), 'w') as inlist_grid_points:
         inlist_grid_points.write("&controls\n")
-        inlist_grid_points.write("initial_mass = {0}d0\n".format(mass))
+        inlist_grid_points.write("initial_mass = {0:.10f}d0\n".format(mass))
         if new_Z is not None:
-            inlist_grid_points.write("Zbase = {0}d0\n".format(new_Z))
+            inlist_grid_points.write("Zbase = {0:.10f}d0\n".format(new_Z))
         inlist_grid_points.write("/ ! end of star_controls namelist\n")
         inlist_grid_points.write("&star_job\n")
         if new_Z is not None:
-            inlist_grid_points.write("new_Z = {0}d0\n".format(new_Z))
+            inlist_grid_points.write("new_Z = {0:.10f}d0\n".format(new_Z))
         inlist_grid_points.write("/ ! end of star_job namelist\n")
         inlist_grid_points.close()
 

--- a/bin/posydon-setup-grid
+++ b/bin/posydon-setup-grid
@@ -852,7 +852,8 @@ def construct_command_line(number_of_mpi_processes, path_to_grid,
                            inlist_star1_formation, inlist_star2_formation,
                            star_history_columns, binary_history_columns, profile_columns,
                            run_directory, grid_type, path_to_run_grid_exec,
-                           psycris_inifile=None):
+                           psycris_inifile=None, keep_profiles=False,
+                           keep_photos=False):
     """Based on the inifile construct the command line call to posydon-run-grid
     """
     if grid_type == "fixed":
@@ -867,6 +868,10 @@ def construct_command_line(number_of_mpi_processes, path_to_grid,
     command_line += '--mesa-binary-history-columns {11} --mesa-profile-columns {12} '
     command_line += '--output-directory {13} --grid-type {14} '
     command_line += '--psycris-inifile {16}'
+    if keep_profiles:
+        command_line += ' --keep_profiles'
+    if keep_photos:
+        command_line += ' --keep_photos'
     command_line = command_line.format(number_of_mpi_processes,
                                        path_to_grid,
                                        binary_exe,
@@ -917,6 +922,12 @@ if __name__ == '__main__':
 
     if 'scenario' not in mesa_inlists.keys():
         mesa_inlists['scenario'] = None
+
+    if 'keep_profiles' not in run_parameters.keys():
+        run_parameters['keep_profiles'] = False
+
+    if 'keep_photos' not in run_parameters.keys():
+        run_parameters['keep_photos'] = False
 
     if ((not os.path.isfile(run_parameters['grid'])) and (not os.path.isdir(run_parameters['grid']))):
         raise ValueError("Supplied grid does not exist, please check your path and try again")
@@ -990,7 +1001,9 @@ if __name__ == '__main__':
                                               mesa_inlists['profile_columns'],
                                               args.run_directory,
                                               'fixed',
-                                              path_to_run_grid_exec)
+                                              path_to_run_grid_exec,
+                                              keep_profiles=run_parameters['keep_profiles'],
+                                              keep_photos=run_parameters['keep_photos'])
         command_line += ' --grid-point-index $SLURM_ARRAY_TASK_ID'
     else:
         command_line = construct_command_line(slurm['number_of_mpi_tasks']*slurm['number_of_nodes'],
@@ -1009,7 +1022,9 @@ if __name__ == '__main__':
                                               args.run_directory,
                                               args.grid_type,
                                               path_to_run_grid_exec,
-                                              psycris_inifile = run_parameters["psycris_inifile"])
+                                              psycris_inifile = run_parameters["psycris_inifile"],
+                                              keep_profiles=run_parameters['keep_profiles'],
+                                              keep_photos=run_parameters['keep_photos'])
 
     # now we need to know how this person plans to run the above created
     # command. As a shell script? As a SLURM submission? In some other way?

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -1370,20 +1370,24 @@ class PSyGrid:
                     initial_values[key].append(self.initial_values[key][i])
 
             # replace star_1_mass, star_2_mass, period_days, Z
+            NDIG = 10 # rounding matches initial point rounding
             if 'star_1_mass' in self.initial_values.dtype.names:
-                initial_values['m1'] = initial_values['star_1_mass']
+                initial_values['m1'] = np.around(initial_values['star_1_mass'],
+                                                 NDIG)
             if 'star_2_mass' in self.initial_values.dtype.names:
-                initial_values['m2'] = initial_values['star_2_mass']
+                initial_values['m2'] = np.around(initial_values['star_2_mass'],
+                                                 NDIG)
             if 'period_days' in self.initial_values.dtype.names:
-                initial_values['initial_period_in_days'] = initial_values[
-                    'period_days']
+                initial_values['initial_period_in_days'] = np.around(
+                                            initial_values['period_days'],NDIG)
             MESA_dir_name = self.MESA_dirs[0].decode("utf-8")
             if  'initial_z' in MESA_dir_name:
-                initial_values['initial_z'] = initial_values['Z']
+                initial_values['initial_z'] = np.around(initial_values['Z'],
+                                                        NDIG)
             if  'Zbase' in MESA_dir_name:
-                initial_values['Zbase'] = initial_values['Z']
+                initial_values['Zbase'] = np.around(initial_values['Z'], NDIG)
             if  'new_Z' in MESA_dir_name:
-                initial_values['new_Z'] = initial_values['Z']
+                initial_values['new_Z'] = np.around(initial_values['Z'], NDIG)
             for key in self.initial_values.dtype.names:
                 if key not in ['m1', 'm2', 'initial_period_in_days',
                                'Zbase', 'new_Z', 'initial_z']:
@@ -1395,14 +1399,12 @@ class PSyGrid:
                     initial_values[key] = [new_mesa_flag[key]]*n_runs_to_rerun
 
             # create the CSV file
-            NDIG = 10 # rounding matches initial point rounding
             with open(path_to_file+'grid.csv', 'w', newline='') as file:
                 writer = csv.writer(file)
                 writer.writerow(initial_values.keys())
                 for i in range(n_runs_to_rerun):
                     writer.writerow(
-                        [round(initial_values[key][i], NDIG) for key in
-                         initial_values])
+                        [initial_values[key][i]for key in initial_values])
         elif termination_flags is not None and runs_to_rerun is None:
             if isinstance(termination_flags, str):
                 rerun_flags = [termination_flags]
@@ -1429,20 +1431,24 @@ class PSyGrid:
                         initial_values[key].append(self.initial_values[key][i])
 
             # replace star_1_mass, star_2_mass, period_days, Z
+            NDIG = 10 # rounding matches initial point rounding
             if 'star_1_mass' in self.initial_values.dtype.names:
-                initial_values['m1'] = initial_values['star_1_mass']
+                initial_values['m1'] = np.around(initial_values['star_1_mass'],
+                                                 NDIG)
             if 'star_2_mass' in self.initial_values.dtype.names:
-                initial_values['m2'] = initial_values['star_2_mass']
+                initial_values['m2'] = np.around(initial_values['star_2_mass'],
+                                                 NDIG)
             if 'period_days' in self.initial_values.dtype.names:
-                initial_values['initial_period_in_days'] = initial_values[
-                    'period_days']
+                initial_values['initial_period_in_days'] = np.around(
+                                            initial_values['period_days'],NDIG)
             MESA_dir_name = self.MESA_dirs[0].decode("utf-8")
             if  'initial_z' in MESA_dir_name:
-                initial_values['initial_z'] = initial_values['Z']
+                initial_values['initial_z'] = np.around(initial_values['Z'],
+                                                        NDIG)
             if  'Zbase' in MESA_dir_name:
-                initial_values['Zbase'] = initial_values['Z']
+                initial_values['Zbase'] = np.around(initial_values['Z'], NDIG)
             if  'new_Z' in MESA_dir_name:
-                initial_values['new_Z'] = initial_values['Z']
+                initial_values['new_Z'] = np.around(initial_values['Z'], NDIG)
             for key in self.initial_values.dtype.names:
                 if key not in ['m1', 'm2', 'initial_period_in_days', 'Zbase',
                                'new_Z', 'initial_z']:
@@ -1454,14 +1460,12 @@ class PSyGrid:
                     initial_values[key] = [new_mesa_flag[key]]*n_runs_to_rerun
 
             # create the CSV file
-            NDIG = 10 # rounding matches initial point rounding
             with open(path_to_file+'grid.csv', 'w', newline='') as file:
                 writer = csv.writer(file)
                 writer.writerow(initial_values.keys())
                 for i in range(n_runs_to_rerun):
                     writer.writerow(
-                        [round(initial_values[key][i], NDIG) for key in
-                         initial_values])
+                        [initial_values[key][i]for key in initial_values])
         else:
             raise ValueError("Choose either the runs manually, or "
                              "indicate the termination flag(s).")

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -1377,6 +1377,13 @@ class PSyGrid:
             if 'period_days' in self.initial_values.dtype.names:
                 initial_values['initial_period_in_days'] = initial_values[
                     'period_days']
+            MESA_dir_name = self.MESA_dirs[0].decode("utf-8")
+            if  'initial_z' in MESA_dir_name:
+                initial_values['initial_z'] = initial_values['Z']
+            if  'Zbase' in MESA_dir_name:
+                initial_values['Zbase'] = initial_values['Z']
+            if  'new_Z' in MESA_dir_name:
+                initial_values['new_Z'] = initial_values['Z']
             for key in self.initial_values.dtype.names:
                 if key not in ['m1', 'm2', 'initial_period_in_days',
                                'Zbase', 'new_Z', 'initial_z']:
@@ -1388,12 +1395,14 @@ class PSyGrid:
                     initial_values[key] = [new_mesa_flag[key]]*n_runs_to_rerun
 
             # create the CSV file
+            NDIG = 10 # rounding matches initial point rounding
             with open(path_to_file+'grid.csv', 'w', newline='') as file:
                 writer = csv.writer(file)
                 writer.writerow(initial_values.keys())
                 for i in range(n_runs_to_rerun):
                     writer.writerow(
-                        [initial_values[key][i] for key in initial_values])
+                        [round(initial_values[key][i], NDIG) for key in
+                         initial_values])
         elif termination_flags is not None and runs_to_rerun is None:
             if isinstance(termination_flags, str):
                 rerun_flags = [termination_flags]
@@ -1427,6 +1436,13 @@ class PSyGrid:
             if 'period_days' in self.initial_values.dtype.names:
                 initial_values['initial_period_in_days'] = initial_values[
                     'period_days']
+            MESA_dir_name = self.MESA_dirs[0].decode("utf-8")
+            if  'initial_z' in MESA_dir_name:
+                initial_values['initial_z'] = initial_values['Z']
+            if  'Zbase' in MESA_dir_name:
+                initial_values['Zbase'] = initial_values['Z']
+            if  'new_Z' in MESA_dir_name:
+                initial_values['new_Z'] = initial_values['Z']
             for key in self.initial_values.dtype.names:
                 if key not in ['m1', 'm2', 'initial_period_in_days', 'Zbase',
                                'new_Z', 'initial_z']:
@@ -1438,12 +1454,14 @@ class PSyGrid:
                     initial_values[key] = [new_mesa_flag[key]]*n_runs_to_rerun
 
             # create the CSV file
+            NDIG = 10 # rounding matches initial point rounding
             with open(path_to_file+'grid.csv', 'w', newline='') as file:
                 writer = csv.writer(file)
                 writer.writerow(initial_values.keys())
                 for i in range(n_runs_to_rerun):
                     writer.writerow(
-                        [initial_values[key][i] for key in initial_values])
+                        [round(initial_values[key][i], NDIG) for key in
+                         initial_values])
         else:
             raise ValueError("Choose either the runs manually, or "
                              "indicate the termination flag(s).")


### PR DESCRIPTION
This PR introduces some changes in order to run the grids at low metallically for POSYDON v2:
- add metallicity layering in inlist_step1 of the star formation step of CO-HeMS grid
- format python scientific notation to fortran notation (needed to run 0.001Zsun and 0.0001Zsun grid slices)
- rerun method of psygrid sorts out initial_z, Zbase and new_Z when present in the original grid points (needed for the rerun simulations)
- the submission script now recognises booleans and formats them into fortran booleans (needed for x_logical_ctrl(4)=True reruns), also we remove brackets from the simulation directory name as the shell script complains about it
- the submission script can now run low metallicity single HMS and HeMS grids. The first one run with one step0 which requires metallicity as initial_z and Zbase. The second runs in step0, step1, step2 (in contrast to CO-HeMS where step2 does not exists as it is replaced by the binary step). Here step0 does not require any metallicity information, step1 requires initial_z, Zbase and new_Z while the last step does not require new_Z.