### PR TITLE
Updating modules to newest versions for python 3.11

### DIFF
--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -1236,7 +1236,7 @@ class StepSN(object):
                     # if key is 'nearest_neighbour_distance':
                     #     setattr(binary, key, ['None', 'None', 'None'])
                 binary.separation = new_separation
-                if binary.state is not "disrupted":
+                if binary.state != "disrupted":
                     binary.state = "detached"
                 binary.event = None
                 binary.time = binary.time_history[-1]
@@ -1333,7 +1333,7 @@ class StepSN(object):
                     # if key is 'nearest_neighbour_distance':
                     #     setattr(binary, key, ['None', 'None', 'None'])
                 binary.separation = new_separation
-                if binary.state is not "disrupted":
+                if binary.state != "disrupted":
                     binary.state = "detached"
                 binary.event = None
                 binary.time = binary.time_history[-1]
@@ -1417,7 +1417,7 @@ class StepSN(object):
 
             # update the binary object which was disrupted already before the SN
             for key in BINARYPROPERTIES:
-                if key is not 'nearest_neighbour_distance':
+                if key != 'nearest_neighbour_distance':
                     setattr(binary, key, None)
             binary.state = "disrupted"
             binary.event = None
@@ -1637,7 +1637,7 @@ class StepSN(object):
                 # compute new orbital period before reseting the binary properties
 
                 for key in BINARYPROPERTIES:
-                    if key is not 'nearest_neighbour_distance':
+                    if key != 'nearest_neighbour_distance':
                         setattr(binary, key, None)
 
                 binary.state = "detached"
@@ -1662,7 +1662,7 @@ class StepSN(object):
                     raise ValueError("This should never happen!")
 
                 for key in BINARYPROPERTIES:
-                    if key is not 'nearest_neighbour_distance':
+                    if key != 'nearest_neighbour_distance':
                         setattr(binary, key, None)
                 binary.state = "disrupted"
                 binary.event = None

--- a/setup.py
+++ b/setup.py
@@ -61,34 +61,34 @@ else:
 # are all used in the example below for specifying specific version of the
 # packages that are compatbile with your software.
 install_requires = [
-    'numpy == 1.19.1',
-    'scipy == 1.5.2',
-    'iminuit == 1.4.9',
-    'configparser == 5.0.0',
-    'astropy == 4.0.1',
-    'pandas == 1.3.0',
-    'scikit-learn == 0.21.3',
-    'matplotlib ==  3.5.0',
-    'matplotlib-label-lines == 0.3.8',
-    'PyQt5 == 5.15.3',
-    'h5py == 3.7.0',
-    'psutil == 5.6.7',
-    'tqdm == 4.48.2',
-    'tables == 3.6.1',
-    'progressbar2 == 4.0.0',
+    'numpy == 1.24.2',
+    'scipy == 1.10.1',
+    'iminuit == 2.21.3',
+    'configparser == 5.3.0',
+    'astropy == 5.2.2',
+    'pandas == 2.0.0',
+    'scikit-learn == 1.2.2',
+    'matplotlib ==  3.7.1',
+    'matplotlib-label-lines == 0.5.2',
+    'PyQt5 == 5.15.9',
+    'h5py == 3.8.0',
+    'psutil == 5.9.4',
+    'tqdm == 4.65.0',
+    'tables == 3.8.0',
+    'progressbar2 == 4.2.0',
     'hurry.filesize == 0.9',
 ]
 
 tests_require = [
-    "pytest == 6.2.2",
-    "pytest-cov >= 2.4.0",
+    "pytest == 7.3.1",
+    "pytest-cov >= 4.0.0",
 ]
 
 # For documenation
 extras_require = {
     "doc": [
         "ipython",
-        "sphinx <= 4.2.0",
+        "sphinx == 6.1.3",
         "numpydoc",
         "sphinx_rtd_theme",
         "sphinxcontrib_programoutput",


### PR DESCRIPTION
Starting the migration to Python 3.11. We updated setup.py installation was successful but couldn't run a population.  It failed when loading the interpolation files in pickle.load() 
` self.interpolators = pickle.load(f)`
`ModuleNotFoundError: No module named 'sklearn.neighbors.regression'`
This migration will require us to retrain the interpolators because sklearn change their module structure. 