### PR TITLE
some grid fixes

### DIFF
--- a/bin/setup-pipeline
+++ b/bin/setup-pipeline
@@ -175,6 +175,10 @@ def slurm_job(job_name,
     path_to_csv_file = os.path.join(PATH,f"{job_name}.csv")
 
     with open(f'{job_name}.slurm', 'w') as f:
+        if 'step' in job_name:
+            STEPID = job_name.split("_")[1]
+        elif job_name == 'rerun':
+            STEPID = 'R'
         f.write("#!/bin/bash\n")
         f.write(f"#SBATCH --account={ACCOUNT}\n")
         f.write(f"#SBATCH --partition={PARTITION}\n")
@@ -182,7 +186,7 @@ def slurm_job(job_name,
         f.write("#SBATCH --cpus-per-task 1\n")
         f.write("#SBATCH --ntasks-per-node 1\n")
         f.write(f"#SBATCH --time={WALLTIME}\n")
-        f.write("#SBATCH --job-name=psygrid\n")
+        f.write(f"#SBATCH --job-name=psygrid{STEPID}\n")
         f.write("#SBATCH --mem-per-cpu=4G\n")
 
         if EMAIL is not None:

--- a/bin/setup-pipeline
+++ b/bin/setup-pipeline
@@ -175,10 +175,12 @@ def slurm_job(job_name,
     path_to_csv_file = os.path.join(PATH,f"{job_name}.csv")
 
     with open(f'{job_name}.slurm', 'w') as f:
-        if 'step' in job_name:
+        if ('step' in job_name) and (len(job_name.split("_")) > 1):
             STEPID = job_name.split("_")[1]
         elif job_name == 'rerun':
             STEPID = 'R'
+        else:
+            STEPID = ''
         f.write("#!/bin/bash\n")
         f.write(f"#SBATCH --account={ACCOUNT}\n")
         f.write(f"#SBATCH --partition={PARTITION}\n")

--- a/bin/setup-pipeline
+++ b/bin/setup-pipeline
@@ -209,6 +209,7 @@ def slurm_job(job_name,
 
         if job_name == 'step_3':
             f.write(f"#SBATCH --output={PATH}/logs/plot_grid.out\n")
+            f.write("unset DISPLAY\n")
 
         if job_name == 'step_4':
             f.write(f"#SBATCH --output={PATH}/logs/check_failure_rate.out\n")

--- a/bin/setup-pipeline
+++ b/bin/setup-pipeline
@@ -217,7 +217,7 @@ def slurm_job(job_name,
             f.write(f"#SBATCH --output={PATH}/logs/post_processing_%a.out\n")
             f.write(f"export PATH_TO_POSYDON={PATH_TO_POSYDON}\n")
 
-        if job_name == 'step_7':
+        if job_name == 'step_6':
             f.write(f"#SBATCH --output={PATH}/logs/train_interpolators_%a.out\n")
 
         if job_name == 'step_7':

--- a/docs/BinaryStar/BinaryStar.rst
+++ b/docs/BinaryStar/BinaryStar.rst
@@ -91,15 +91,15 @@ The simplest method is to provide the two star objects and `kwargs` of the initi
 
 .. code-block:: python
 
-  kwargs1 = {state='MS',
-             mass=20.0,
-             metallicity=0.014}
+  kwargs1 = {'state' : 'MS',
+             'mass' : 20.0,
+             'metallicity' : 0.014}
 
   star_1 = SingleStar(**kwargs1)
 
-  kwargs2 = {state='MS',
-             mass=10.0,
-             metallicity=0.014}
+  kwargs2 = {'state' : 'MS',
+             'mass' : 10.0,
+             'metallicity' : 0.014}
 
   star_2 = SingleStar(**kwargs2)
 

--- a/docs/SingleStar/SingleStar.rst
+++ b/docs/SingleStar/SingleStar.rst
@@ -86,9 +86,9 @@ The simplest method is to provide `kwargs` of the initial stellar parameters.
 
 .. code-block:: python
 
-  kwargs = {state='MS',
-            mass=10.0,
-            metallicity=0.014)
-  SingleStar(kwargs)
+  kwargs = {'state' : 'MS',
+            'mass' : 10.0,
+            'metallicity' : 0.014}
+  SingleStar(**kwargs)
 
 Now, the SingleStar object is ready to be used.

--- a/posydon/grids/io.py
+++ b/posydon/grids/io.py
@@ -384,9 +384,9 @@ def initial_values_from_dirname(mesa_dir):
     """Use the name of the directory for inferring the main initial values."""
     dirname = str(os.path.basename(os.path.normpath(mesa_dir)))
     if "initial_mass" in dirname:                           # single-star grid
-        variable_names = ["initial_mass"]
+        variable_names = ["initial_mass", "initial_z"]
     else:                                                   # binary-star grid
-        variable_names = ["m1", "m2", "initial_period_in_days"]
+        variable_names = ["m1", "m2", "initial_period_in_days", "initial_z"]
         for variable_name in variable_names:
             assert variable_name in dirname
 

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -1989,7 +1989,7 @@ def join_grids(input_paths, output_path,
     """Join two or more PSyGrid HDF5 files into one."""
     def say(something):
         if verbose:
-            print(something, flush=True)
+            print(something)
 
     # open the grids, and figure out the configuration of the new joined grid
     grids = []
@@ -2060,7 +2060,6 @@ def join_grids(input_paths, output_path,
         valtoset = ["forced_initial_RLO", "forced_initial_RLO", "initial_MT"]
         for grid in grids:
             new_detected_initial_RLO = get_detected_initial_RLO(grid)
-            say(new_detected_initial_RLO)
             for new_sys in new_detected_initial_RLO:
                 e = False
                 for sys in detected_initial_RLO:
@@ -2074,7 +2073,6 @@ def join_grids(input_paths, output_path,
                 # add non existing new entry
                 if not e:
                     detected_initial_RLO.append(new_sys)
-            say(detected_initial_RLO)
     
     say("Opening new file...")
     # open new HDF5 file and start copying runs

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -2062,17 +2062,17 @@ def join_grids(input_paths, output_path,
             new_detected_initial_RLO = get_detected_initial_RLO(grid)
             say(new_detected_initial_RLO)
             for new_sys in new_detected_initial_RLO:
+                e = False
                 for sys in detected_initial_RLO:
                     # check whether there are double entries
                     if (abs(sys["star_1_mass"]-new_sys["star_1_mass"])<1.0e-5 and
                         abs(sys["star_2_mass"]-new_sys["star_2_mass"])<1.0e-5):
+                        e = True
                         # if so, replace old entry if the new one has a larger period
                         if sys["period_days"]<new_sys["period_days"]:
                             sys = new_sys.copy()
-                    else:
-                        # otherwise add new entry
-                        detected_initial_RLO.append(new_sys)
-                if len(detected_initial_RLO)<1:
+                # add non existing new entry
+                if not e:
                     detected_initial_RLO.append(new_sys)
             say(detected_initial_RLO)
     

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -2062,14 +2062,14 @@ def join_grids(input_paths, output_path,
             new_detected_initial_RLO = get_detected_initial_RLO(grid)
             for new_sys in new_detected_initial_RLO:
                 e = False
-                for sys in detected_initial_RLO:
+                for i, sys in enumerate(detected_initial_RLO):
                     # check whether there are double entries
                     if (abs(sys["star_1_mass"]-new_sys["star_1_mass"])<1.0e-5 and
                         abs(sys["star_2_mass"]-new_sys["star_2_mass"])<1.0e-5):
                         e = True
                         # if so, replace old entry if the new one has a larger period
                         if sys["period_days"]<new_sys["period_days"]:
-                            sys = new_sys.copy()
+                            detected_initial_RLO[i] = new_sys.copy()
                 # add non existing new entry
                 if not e:
                     detected_initial_RLO.append(new_sys)

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -1989,7 +1989,7 @@ def join_grids(input_paths, output_path,
     """Join two or more PSyGrid HDF5 files into one."""
     def say(something):
         if verbose:
-            print(something)
+            print(something, flush=True)
 
     # open the grids, and figure out the configuration of the new joined grid
     grids = []
@@ -2060,6 +2060,7 @@ def join_grids(input_paths, output_path,
         valtoset = ["forced_initial_RLO", "forced_initial_RLO", "initial_MT"]
         for grid in grids:
             new_detected_initial_RLO = get_detected_initial_RLO(grid)
+            say(new_detected_initial_RLO)
             for new_sys in new_detected_initial_RLO:
                 for sys in detected_initial_RLO:
                     # check whether there are double entries
@@ -2073,6 +2074,7 @@ def join_grids(input_paths, output_path,
                         detected_initial_RLO.append(new_sys)
                 if len(detected_initial_RLO)<1:
                     detected_initial_RLO.append(new_sys)
+            say(detected_initial_RLO)
     
     say("Opening new file...")
     # open new HDF5 file and start copying runs

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -879,6 +879,10 @@ class PSyGrid:
                 # if not star history file, NaN values
                 if read_from is None:
                     init_X, init_Y, init_Z = np.nan, np.nan, np.nan
+                    # try to get metallicity from directory name
+                    params_from_path = initial_values_from_dirname(run.path)
+                    if (len(params_from_path)==4) or (len(params_from_path)==2):
+                        init_Z = params_from_path[-1]
                 else:
                     star_header = np.genfromtxt(
                         read_from, skip_header=1, max_rows=1, names=True)

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -2061,17 +2061,17 @@ def join_grids(input_paths, output_path,
         for grid in grids:
             new_detected_initial_RLO = get_detected_initial_RLO(grid)
             for new_sys in new_detected_initial_RLO:
-                e = False
+                exists_already = False
                 for i, sys in enumerate(detected_initial_RLO):
                     # check whether there are double entries
                     if (abs(sys["star_1_mass"]-new_sys["star_1_mass"])<1.0e-5 and
                         abs(sys["star_2_mass"]-new_sys["star_2_mass"])<1.0e-5):
-                        e = True
+                        exists_already = True
                         # if so, replace old entry if the new one has a larger period
                         if sys["period_days"]<new_sys["period_days"]:
                             detected_initial_RLO[i] = new_sys.copy()
                 # add non existing new entry
-                if not e:
+                if not exists_already:
                     detected_initial_RLO.append(new_sys)
     
     say("Opening new file...")

--- a/posydon/grids/termination_flags.py
+++ b/posydon/grids/termination_flags.py
@@ -260,20 +260,20 @@ def get_detected_initial_RLO(grid):
             period = grid.initial_values[i]["period_days"]
             e = False
             #check for already existing entries of same mass combination
-            for d in detected:
+            for j, d in enumerate(detected):
                 if (abs(d["star_1_mass"]-mass1)<1.0e-5 and
                     abs(d["star_2_mass"]-mass2)<1.0e-5):
                     e = True
                     #update values if new one has a larger period
                     if d["period_days"]<period:
-                        d=({"star_1_mass": mass1,
-                            "star_2_mass": mass2,
-                            "period_days": period,
-                            "termination_flag_3":
-                             grid.final_values[i]["termination_flag_3"],
-                            "termination_flag_4":
-                             grid.final_values[i]["termination_flag_4"],
-                            })
+                        detected[j]=({"star_1_mass": mass1,
+                                      "star_2_mass": mass2,
+                                      "period_days": period,
+                                      "termination_flag_3":
+                            grid.final_values[i]["termination_flag_3"],
+                                      "termination_flag_4":
+                            grid.final_values[i]["termination_flag_4"],
+                                     })
             #add masses, period, and termination flags 3 and 4 of detected
             # system to the list
             if not e:

--- a/posydon/grids/termination_flags.py
+++ b/posydon/grids/termination_flags.py
@@ -258,12 +258,12 @@ def get_detected_initial_RLO(grid):
             mass1 = grid.initial_values[i]["star_1_mass"]
             mass2 = grid.initial_values[i]["star_2_mass"]
             period = grid.initial_values[i]["period_days"]
-            e = False
+            exists_already = False
             #check for already existing entries of same mass combination
             for j, d in enumerate(detected):
                 if (abs(d["star_1_mass"]-mass1)<1.0e-5 and
                     abs(d["star_2_mass"]-mass2)<1.0e-5):
-                    e = True
+                    exists_already = True
                     #update values if new one has a larger period
                     if d["period_days"]<period:
                         detected[j]=({"star_1_mass": mass1,
@@ -276,7 +276,7 @@ def get_detected_initial_RLO(grid):
                                      })
             #add masses, period, and termination flags 3 and 4 of detected
             # system to the list
-            if not e:
+            if not exists_already:
                 detected.append({"star_1_mass": mass1,
                                  "star_2_mass": mass2,
                                  "period_days": period,


### PR DESCRIPTION
- [x] in case there are no history files, try to get metallicity from directory names
- adding the metallicity to be read from directory names (will be used when joining grids as well to match masses, period and metallicity)
- read the metallicity value from directory name when there is no history.data, while X and Y keep nan.
- [x] add initial RLO fix when joining grids, to avoid non-detections on slice boundary or in reruns
- fix updating of the initial RLO list in termination_flags.py, too
- [x] add to reset the display, when creating plots via slurm (ssh -X, may cause otherwise troubles with the display settings)
- [x] add step number to slurm job-name