### PR TITLE
Fixes in psy grid

### DIFF
--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -1304,7 +1304,7 @@ class PSyGrid:
                     run.final_profile1.dtype.names)
             if run.final_profile2 is not None:
                 ret += "\nColumns in final_profile2: {}\n".format(
-                    run.final_profile1.dtype.names)
+                    run.final_profile2.dtype.names)
         ret += "\n"
 
         # Print out initial values array parameters

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -1096,12 +1096,18 @@ class PSyGrid:
                     warnings.warn("run {} has a run_index out of ".format(i) +
                         "range: {}>={}".format(run_included_at[i], run_index))
                     continue
-                for colname in self.initial_values.dtype.names:
-                    value = self.initial_values[i][colname]
-                    new_initial_values[run_included_at[i]][colname] = value
-                for colname in self.final_values.dtype.names:
-                    value = self.final_values[i][colname]
-                    new_final_values[run_included_at[i]][colname] = value
+                for colname in dtype_initial_values.names:
+                    if colname in self.initial_values.dtype.names:
+                        value = self.initial_values[i][colname]
+                        new_initial_values[run_included_at[i]][colname] = value
+                    else:
+                        new_initial_values[run_included_at[i]][colname] = np.nan
+                for colname in dtype_final_values.names:
+                    if colname in self.final_values.dtype.names:
+                        value = self.final_values[i][colname]
+                        new_final_values[run_included_at[i]][colname] = value
+                    else:
+                        new_final_values[run_included_at[i]][colname] = np.nan
         #replace old initial/final value array
         self.initial_values = np.copy(new_initial_values)
         self.final_values = np.copy(new_final_values)

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -633,6 +633,7 @@ class PSyGrid:
         run_included_at = np.full(N_runs, -1, dtype=int)
         run_index = 0
         N_nans = 0
+        N_Zs = 0
         for i in tqdm.tqdm(range(N_runs)):
             # Select the ith run
             run = grid.runs[i]
@@ -937,6 +938,12 @@ class PSyGrid:
                     
             if np.isnan(self.initial_values[i]["Z"]):
                 N_nans += 1
+            elif self.initial_values[i]["Z"]>0:
+                N_Zs += 1
+                
+            if i%1000==0:
+                warnings.warn("i={},".format(i)+
+                              "where_to_add={}".format(where_to_add))
 
             if binary_grid:
                 if ignore_data:
@@ -1030,6 +1037,7 @@ class PSyGrid:
                           "length(MESA_dirs)={}".format(lenMESA_dirs))
 
         warnings.warn("N_nans(orig0)={}".format(N_nans))
+        warnings.warn("N_Zs(orig0)={}".format(N_Zs))
         #general fix for termination_flag in case of initial RLO in binaries
         if binary_grid and initial_RLO_fix:
             #create list of already detected initial RLO

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -930,18 +930,18 @@ class PSyGrid:
 
             if not ignore_data:
                 if addX:
-                    self.initial_values["X"] = where_to_add["X"]
+                    self.initial_values[i]["X"] = where_to_add["X"]
                 if addY:
-                    self.initial_values["Y"] = where_to_add["Y"]
+                    self.initial_values[i]["Y"] = where_to_add["Y"]
                 if addZ:
-                    self.initial_values["Z"] = where_to_add["Z"]
+                    self.initial_values[i]["Z"] = where_to_add["Z"]
                     
             if np.isnan(self.initial_values[i]["Z"]):
                 N_nans += 1
             elif self.initial_values[i]["Z"]>0:
                 N_Zs += 1
                 
-            if i%1000==0:
+            if i%1000==999:
                 warnings.warn("i={},".format(i)+
                               "where_to_add={}".format(where_to_add))
 

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -1088,6 +1088,7 @@ class PSyGrid:
             np.empty(run_index, dtype=dtype_initial_values))
         new_final_values = initialize_empty_array(
             np.empty(run_index, dtype=dtype_final_values))
+        N_nans = 0
         for i in range(N_runs):
             #only use included runs with a valid index
             if run_included_at[i]>=0:
@@ -1096,6 +1097,8 @@ class PSyGrid:
                     warnings.warn("run {} has a run_index out of ".format(i) +
                         "range: {}>={}".format(run_included_at[i], run_index))
                     continue
+                if np.isnan(self.initial_values[i]["Z"]):
+                    N_nans += 1
                 for colname in dtype_initial_values.names:
                     if colname in self.initial_values.dtype.names:
                         value = self.initial_values[i][colname]
@@ -1108,9 +1111,15 @@ class PSyGrid:
                         new_final_values[run_included_at[i]][colname] = value
                     else:
                         new_final_values[run_included_at[i]][colname] = np.nan
+        warnings.warn("N_nans(orig)={}".format(N_nans))
         #replace old initial/final value array
         self.initial_values = np.copy(new_initial_values)
         self.final_values = np.copy(new_final_values)
+        N_nans = 0
+        for i in range(run_index):
+            if np.isnan(self.initial_values[i]["Z"]):
+                N_nans += 1
+        warnings.warn("N_nans(copy)={}".format(N_nans))
 
         # Store the full table of initial_values
         hdf5.create_dataset("/grid/initial_values", data=self.initial_values,

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -1971,8 +1971,8 @@ PROPERTIES_TO_BE_NONE = {
 }
 
 PROPERTIES_TO_BE_CONSISTENT = ["binary", "eep", "start_at_RLO",
-                               "initial_RLO_fix",
-                               "He_core_fix", "history_DS_error",
+                               "initial_RLO_fix", "He_core_fix",
+                               "accept_missing_profile", "history_DS_error",
                                "history_DS_exclude", "profile_DS_error",
                                "profile_DS_exclude", "profile_DS_interval"]
 


### PR DESCRIPTION
Main task:
- [x] fix adding of abundance values (lines 927-931 -> 927-931): don't write on all values, only on current run

Side tasks:
- [x] modify the copy of the initial and final values to be done in a safer way (lines 1099-1104 -> 1099-1112)
- [x] fix typo (line 1307->1315): `profile1` -> `profile2`
- [x] fix issue with inconsistent properties introduced in PR#36 (line 1966-1967 -> 1974-1975): add `accept_missing_profile` to list
