### PR TITLE
Save profiles

### DIFF
--- a/bin/posydon-run-grid
+++ b/bin/posydon-run-grid
@@ -117,9 +117,8 @@ def parse_commandline():
     parser.add_argument("--verbose", action="store_true", default=False,
                         help="Run in Verbose Mode")
 
-    parser.add_argument("--keep_profiles", action="store_false", default=False,
+    parser.add_argument("--keep_profiles", action="store_true", default=False,
                         help="Do not delete profiles at run completion")
-
 
     args = parser.parse_args()
 
@@ -365,6 +364,7 @@ def run_mesa(mesa_executable, work_dir, final_dir, **kwargs):
         final_dir:
             When completed where would you like the output to go
     """
+
     outfile_name = kwargs.pop('outfile_name', 'out.txt')
     keep_profiles = kwargs.pop('keep_profiles', False)
 

--- a/bin/posydon-run-grid
+++ b/bin/posydon-run-grid
@@ -117,6 +117,10 @@ def parse_commandline():
     parser.add_argument("--verbose", action="store_true", default=False,
                         help="Run in Verbose Mode")
 
+    parser.add_argument("--keep_profiles", action="store_false", default=False,
+                        help="Do not delete profiles at run completion")
+
+
     args = parser.parse_args()
 
     if args.grid_type not in ['fixed', 'dynamic']:
@@ -362,18 +366,21 @@ def run_mesa(mesa_executable, work_dir, final_dir, **kwargs):
             When completed where would you like the output to go
     """
     outfile_name = kwargs.pop('outfile_name', 'out.txt')
+    keep_profiles = kwargs.pop('keep_profiles', False)
+
     os.chdir(work_dir)
     os.system("{0} &> {1}".format(mesa_executable, os.path.join(work_dir, outfile_name)))
 
-    if os.path.exists(os.path.join(work_dir, 'LOGS')):
-        os.chmod(os.path.join(work_dir, 'LOGS'), stat.S_IRWXU  | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH )
-        os.system("rm LOGS/profile*")
-    if os.path.exists(os.path.join(work_dir, 'LOGS1')):
-        os.chmod(os.path.join(work_dir, 'LOGS1'), stat.S_IRWXU  | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH )
-        os.system("rm LOGS1/profile*")
-    if os.path.exists(os.path.join(work_dir, 'LOGS2')):
-        os.chmod(os.path.join(work_dir, 'LOGS2'), stat.S_IRWXU  | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH )
-        os.system("rm LOGS2/profile*")
+    if not keep_profiles:
+        if os.path.exists(os.path.join(work_dir, 'LOGS')):
+            os.chmod(os.path.join(work_dir, 'LOGS'), stat.S_IRWXU  | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH )
+            os.system("rm LOGS/profile*")
+        if os.path.exists(os.path.join(work_dir, 'LOGS1')):
+            os.chmod(os.path.join(work_dir, 'LOGS1'), stat.S_IRWXU  | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH )
+            os.system("rm LOGS1/profile*")
+        if os.path.exists(os.path.join(work_dir, 'LOGS2')):
+            os.chmod(os.path.join(work_dir, 'LOGS2'), stat.S_IRWXU  | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH )
+            os.system("rm LOGS2/profile*")
     if os.path.exists(os.path.join(work_dir, '.mesa_temp_cache')): os.system("rm -rf .mesa_temp_cache")
     os.system("rm -rf photos*")
 
@@ -624,7 +631,8 @@ def run_grid_point(grid, star1_formation, star2_formation,
                           work_dir, args.mesa_binary_inlist_project)
 
     # run the binary exectuable
-    run_mesa(args.mesa_binary_executable, work_dir, final_dir)
+    run_mesa(args.mesa_binary_executable, work_dir, final_dir,
+             keep_profiles=arg.keep_profiles)
 
     # find out what happened
     mesa_result = extract_mesa_results(final_dir)
@@ -750,7 +758,8 @@ if __name__ == '__main__':
         for index, inlist_step in enumerate(args.mesa_star1_inlist_project):
             create_star_formation(grid_param_dict['initial_mass'], work_dir, inlist_step)
             run_mesa(args.mesa_star1_executable, work_dir, final_dir,
-                     outfile_name='out_star1_formation_step{0}.txt'.format(index))
+                     outfile_name='out_star1_formation_step{0}.txt'.format(index),
+                     keep_profiles=args.keep_profiles)
 
         sys.exit(0)
 

--- a/bin/posydon-run-grid
+++ b/bin/posydon-run-grid
@@ -632,7 +632,7 @@ def run_grid_point(grid, star1_formation, star2_formation,
 
     # run the binary exectuable
     run_mesa(args.mesa_binary_executable, work_dir, final_dir,
-             keep_profiles=arg.keep_profiles)
+             keep_profiles=args.keep_profiles)
 
     # find out what happened
     mesa_result = extract_mesa_results(final_dir)

--- a/bin/posydon-run-grid
+++ b/bin/posydon-run-grid
@@ -120,6 +120,9 @@ def parse_commandline():
     parser.add_argument("--keep_profiles", action="store_true", default=False,
                         help="Do not delete profiles at run completion")
 
+    parser.add_argument("--keep_photos", action="store_true", default=False,
+                        help="Do not delete photos at run completion")
+
     args = parser.parse_args()
 
     if args.grid_type not in ['fixed', 'dynamic']:
@@ -407,6 +410,7 @@ def run_mesa(mesa_executable, work_dir, final_dir, **kwargs):
 
     outfile_name = kwargs.pop('outfile_name', 'out.txt')
     keep_profiles = kwargs.pop('keep_profiles', False)
+    keep_photos = kwargs.pop('keep_photos', False)
 
     os.chdir(work_dir)
     os.system("{0} &> {1}".format(mesa_executable, os.path.join(work_dir, outfile_name)))
@@ -422,7 +426,9 @@ def run_mesa(mesa_executable, work_dir, final_dir, **kwargs):
             os.chmod(os.path.join(work_dir, 'LOGS2'), stat.S_IRWXU  | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH )
             os.system("rm LOGS2/profile*")
     if os.path.exists(os.path.join(work_dir, '.mesa_temp_cache')): os.system("rm -rf .mesa_temp_cache")
-    os.system("rm -rf photos*")
+
+    if not keep_photos:
+        os.system("rm -rf photos*")
 
     if not work_dir == final_dir:
         if os.path.isdir(final_dir):
@@ -682,7 +688,8 @@ def run_grid_point(grid, star1_formation, star2_formation,
 
     # run the binary exectuable
     run_mesa(args.mesa_binary_executable, work_dir, final_dir,
-             keep_profiles=args.keep_profiles)
+             keep_profiles=args.keep_profiles,
+             keep_photos=args.keep_photos)
 
     # find out what happened
     mesa_result = extract_mesa_results(final_dir)
@@ -818,7 +825,8 @@ if __name__ == '__main__':
                 create_star_formation(grid_param_dict['initial_mass'], work_dir, inlist_step)
             run_mesa(args.mesa_star1_executable, work_dir, final_dir,
                      outfile_name='out_star1_formation_step{0}.txt'.format(index),
-                     keep_profiles=args.keep_profiles)
+                     keep_profiles=args.keep_profiles,
+                     keep_photos=args.keep_photos)
 
         sys.exit(0)
 

--- a/bin/posydon-setup-grid
+++ b/bin/posydon-setup-grid
@@ -852,7 +852,7 @@ def construct_command_line(number_of_mpi_processes, path_to_grid,
                            inlist_star1_formation, inlist_star2_formation,
                            star_history_columns, binary_history_columns, profile_columns,
                            run_directory, grid_type, path_to_run_grid_exec,
-                           psycris_inifile=None):
+                           psycris_inifile=None, keep_profiles=False):
     """Based on the inifile construct the command line call to posydon-run-grid
     """
     if grid_type == "fixed":
@@ -866,7 +866,9 @@ def construct_command_line(number_of_mpi_processes, path_to_grid,
     command_line += '--mesa-star2-inlist-project {9} --mesa-star-history-columns {10} '
     command_line += '--mesa-binary-history-columns {11} --mesa-profile-columns {12} '
     command_line += '--output-directory {13} --grid-type {14} '
-    command_line += '--psycris-inifile {16}'
+    command_line += '--psycris-inifile {16} '
+    if keep_profiles:
+        command_line += '--keep_profiles'
     command_line = command_line.format(number_of_mpi_processes,
                                        path_to_grid,
                                        binary_exe,
@@ -917,6 +919,9 @@ if __name__ == '__main__':
 
     if 'scenario' not in mesa_inlists.keys():
         mesa_inlists['scenario'] = None
+
+    if 'keep_profiles' not in run_parameters.keys():
+        run_parameters['keep_profiles'] = False
 
     if ((not os.path.isfile(run_parameters['grid'])) and (not os.path.isdir(run_parameters['grid']))):
         raise ValueError("Supplied grid does not exist, please check your path and try again")
@@ -990,7 +995,8 @@ if __name__ == '__main__':
                                               mesa_inlists['profile_columns'],
                                               args.run_directory,
                                               'fixed',
-                                              path_to_run_grid_exec)
+                                              path_to_run_grid_exec,
+                                              keep_profiles=run_parameters['keep_profiles'])
         command_line += ' --grid-point-index $SLURM_ARRAY_TASK_ID'
     else:
         command_line = construct_command_line(slurm['number_of_mpi_tasks']*slurm['number_of_nodes'],
@@ -1009,7 +1015,8 @@ if __name__ == '__main__':
                                               args.run_directory,
                                               args.grid_type,
                                               path_to_run_grid_exec,
-                                              psycris_inifile = run_parameters["psycris_inifile"])
+                                              psycris_inifile = run_parameters["psycris_inifile"],
+                                              keep_profiles=run_parameters['keep_profiles'])
 
     # now we need to know how this person plans to run the above created
     # command. As a shell script? As a SLURM submission? In some other way?

--- a/bin/posydon-setup-grid
+++ b/bin/posydon-setup-grid
@@ -852,7 +852,8 @@ def construct_command_line(number_of_mpi_processes, path_to_grid,
                            inlist_star1_formation, inlist_star2_formation,
                            star_history_columns, binary_history_columns, profile_columns,
                            run_directory, grid_type, path_to_run_grid_exec,
-                           psycris_inifile=None, keep_profiles=False):
+                           psycris_inifile=None, keep_profiles=False,
+                           keep_photos=False):
     """Based on the inifile construct the command line call to posydon-run-grid
     """
     if grid_type == "fixed":
@@ -866,9 +867,11 @@ def construct_command_line(number_of_mpi_processes, path_to_grid,
     command_line += '--mesa-star2-inlist-project {9} --mesa-star-history-columns {10} '
     command_line += '--mesa-binary-history-columns {11} --mesa-profile-columns {12} '
     command_line += '--output-directory {13} --grid-type {14} '
-    command_line += '--psycris-inifile {16} '
+    command_line += '--psycris-inifile {16}'
     if keep_profiles:
-        command_line += '--keep_profiles'
+        command_line += ' --keep_profiles'
+    if keep_photos:
+        command_line += ' --keep_photos'
     command_line = command_line.format(number_of_mpi_processes,
                                        path_to_grid,
                                        binary_exe,
@@ -922,6 +925,9 @@ if __name__ == '__main__':
 
     if 'keep_profiles' not in run_parameters.keys():
         run_parameters['keep_profiles'] = False
+
+    if 'keep_photos' not in run_parameters.keys():
+        run_parameters['keep_photos'] = False
 
     if ((not os.path.isfile(run_parameters['grid'])) and (not os.path.isdir(run_parameters['grid']))):
         raise ValueError("Supplied grid does not exist, please check your path and try again")
@@ -996,7 +1002,8 @@ if __name__ == '__main__':
                                               args.run_directory,
                                               'fixed',
                                               path_to_run_grid_exec,
-                                              keep_profiles=run_parameters['keep_profiles'])
+                                              keep_profiles=run_parameters['keep_profiles'],
+                                              keep_photos=run_parameters['keep_photos'])
         command_line += ' --grid-point-index $SLURM_ARRAY_TASK_ID'
     else:
         command_line = construct_command_line(slurm['number_of_mpi_tasks']*slurm['number_of_nodes'],
@@ -1016,7 +1023,8 @@ if __name__ == '__main__':
                                               args.grid_type,
                                               path_to_run_grid_exec,
                                               psycris_inifile = run_parameters["psycris_inifile"],
-                                              keep_profiles=run_parameters['keep_profiles'])
+                                              keep_profiles=run_parameters['keep_profiles'],
+                                              keep_photos=run_parameters['keep_photos'])
 
     # now we need to know how this person plans to run the above created
     # command. As a shell script? As a SLURM submission? In some other way?


### PR DESCRIPTION
I have added the option to the .ini file to save mesa profiles. In reality it wraps the various rm `LOGS/profiles*` commands in an `if`-statement that is by default set to false. This can be set to true by adding the line `keep_profiles = True` to the .ini file, at the very end under the `[run_parameters]` setting.