### PR TITLE
[insane PR 🤯] POSYDON v2 DCO population synthesis workflow

### DIFF
--- a/posydon/popsyn/normalized_pop_mass.py
+++ b/posydon/popsyn/normalized_pop_mass.py
@@ -47,6 +47,8 @@ def initial_total_underlying_mass(df=None, **kwargs):
         initial_ZAMS_mass_2 = initial_ZAMS_mass[3]
         initial_ZAMS_TOTAL_mass = (sum(initial_ZAMS_mass_1)
                                    + sum(initial_ZAMS_mass_2))
+    elif isinstance(df, float):
+        initial_ZAMS_TOTAL_mass = df
     else:
         sel = df['event'] == 'ZAMS'
         initial_ZAMS_TOTAL_mass = sum(df['S1_mass'][sel]+df['S2_mass'][sel])

--- a/posydon/popsyn/rate_calculation.py
+++ b/posydon/popsyn/rate_calculation.py
@@ -1,0 +1,692 @@
+
+__author__ = ['Simone Bavera <Simone.Bavera@unige.ch>']
+
+import os
+import warnings
+import numpy as np
+from tqdm import tqdm
+import scipy as sp
+from scipy.interpolate import interp1d
+from astropy import units as u
+from astropy import constants as const # TODO: replace this in favour of POSYDON constats module
+from astropy.cosmology import Planck15 as cosmology # TODO: update to Planck18 once we update astropy module
+from astropy.cosmology import z_at_value
+import posydon.popsyn.selection_effects as selection_effects # TODO: replace in favour of our module
+from posydon.utils.constants import Zsun
+from posydon.popsyn.star_formation_history import (star_formation_rate,
+                                                   mean_metallicity,
+                                                   std_log_metallicity_dist,
+                                                   get_illustrisTNG_data,
+                                                   fractional_SFR_at_given_redshift)
+
+DEFAULT_MODEL = {
+    'delta_t' : 100, # Myr
+    'SFR' : 'IllustrisTNG',
+    'sigma_SFR' : None,
+    'Z_max' : 1.,
+    'select_one_met' : False,
+    'dlogZ' : None, # e.g, [np.log10(0.0142/2),np.log10(0.0142*2)]
+    'Zsun' : Zsun,
+}
+
+class Rates(object):
+
+    def __init__(self, df, verbose=False, **kwargs):
+        """Compute DCO rates.
+
+        Parameters
+        ----------
+        df : object
+            Pandas dataframe containing the synthetic binary population.
+        delta_t : float
+            Cosmic time bin size used to bin distribute the synthetc binary
+            population.
+        SFR : string
+            Star-formation-rate history you want to use:
+            'Madau+Dickinson14', 'Madau+Fragos17', 'Neijssel+19', 'IllustrisTNG'
+        sigma_SFR : string
+            Standard deviation of the trucated log-normal metallicity distribution
+            assumed for the star-formation rate history in the case you select
+            'Madau+Dickinson14', 'Madau+Fragos17', 'Neijssel+19',
+        Z_max : float
+            The absolute maximum metallicity of the star formation rate history.
+            NOTE: This should be used when assuming a truncated log-normal
+            distribution of metallcities to not overpredict 1, also it can be
+            used with the IllustrisTNG SFR to prevent unphysically high
+            metallicities.
+        select_one_met : bool
+            If `True` your synthetic binary population should contain only one
+            descrete metallicity.
+        dlogZ : float or range
+            Used when `select_one_met=True` to select the metallicity range
+            around which you want to integrate the SFR history. If float value
+            value is provided we assume a symmetric range dlogZ/2 around the
+            provided metallcity else we consider the range provided
+            [Z_min, Z_max] which could also be asymmetric.
+        verbose : bool
+            `True` if you want the print statements.
+
+
+        TODO: add the definitios of the variables used by this class.
+
+        """
+
+        self.df = df
+        self.verbose = verbose
+
+        if kwargs:
+            for key in kwargs:
+                if key not in DEFAULT_MODEL:
+                    raise ValueError(key + " is not a valid parameter name!")
+            for varname in DEFAULT_MODEL:
+                default_value = DEFAULT_MODEL[varname]
+                setattr(self, varname, kwargs.get(varname, default_value))
+        else:
+            for varname in DEFAULT_MODEL:
+                default_value = DEFAULT_MODEL[varname]
+                setattr(self, varname, default_value)
+
+    ######################################################
+    ###   DCO detection rate and merger rate density   ###
+    ###    see arXiv:1906.12257, arXiv:2010.16333,     ###
+    ###        arXiv:2106.15841, arXiv:221210924,      ###
+    ###        arXiv:2204.02619, arXiv:2011.10057      ###
+    ###              arXiv:2012.02274                  ###
+    ######################################################
+
+    def chi_eff(self, m_1, m_2, a_1, a_2, tilt_1, tilt_2):
+        return (m_1*a_1*np.cos(tilt_1)+m_2*a_2*np.cos(tilt_2))/(m_1+m_2)
+
+    def m_chirp(self, m_1, m_2):
+        return (m_1*m_2)**(3./5)/(m_1+m_2)**(1./5)
+
+    def mass_ratio(self, m_1, m_2):
+        q = m_2/m_1
+        q[q>1.] = 1./q[q>1.]
+        return q
+
+    def get_data(self, var, index=None):
+        """Resample class elements.
+
+        Parameters
+        ----------
+        var : string
+            Key of self.df. This method support a list of custom definitios for
+            DCO studies like q, m_tot, m_chirp, chi_eff.
+        index : list of int
+            List of indicies of the binaries of interest.
+
+        Returns
+        -------
+        array
+            Array containing the self.df[var][index].
+
+        """
+        if var not in self.df:
+            # compute some useful quantities that are not defined in df_synthetic
+            if var == 'q':
+                values = self.mass_ratio(self.df["S1_mass"], self.df["S2_mass"])
+            elif var == 'm_tot':
+                values = self.df["S1_mass"] + self.df["S2_mass"]
+            elif var == 'm_chirp':
+                values = self.m_chirp(self.df["S1_mass"], self.df["S2_mass"])
+            elif var == 'chi_eff':
+                # check if tilts are provided
+                if ("tilt_BH1" not in self.df or "tilt_BH2" not in self.df):
+                    warnings.warn('Spin tilts not in dataset! Assuming spins '
+                                   'are aligned to orbital angular momentum '
+                                   'to compute chi_eff!')
+                    tilt_BH1 = np.zeros(len(self.df["S1_spin"]))
+                    tilt_BH2 = tilt_BH1
+                else:
+                    tilt_BH1 = self.df["tilt_BH1"]
+                    tilt_BH2 = self.df["tilt_BH2"]
+                values = self.chi_eff(self.df["S1_mass"],
+                                      self.df["S2_mass"],
+                                      self.df["S1_spin"],
+                                      self.df["S2_spin"],
+                                      tilt_BH1,
+                                      tilt_BH2)
+            else:
+                raise ValueError(f'Definition for {var} not available!')
+        else:
+            values =  self.df[var]
+
+        if index is not None:
+            return values[index].values
+        else:
+            return values.values
+
+    def get_redshift_from_cosmic_time_interpolator(self):
+        """Interpolator to compute the cosmological redshift given the cosmic time.
+
+        Returns
+        -------
+        object
+            Returns the trained interpolator object.
+
+        """
+        # astropy z_at_value method is too slow to compute z_mergers efficinty
+        # we must implment interpolation
+        t = np.linspace(1e-2, cosmology.age(1e-08).value*0.9999999, 1000)
+        z = np.zeros(1000)
+        for i in range(1000):
+            z[i] = z_at_value(cosmology.age, t[i] * u.Gyr)
+        f_z_m = interp1d(t, z, kind='cubic')
+        return f_z_m
+
+    def get_redshift_from_cosmic_time(self, t_cosm):
+        """Compute the cosmological redshift given the cosmic time..
+
+        Parameters
+        ----------
+        t_cosm : array doubles
+            Cosmic time to which you want to know the redhisft.
+
+        Returns
+        -------
+        array doubles
+            Cosmolgocial redshift corresponding to the cosmic time.
+
+        """
+        interpolator = self.get_redshift_from_cosmic_time_interpolator()
+        return interpolator(t_cosm)
+
+    def get_cosmic_time_from_redshift(self, z):
+        """Compute the cosmic time from redshift.
+
+        Parameters
+        ----------
+        z : double
+            Cosmological redshift.
+
+        Returns
+        -------
+        double
+            Return age of the cosmic time in Gyr given the redshift z.
+
+        """
+        return cosmology.age(z).value  # Gyr
+
+    def get_comoving_disntance_from_redshift(self, z):
+        """Compute the comoving distance from redshift.
+
+        Parameters
+        ----------
+        z : double
+            Cosmological redshift.
+
+        Returns
+        -------
+        double
+            Comoving distance in Mpc corresponding to the redhisft z.
+
+        """
+        return cosmology.comoving_distance(z).value  # Mpc
+
+    def get_cosmic_time_at_dco_merger(self, z_birth):
+        """Get cosmic time at DCO merger.
+
+        Parameters
+        ----------
+        z_birth : double
+            Cosmological redshift of formation of the DCO system
+            (must be the same for every binary).
+
+        Returns
+        -------
+        double
+            Cosmic time in Gyr at DCO merger for all binaries born at z_birth.
+
+        """
+        n = self.df.shape[0]
+        t_birth = self.get_cosmic_time_from_redshift(z_birth) * np.ones(n) # Gyr
+        return t_birth + (self.df["time"] + self.df["t_delay"]) * 10 ** (-3)  #Gyr
+
+    def get_redshift_at_dco_merger(self, z_birth):
+        """Get redshift of merger of DCOs.
+
+        Parameters
+        ----------
+        z_birth : double
+            Redshift of formation of the DCO system (must be the same for every
+            binary).
+
+        Returns
+        -------
+        double
+            Redshift of merger of DCOs born at z_birth.
+
+        """
+        n = self.df.shape[0]
+        t_merger = self.get_cosmic_time_at_dco_merger(z_birth)
+        z_merger = np.ones(n) * np.nan
+        bool_merger = t_merger < self.get_cosmic_time_from_redshift(0.) * np.ones(n)  # check if the binary merges
+        z_merger[bool_merger] = z_at_value(cosmology.age, t_merger[bool_merger] * u.Gyr)
+        return z_merger
+
+    def get_centers_metallicity_bins(self):
+        """Return the centers of the metallicity bins.
+
+        Returns
+        -------
+        array double
+            Returns sampled metallicities of the populattion. This correponds
+            to the center of each metallicity bin.
+
+        """
+        return np.unique(self.df['metallicity'].values)
+
+    def get_edges_metallicity_bins(self):
+        """Return the edges of the metallicity bins.
+
+        Returns
+        -------
+        array double
+            Returns the edges of all metallicity bins. We assume metallicities
+            were binned in log-space.
+
+        """
+        met_val = np.log10(self.get_centers_metallicity_bins())
+        bin_met = np.zeros(len(met_val)+1)
+        # if more than one metallicty bin
+        if len(met_val) > 1 :
+            bin_met[0] = met_val[0] - (met_val[1] - met_val[0]) / 2.
+            bin_met[-1] = met_val[-1] + (met_val[-1] - met_val[-2]) / 2.
+            bin_met[1:-1] = met_val[:-1] + (met_val[1:] - met_val[:-1]) / 2.
+        # one metallicty bin
+        elif len(met_val) == 1 :
+            if isinstance(self.dlogZ, float):
+                bin_met[0] = met_val[0] - self.dlogZ / 2.
+                bin_met[-1] = met_val[0] + self.dlogZ / 2.
+            elif isinstance(self.dlogZ, list) or isinstance(self.dlogZ, np.array):
+                bin_met[0] = self.dlogZ[0]
+                bin_met[-1] = self.dlogZ[1]
+
+        return 10**bin_met
+
+
+    def get_centers_redshift_bins(self):
+        """Compute redshift bin centers.
+
+        Returns
+        -------
+        array doubles
+            We devide the cosmic time history of the Universe in equally spaced
+            bins of cosmic time of self.delta_t (100 Myr default) an compute the
+            redshift corresponding to center of these bins.
+
+        """
+        # generate t_birth at the middle of each self.delta_t bin
+        t_birth_bin = [cosmology.age(0.).value]
+        t_birth = []
+        # devide the
+        self.n_redshift_bin_centers = int(cosmology.age(0).to('Myr').value/self.delta_t)
+        for i in range(self.n_redshift_bin_centers+1):
+            t_birth.append(t_birth_bin[i] - self.delta_t*1e-3/2.) # Gyr
+            t_birth_bin.append(t_birth_bin[i] - self.delta_t*1e-3) # Gyr
+        t_birth = np.array(t_birth)
+        # compute the redshift
+        z_birth = []
+        for i in range(self.n_redshift_bin_centers+1):
+            z_birth.append(z_at_value(cosmology.age, t_birth[i] * u.Gyr))
+        z_birth = np.array(z_birth)
+
+        return z_birth
+
+    def get_edges_redshift_bins(self):
+        """Compute redshift bin edges.
+
+        Returns
+        -------
+        array doubles
+            We devide the cosmic time history of the Universe in equally spaced
+            bins of cosmic time of self.delta_t (100 Myr default) an compute the
+            redshift corresponding to edges of these bins.
+
+        """
+        # generate t_birth at the middle of each self.delta_t bin
+        t_birth_bin = [cosmology.age(0.).value]
+        for i in range(self.n_redshift_bin_centers+1):
+            t_birth_bin.append(t_birth_bin[i] - self.delta_t*1e-3) # Gyr
+        # compute the redshift
+        z_birth_bin = []
+        for i in range(self.n_redshift_bin_centers):
+            # do not count first edge, we add z=0. later
+            z_birth_bin.append(z_at_value(cosmology.age, t_birth_bin[i+1] * u.Gyr))
+        # add the first and last bin edge at z=0. and z=inf.=100
+        z_birth_bin = np.array([0.]+z_birth_bin+[100.])
+
+        return z_birth_bin
+
+    def merger_rate_weight(self, z_birth, z_merger, p_det, i):
+        """Compute the merger rate weight (w_ijk) in yr^-1 units.
+
+        Parameters
+        ----------
+        z_birth : array doubles
+            Cosmological redshift of formation of the binary systems. This MUST
+            be the same for all binaries.
+        z_merger : array doubles
+            Cosmological redshift of merger of the binary systems.
+        p_det : array doubles
+            Detection probability of the binary.
+        i : array integers
+            Indicies correponding to the binaries you want to select out of the
+            population.
+
+        Returns
+        -------
+        array doubles
+            Return the cosmological weights w_ijk (detection rate contibution)
+            of the binary k in the metallicity bin j born at redshift birth i
+            as in Eq. (B.8) of Bavera et al. (2020).
+
+        """
+        # get SFR at a given population birth redshift
+        SFR_at_z_birth = star_formation_rate(self.SFR, z_birth)
+
+        # get metallicity bin edges
+        met_bins = self.get_edges_metallicity_bins()
+
+        # distribute the DCO to the corresponding bin
+        binplace = np.digitize(self.get_data("metallicity", i), met_bins)
+
+        # compute fSFR assuming log-normal distributed metallicities
+        fSFR = fractional_SFR_at_given_redshift(z_birth, SFR_at_z_birth,
+                                                self.SFR, self.sigma_SFR,
+                                                met_bins, binplace,
+                                                self.Z_max, self.select_one_met)
+
+        # simulated mass per given metallicity corrected for the unmodeled
+        # single and binary stellar mass
+        M_model = self.get_data("underlying_mass_for_met",i)
+
+        # speed of light
+        c = const.c.to('Mpc/yr').value  # Mpc/yr
+
+        # delta cosmic time bin
+        deltaT = self.delta_t * 10 ** 6  # yr
+
+        # comoving distance corresponding to the DCO merger redshift
+        D_c = self.get_comoving_disntance_from_redshift(z_merger)
+
+        # DCO cosmological weights B.8 in Bavera et al. (2020)
+        return 4.*np.pi * c * D_c**2 * p_det * deltaT * fSFR / M_model # yr^-1
+
+
+    def compute_merger_rate_weights(self, sensitivity, flag_pdet=True, path_to_dir='./', extention='npz'):
+        """Compute the cosmological weights of the DCO population.
+
+        This function will create a directory path_to_dir/DCOs/sensitivity where
+        it will save the weigths, binary indicies k, z_formation, z_merger.
+        This is needed for scalability as a ~100k DCO population generates ~10M
+        non-zero weights assuming a delta_t=100Myr.
+
+        Parameters
+        ----------
+        sensitivity : string
+            TODO: update this once we implement POSYDON p_det calculation
+            Choose which GW detector sensitivity you want to use, available:
+            'design': LVK target design sensitivity, see fig. 1 of arXiv:1304.0670v3
+            'infinite': intrinsic merging DCO population, i.e. p_det = 1
+        flag_pdet : bool
+            This is a control variable. In order to be sure you want to run
+            infinite sensitivity set `p_det=False`.
+        path_to_dir : string
+            Path to the workingn directory where you want to store the
+            cosmological weights.
+
+        """
+        # check if the folder three exists, otherwise create it
+        DCO_dir = os.path.join(path_to_dir,'DCOs')
+        if 'DCOs' not in os.listdir(path_to_dir):
+            os.makedirs(DCO_dir)
+
+        sensitivity_dir = os.path.join(DCO_dir, f'{sensitivity}_sensitivity')
+        if f'{sensitivity}_sensitivity' not in os.listdir(DCO_dir):
+            os.makedirs(sensitivity_dir)
+
+        # index of all DCOs
+        n = self.df.shape[0]
+        index = np.arange(0, n)
+
+        # redshif of each time bin
+        z_birth = self.get_centers_redshift_bins()
+
+        # define interpolator
+        get_redshift_from_time = self.get_redshift_from_cosmic_time_interpolator()
+
+        # hashmap to store everythig
+        data = {'index': {}, 'z_merger': {}, 'weights': {}}
+
+        # loop over all redshift bins
+        for i in tqdm(range(len(z_birth))):
+
+            # compute the merger time of each DCOs
+            t_merger = self.get_cosmic_time_at_dco_merger(z_birth[i])
+
+            # detectable population
+            if flag_pdet == True and sensitivity != 'infinite':
+
+                # sort out systems not merging within the Hubble time
+                bool_merger = t_merger < cosmology.age(1e-08).value*0.9999999 * np.ones(n)
+
+                # if there are no merging DCO, continue
+                if len(index[bool_merger]) == 0:
+                    data['index'][str(z_birth[i])] = np.array([])
+                    data['z_merger'][str(z_birth[i])] = np.array([])
+                    data['weights'][str(z_birth[i])] = np.array([])
+                    continue
+
+                # get some quantities to compute detection probabilities
+                S1_mass = self.get_data('S1_mass', index[bool_merger])
+                S2_mass = self.get_data('S2_mass', index[bool_merger])
+                z_m = get_redshift_from_time(t_merger[bool_merger])
+
+                # TODO: implement p_det POSYDON code
+                # compute detection probabilities
+                DL = [x.value for x in cosmology.luminosity_distance(z_m)]
+                snr_threshold = 8.
+                p_det = selection_effects.detection_probability(m1=S1_mass, m2=S2_mass,
+                                                                redshift=z_m, distance=DL,
+                                                                snr_threshold=snr_threshold,
+                                                                sensitivity=sensitivity)
+
+                # sort out undetectable sources
+                bool_detect = p_det > 0.
+
+                # if there are no detectable DCO, continue
+                if len(index[bool_merger][bool_detect]) == 0:
+                    data['index'][str(z_birth[i])] = np.array([])
+                    data['z_merger'][str(z_birth[i])] = np.array([])
+                    data['weights'][str(z_birth[i])] = np.array([])
+                    continue
+
+                # store index and redshift of merger
+                data['index'][str(z_birth[i])] = index[bool_merger][bool_detect]
+                data['z_merger'][str(z_birth[i])] = z_m[bool_detect]
+
+                # compute and store marger rate weights as in eq. B.8 in Bavera et al. (2020)
+                z_b = np.ones(len(index[bool_merger][bool_detect]))*z_birth[i]
+                w_ijk = self.merger_rate_weight(z_b, z_m[bool_detect],
+                                                p_det[bool_detect],
+                                                index[bool_merger][bool_detect])
+                data['weights'][str(z_birth[i])] = w_ijk
+
+            # intrinsic population
+            elif flag_pdet == False and sensitivity == 'infinite':
+
+                # sort out systems not merging within the Hubble time
+                bool_merger = t_merger < cosmology.age(1e-08).value*0.9999999 * np.ones(n)
+
+                # if there are no merging DCO, continue
+                if len(index[bool_merger]) == 0:
+                    data['index'][str(z_birth[i])] = np.array([])
+                    data['z_merger'][str(z_birth[i])] = np.array([])
+                    data['weights'][str(z_birth[i])] = np.array([])
+                    continue
+
+                # get merger redshifts
+                z_m = get_redshift_from_time(t_merger[bool_merger])
+
+                # set detection probabilities to 1
+                p_det = np.ones(len(index[bool_merger]))
+
+                # store index and redshift of merger
+                data['index'][str(z_birth[i])] = index[bool_merger]
+                data['z_merger'][str(z_birth[i])] = z_m
+
+                # compute and store marger rate weights as in eq. B.8 in Bavera et al. (2020)
+                z_b = np.ones(len(index[bool_merger]))*z_birth[i]
+                w_ijk = self.merger_rate_weight(z_b, z_m, p_det, index[bool_merger])
+                data['weights'][str(z_birth[i])] = w_ijk
+
+            else:
+                raise ValueError('Missmatch between sensitivity and flag_pdet!')
+
+        # TODO: implemet the saving to h5 files
+        if extention == 'npz':
+            if self.verbose:
+                print('Formatting the data ....')
+            data_to_save = [[],[],[],[]]
+            for i, dict in enumerate([data[key] for key in data.keys()]):
+                for key in dict.keys():
+                    data_to_save[i].extend(dict[key].tolist())
+                    if i == 0:
+                        data_to_save[3].extend(np.ones(len(dict[key]))*float(key))
+            if self.verbose:
+                print('Saving the data ....')
+            for i, key in enumerate(data.keys()):
+                if key == 'index':
+                    fmt_str = '%i'
+                else:
+                    fmt_str = '%.8E'
+                np.savez(os.path.join(sensitivity_dir, f"{key}.npz"),
+                         key=data_to_save[i], fmt=fmt_str)
+
+            np.savez(os.path.join(sensitivity_dir,"z_formation.npz"),
+                     key=data_to_save[3], fmt='%.8E')
+        else:
+            raise ValueError('Extension not supported!')
+
+    def load_merger_rate_weights(self, sensitivity, path_to_dir='./', extention='npz'):
+        """Load the cosmological weights of the DCO populatio.
+
+        Parameters
+        ----------
+        sensitivity : string
+            TODO: update this once we implement POSYDON p_det calculation
+            Choose which GW detector sensitivity you want to use, available:
+            'design': LVK target design sensitivity, see fig. 1 of arXiv:1304.0670v3
+            'infinite': intrinsic merging DCO population, i.e. p_det = 1
+        path_to_dir : string
+            Path to the directory where you the cosmological weights are stored.
+
+        Returns
+        -------
+        array doubles
+            Return the cosmological weights, z_formation, z_merger and binary
+            index k associated to each weighted binary.
+
+        """
+        dir_ = os.path.join(path_to_dir, f'DCOs/{sensitivity}_sensitivity')
+
+        if extention == 'npz':
+            if self.verbose:
+                print('Loading the data ...')
+            index = np.load(os.path.join(dir_, 'index.npz'), allow_pickle=True)['key']
+            z_formation = np.load(os.path.join(dir_, 'z_formation.npz'), allow_pickle=True)['key']
+            z_merger = np.load(os.path.join(dir_, 'z_merger.npz'), allow_pickle=True)['key']
+            weights = np.load(os.path.join(dir_, 'weights.npz'), allow_pickle=True)['key']
+        else:
+            raise ValueError('Extension not supported!')
+        return index, z_formation, z_merger, weights
+
+
+    def get_shell_comovig_volume(self, z_hor_i, z_hor_f, sensitivity='infinite'):
+        """Compute comoving volume corresponding to a redshift shell.
+
+        Parameters
+        ----------
+        z_hor_i : double
+            Cosmological redshift. Lower bound of the integration.
+        z_hor_f : double
+            Cosmological redshift. Upper bound of the integration.
+        sensitivity : string
+            hoose which GW detector sensitivity you want to use. At the moment
+            only 'infinite' is available, i.e. p_det = 1.
+
+        Returns
+        -------
+        double
+            Retruns the comoving volume between the two shells z_hor_i
+            and z_hor_f in Gpc^3.
+
+        """
+        c = const.c.to('Gpc/yr').value  # Gpc/yr
+        H_0 = cosmology.H(0).to('1/yr').value # km/Gpc*s
+        def E(z):
+            Omega_m = cosmology.Om0
+            Omega_L = 1-cosmology.Om0
+            return np.sqrt(Omega_m*(1.+z)**3+Omega_L)
+        def f(z,sensitivity):
+            if sensitivity=='infinite':
+                return (1./(1.+z) * 4*np.pi*c / H_0
+                        * (self.get_comoving_disntance_from_redshift(z)
+                        * 10**(-3.))**2. / E(z))
+            else:
+                # TODO: peanut-shaped antenna patter comoving volume calculation
+                raise ValueError('Sensitivity not supported!')
+        return sp.integrate.quad(f, z_hor_i, z_hor_f, args=(sensitivity))[0] # Gpc^3
+
+
+    def compute_merger_rate_density(self, w_ijk, z_event, observable='DCOs', sensitivity='infiite', index=None):
+        """Compute the DCOs merger rate density.
+
+        TODO: add support for GRBs.
+
+        Parameters
+        ----------
+        w_ijk : array doubles
+            Cosmological weights computed with Eq. B.8 of Bavera et at. (2020).
+        z_event : array doubles
+            Cosmolgocial redshift of the event you are tracking.
+        Type : string
+            Event you are tracking, available:
+            'DCOs': merger event of a DCO system
+            'GRBs': coming soon.
+        sensitivity : string
+            This takes into account the detector sensitivity, available:
+            'infinite': p_det = 1
+            'beamed': TODO for GRBs
+
+        Returns
+        -------
+        array doubles
+            Return the DCOs merger rate density (Gpc^-3 yr^-1) as a function of
+            cosmolgocial redshift as in Eq. (D.1) in Bavera et al. (2022)
+            arXiv:2106.15841
+
+        """
+
+        z_hor = self.get_edges_redshift_bins()
+        n = len(z_hor)
+
+        if observable=='DCOs':
+            z_merger_DCO = z_event
+            Rate_DCOs = np.zeros(n-1)
+            if sensitivity=='infinite':
+                for i in range(1,n):
+                    # compute Eq. (D.1) in Bavera et al. (2022) arXiv:2106.15841
+                    condition_DCOs = np.logical_and(z_merger_DCO>z_hor[i-1],
+                                                    z_merger_DCO<=z_hor[i])
+                    Rate_DCOs[i-1] = (sum(w_ijk[condition_DCOs])
+                                     /self.get_shell_comovig_volume(z_hor[i-1],
+                                                                    z_hor[i],
+                                                                    sensitivity))
+                return Rate_DCOs # Gpc^-3 yr^-1
+            else:
+                raise ValueError('Unsupported sensitivity!')
+        else:
+            raise ValueError('Unknown observable!')

--- a/posydon/popsyn/rate_calculation.py
+++ b/posydon/popsyn/rate_calculation.py
@@ -431,12 +431,14 @@ class Rates(object):
         Parameters
         ----------
         sensitivity : string
-            Choose which GW detector sensitivity you want to use, available:
-            'O3actual_H1L1V1' : TODO add refs
-            'O4high_H1L1V1' : TODO add refs
-            'O4low_H1L1V1' : TODO add refs
-            'design_H1L1V1': LVK target design sensitivity, see fig. 1 of arXiv:1304.0670v3
-            'infinite': intrinsic merging DCO population, i.e. p_det = 1
+            GW detector sensitivity and network configuration you want to use, see arXiv:1304.0670v3
+            detector sensitivities are taken from: https://dcc.ligo.org/LIGO-T2000012-v2/public
+            available sensitivity keys (for Hanford, Livingston, Virgo network):
+                'O3actual_H1L1V1' : aligo_O3actual_H1.txt, aligo_O3actual_L1.txt, avirgo_O3actual.txt
+                'O4low_H1L1V1' : aligo_O4low.txt, aligo_O4low.txt, avirgo_O4high_NEW.txt
+                'O4high_H1L1V1' : aligo_O4high.txt, aligo_O4high.txt, avirgo_O4high_NEW.txt
+                'design_H1L1V1' : AplusDesign.txt, AplusDesign.txt, avirgo_O5high_NEW.txt
+                'infinite': intrinsic merging DCO population, i.e. p_det = 1
         flag_pdet : bool
             This is a control variable. In order to be sure you want to run
             infinite sensitivity set `p_det=False`.
@@ -585,11 +587,14 @@ class Rates(object):
         Parameters
         ----------
         sensitivity : string
-            'O3actual_H1L1V1' : TODO add refs
-            'O4high_H1L1V1' : TODO add refs
-            'O4low_H1L1V1' : TODO add refs
-            'design_H1L1V1': LVK target design sensitivity, see fig. 1 of arXiv:1304.0670v3
-            'infinite': intrinsic merging DCO population, i.e. p_det = 1
+            GW detector sensitivity and network configuration you want to use, see arXiv:1304.0670v3
+            detector sensitivities are taken from: https://dcc.ligo.org/LIGO-T2000012-v2/public
+            available sensitivity keys (for Hanford, Livingston, Virgo network):
+                'O3actual_H1L1V1' : aligo_O3actual_H1.txt, aligo_O3actual_L1.txt, avirgo_O3actual.txt
+                'O4low_H1L1V1' : aligo_O4low.txt, aligo_O4low.txt, avirgo_O4high_NEW.txt
+                'O4high_H1L1V1' : aligo_O4high.txt, aligo_O4high.txt, avirgo_O4high_NEW.txt
+                'design_H1L1V1' : AplusDesign.txt, AplusDesign.txt, avirgo_O5high_NEW.txt
+                'infinite': intrinsic merging DCO population, i.e. p_det = 1
         path_to_dir : string
             Path to the directory where you the cosmological weights are stored.
 

--- a/posydon/popsyn/star_formation_history.py
+++ b/posydon/popsyn/star_formation_history.py
@@ -2,16 +2,23 @@
 
 
 __authors__ = [
+    'Simone Bavera <Simone.Bavera@unige.ch>',
     "Kyle Akira Rocha <kylerocha2024@u.northwestern.edu>",
     "Devina Misra <devina.misra@unige.ch>",
     "Konstantinos Kovlakas <Konstantinos.Kovlakas@unige.ch>",
 ]
 
-
+import os
 import numpy as np
+import scipy as sp
+from scipy import stats
+from posydon.utils.data_download import PATH_TO_POSYDON_DATA
 from posydon.utils.constants import age_of_universe
 from posydon.utils import (rejection_sampler, histogram_sampler,
                            read_histogram_from_file)
+from posydon.utils.constants import Zsun
+from scipy.interpolate import interp1d
+from astropy.cosmology import Planck15 as cosmology
 
 
 SFH_SCENARIOS = ["burst", "constant", "custom_linear", "custom_log10",
@@ -76,3 +83,207 @@ def get_formation_times(N_binaries, star_formation='constant', **kwargs):
     raise ValueError(
         "Unknown star formation scenario '{}' given. Valid options: {}".
         format(star_formation, ",".join(SFH_SCENARIOS)))
+
+def get_illustrisTNG_data(verbose=False):
+    """Load IllustrisTNG SFR dataset."""
+    if verbose:
+        print('Loading IllustrisTNG data...')
+    return np.load(os.path.join(PATH_TO_POSYDON_DATA, 'SFR/IllustrisTNG.npz'))
+
+def star_formation_rate(SFR, z):
+    """Star formation rate in M_sun yr^-1 Mpc^-3.
+
+    Parameters
+    ----------
+    SFR : string
+        Star formation rate assumption:
+        - Madau+Fragos17 see arXiv:1606.07887
+        - Madau+Dickinson14 see arXiv:1403.0007
+        - Neijssel+19 see arXiv:1906.08136
+        - IllustrisTNG see see arXiv:1707.03395
+    z : double
+        Cosmological redshift.
+
+    Returns
+    -------
+    double
+        The total mass of stars in M_sun formed per comoving volume Mpc^-3
+        per year.
+    """
+    if SFR == "Madau+Fragos17":
+        return 0.01 * (1. + z) ** 2.6 / (1. + ((1. + z) / 3.2) ** 6.2)  # M_sun yr^-1 Mpc^-3
+    elif SFR == "Madau+Dickinson14":
+        return 0.015 * (1. + z) ** 2.7 / (1. + ((1. + z) / 2.9) ** 5.6)  # M_sun yr^-1 Mpc^-3
+    elif SFR == "Neijssel+19":
+        return 0.01 * (1. + z) ** 2.77 / (1. + ((1. + z) / 2.9) ** 4.7) # M_sun yr^-1 Mpc^-3
+    elif SFR=='IllustrisTNG':
+        illustris_data = get_illustrisTNG_data()
+        SFR = illustris_data['SFR'] # M_sun yr^-1 Mpc^-3
+        redshifts = illustris_data['redshifts']
+        SFR_interp = interp1d(redshifts, SFR)
+        return SFR_interp(z)
+    else:
+        raise ValueError('Invalid SFR!')
+
+def mean_metallicity(SFR, z):
+    """Empiric mean metallicity function.
+
+    Parameters
+    ----------
+    SFR : string
+        Star formation rate assumption:
+        - Madau+Fragos17 see arXiv:1606.07887
+        - Madau+Dickinson14 see arXiv:1403.0007
+        - Neijssel+19 see arXiv:1906.08136
+    z : double
+        Cosmological redshift.
+
+    Returns
+    -------
+    double
+        Mean metallicty of the universe at the given redhist.
+
+    """
+
+    if SFR == "Madau+Fragos17" or SFR == "Madau+Dickinson14":
+        return 10 ** (0.153 - 0.074 * z ** 1.34) * Zsun
+    elif SFR == "Neijssel+19":
+        return 0.035*10**(0.035*z)
+    else:
+        raise ValueError('Invalid SFR!')
+
+def std_log_metallicity_dist(sigma):
+    """Standard deviation of the log-metallicity distribution.
+
+    Returns
+    -------
+    double
+        Standard deviation of the adopted distribution.
+
+    """
+    if isinstance(sigma, str):
+        if sigma == 'Bavera+20':
+            return 0.5
+        elif sigma == "Neijssel+19":
+            return 0.39
+        else:
+            raise ValueError('Uknown sigma choice!')
+    elif isinstance(sigma, float):
+        return sigma
+    else:
+        raise ValueError(f'Invalid sigma value {sigma}!')
+
+def fractional_SFR_at_given_redshift(z, SFR_at_z, SFR, sigma, bins, binplace, Z_max, select_one_met=False):
+    """Integrated SFR over deltaZ at a given z as in Eq. (B.9) of Bavera et al. (2020).
+
+    Parameters
+    ----------
+    SFR : string
+        Star formation rate assumption:
+        - Madau+Fragos17 see arXiv:1606.07887
+        - Madau+Dickinson14 see arXiv:1403.0007
+        - IllustrisTNG see see arXiv:1707.03395
+        - Neijssel+19 see arXiv:1906.08136
+    Z : double
+        Metallicity.
+
+    Returns
+    -------
+    double
+        The total mass of stars formed per comoving volume at a given redshift z
+        for a given metallicity range deltaZ.
+
+    """
+    # Z_left_edge == bins[binplace-1]
+    # Z_right_edge == bins[binplace]
+    if SFR == "Madau+Fragos17" or SFR=="Madau+Dickinson14":
+        # assume a truncated log10-normal distribution of metallicities
+        # see Eq. (B.2) in Bavera et al. (2020)
+        sigma = std_log_metallicity_dist(sigma)
+        mu = np.log10(mean_metallicity(SFR, z)) - sigma**2*np.log(10)/2.
+        # renormalisation constant
+        norm = stats.norm.cdf(np.log10(Z_max), mu[0], sigma)
+        fSFR = SFR_at_z*(stats.norm.cdf(np.log10(bins[binplace]), mu, sigma)/norm
+                        - stats.norm.cdf(np.log10(bins[binplace-1]), mu, sigma)/norm)
+        if not select_one_met:
+            #left edge
+            fSFR[binplace == 1] = SFR_at_z[0]*stats.norm.cdf(np.log10(bins[1]), mu[0], sigma)/norm
+    elif SFR == "Neijssel+19":
+        # assume a truncated ln-normal distribution of metallicities
+        sigma = std_log_metallicity_dist(sigma)
+        mu = np.log(mean_metallicity(SFR, z))-sigma**2/2.
+        # renormalisation constant
+        norm = stats.norm.cdf(np.log(Z_max), mu[0], sigma)
+        fSFR = SFR_at_z*(stats.norm.cdf(np.log(bins[binplace]), mu, sigma)/norm
+                        - stats.norm.cdf(np.log(bins[binplace-1]), mu, sigma)/norm)
+        if not select_one_met:
+            #left edge
+            fSFR[binplace == 1] = SFR_at_z[0]*stats.norm.cdf(np.log(bins[1]), mu[0], sigma)/norm
+    elif SFR == 'IllustrisTNG':
+        # numerically itegrate the IlluystrisTNG SFR(z,Z)
+        illustris_data = get_illustrisTNG_data()
+        redshifts = illustris_data['redshifts']
+        Z = illustris_data['mets']
+        M = illustris_data['M'] # Msun
+        # only use data within the metallicity bounds (no lower bound)
+        valid_met_idxs = np.where(Z <= Z_max)[0]
+        # get the index of the correct redshift in the data
+        redz_idx = np.where(redshifts <= z[0])[0][0]
+        # take values of the data at this redshift between our metallicity bounds
+        Z_dist = M[redz_idx, valid_met_idxs]
+        if Z_dist.sum() == 0.:
+            fSFR = np.zeros(len(z))
+        else:
+            Z_dist_cdf = np.cumsum(Z_dist)/Z_dist.sum()
+            Z_dist_cdf_interp = interp1d(np.log10(Z[valid_met_idxs]), Z_dist_cdf, fill_value="extrapolate")
+            fSFR = SFR_at_z*(Z_dist_cdf_interp(np.log10(bins[binplace]))
+                            - Z_dist_cdf_interp(np.log10(bins[binplace-1])))
+            if not select_one_met:
+                #left edge
+                fSFR[binplace == 1] = SFR_at_z[0]*Z_dist_cdf_interp(np.log10(bins[1]))
+    else:
+        raise ValueError('Invalid SFR!')
+
+    return fSFR
+
+
+def integrated_SFRH_over_redshift(SFR, sigma, Z, Z_max):
+    """Integrated SFR history over z as in Eq. (B.10) of Bavera et al. (2020).
+
+    Parameters
+    ----------
+    SFR : string
+        Star formation rate assumption:
+        - Madau+Fragos17 see arXiv:1606.07887
+        - Madau+Dickinson14 see arXiv:1403.0007
+        - Neijssel+19 see arXiv:1906.08136
+    Z : double
+        Metallicity.
+
+    Returns
+    -------
+    double
+        The total mass of stars formed per comoving volume at a given
+        metallicity Z.
+
+    """
+    def E(z, Omega_m=cosmology.Om0):
+        Omega_L = 1.- Omega_m
+        return (Omega_m*(1.+z)**3 + Omega_L)**(1./2.)
+    def f(z,Z):
+        if SFR == "Madau+Fragos17" or SFR == "Madau+Dickinson14":
+            sigma = std_log_metallicity_dist(sigma)
+            mu = np.log10(mean_metallicity(SFR, z))-sigma**2*np.log(10)/2.
+            H_0 = cosmology.H0.to('1/yr').value # yr
+            # put a cutoff on metallicity at Z_max
+            norm = stats.norm.cdf(np.log10(Z_max), mu, sigma)
+            return star_formation_rate(SFR, z)*stats.norm.pdf(np.log10(Z), mu, sigma)/norm*(H_0*(1.+z)*E(z))**(-1)
+        elif SFR == "Neijssel+19":
+            sigma = std_log_metallicity_dist(sigma)
+            mu = np.log10(mean_metallicity(SFR, z))-sigma**2/2.
+            H_0 = cosmology.H0.to('1/yr').value # yr
+            return star_formation_rate(SFR, z)*stats.norm.pdf(np.log(Z), mu, sigma)*(H_0*(1.+z)*E(z))**(-1)
+        else:
+            raise ValueError('Invalid SFR!')
+
+    return sp.integrate.quad(f, 1e-10, np.inf, args=(Z,))[0] # M_sun yr^-1 Mpc^-3

--- a/posydon/popsyn/synthetic_population.py
+++ b/posydon/popsyn/synthetic_population.py
@@ -17,6 +17,7 @@ from posydon.utils.common_functions import convert_metallicity_to_string
 from posydon.popsyn.normalized_pop_mass import initial_total_underlying_mass
 from posydon.utils.common_functions import inspiral_timescale_from_orbital_period
 from posydon.popsyn.cosmology import DCOrates
+import posydon.visualization.plot_dco as plot_dco
 
 
 class SyntheticPopulation:
@@ -267,7 +268,8 @@ class SyntheticPopulation:
             print(f'DCO merger efficiency at Z={met:1.2E}: {eff:1.2E} Msun^-1')
         print('')
         print(f'Total DCO merger efficiency: {total:1.2E} Msun^-1')
-        self.merger_efficiency = efficiencies
+        self.met_merger_efficiency = np.array(self.met_merger_efficiency)
+        self.merger_efficiency = np.array(efficiencies)
 
 
     def compute_cosmological_weights(self, sensitivity, flag_pdet, working_dir, load_data):
@@ -371,3 +373,22 @@ class SyntheticPopulation:
                 print('Detectable population successfully loaded!')
         else:
             raise ValueError('You already have an detectable population stored in memory!')
+
+    def plot_merger_efficiency(self, **kwargs):
+        if self.met_merger_efficiency is None or self.merger_efficiency is None:
+            raise ValueError('First you need to compute the merger efficinty!')
+        plot_dco.plot_merger_efficiency(self.met_merger_efficiency, self.merger_efficiency, **kwargs)
+
+    def plot_merger_rate_density(self, **kwargs):
+        if self.z_rate_density is None or self.rate_density is None:
+            raise ValueError('First you need to compute the merger rate density!')
+        plot_dco.plot_merger_rate_density(self.z_rate_density, self.rate_density, **kwargs)
+
+    def plot_hist_dco_properties(self, var, intrinsic=False, detectable=False, **kwargs):
+        if self.z_rate_density is None or self.rate_density is None:
+            raise ValueError('First you need to compute the merger rate density!')
+        if intrinsic:
+            intrinsic = self.df_intrinsic
+        if detectable:
+            detectable = self.df_detectable
+        plot_dco.plot_hist_dco_properties(var, df_intrinsic=intrinsic, df_detectable=detectable, **kwargs)

--- a/posydon/popsyn/synthetic_population.py
+++ b/posydon/popsyn/synthetic_population.py
@@ -3,8 +3,6 @@
 e.g. with multiple metallicities
 """
 
-
-
 __authors__ = [
     "Kyle Akira Rocha <kylerocha2024@u.northwestern.edu>",
     "Simone Bavera <Simone.Bavera@unige.ch>",
@@ -37,6 +35,10 @@ class SyntheticPopulation:
         self.verbose = verbose
         self.df = None
         self.df_synthetic = None
+        self.df_intrinsic = None
+        self.df_detectable = None
+        self.met_merger_efficiency = None
+        self.merger_efficiency = None
         self.z_rate_density = None
         self.rate_density = None
 
@@ -144,6 +146,7 @@ class SyntheticPopulation:
             # read metallicity from path
             met = float(file.split('/')[-1].split('_Zsun')[0])*Zsun
             simulated_mass_for_met = 0.
+            # TODO: handle binaries at the edge case of the chuncks
             for i, df in enumerate(pd.read_hdf(file,  key='history', chunksize=chunksize)):
 
                 logic = self.apply_logic(df, S1_state=S1_state,

--- a/posydon/popsyn/synthetic_population.py
+++ b/posydon/popsyn/synthetic_population.py
@@ -400,12 +400,14 @@ class SyntheticPopulation:
         Parameters
         ----------
         sensitivity : str
-            Choose which GW detector sensitivity you want to use, available:
-            'O3actual_H1L1V1' : TODO add refs
-            'O4high_H1L1V1' : TODO add refs
-            'O4low_H1L1V1' : TODO add refs
-            'design_H1L1V1': LVK target design sensitivity, see fig. 1 of arXiv:1304.0670v3
-            'infinite': intrinsic merging DCO population, i.e. p_det = 1
+            GW detector sensitivity and network configuration you want to use, see arXiv:1304.0670v3
+            detector sensitivities are taken from: https://dcc.ligo.org/LIGO-T2000012-v2/public
+            available sensitivity keys (for Hanford, Livingston, Virgo network):
+                'O3actual_H1L1V1' : aligo_O3actual_H1.txt, aligo_O3actual_L1.txt, avirgo_O3actual.txt
+                'O4low_H1L1V1' : aligo_O4low.txt, aligo_O4low.txt, avirgo_O4high_NEW.txt
+                'O4high_H1L1V1' : aligo_O4high.txt, aligo_O4high.txt, avirgo_O4high_NEW.txt
+                'design_H1L1V1' : AplusDesign.txt, AplusDesign.txt, avirgo_O5high_NEW.txt
+                'infinite': intrinsic merging DCO population, i.e. p_det = 1
         flag_pdet : bool
             `True` if you use sensitivity != 'infinite'.
         working_dir : str
@@ -524,10 +526,13 @@ class SyntheticPopulation:
         Parameters
         ----------
         sensitivity : str
-            'O3actual_H1L1V1' : TODO add refs
-            'O4high_H1L1V1' : TODO add refs
-            'O4low_H1L1V1' : TODO add refs
-            'design_H1L1V1': LVK target design sensitivity, see fig. 1 of arXiv:1304.0670v3
+            GW detector sensitivity and network configuration you want to use, see arXiv:1304.0670v3
+            detector sensitivities are taken from: https://dcc.ligo.org/LIGO-T2000012-v2/public
+            available sensitivity keys (for Hanford, Livingston, Virgo network):
+                'O3actual_H1L1V1' : aligo_O3actual_H1.txt, aligo_O3actual_L1.txt, avirgo_O3actual.txt
+                'O4low_H1L1V1' : aligo_O4low.txt, aligo_O4low.txt, avirgo_O4high_NEW.txt
+                'O4high_H1L1V1' : aligo_O4high.txt, aligo_O4high.txt, avirgo_O4high_NEW.txt
+                'design_H1L1V1' : AplusDesign.txt, AplusDesign.txt, avirgo_O5high_NEW.txt
         export_cols : list str
             List of additional columns to save in the underlying/detectable
             population.

--- a/posydon/popsyn/synthetic_population.py
+++ b/posydon/popsyn/synthetic_population.py
@@ -400,9 +400,11 @@ class SyntheticPopulation:
         Parameters
         ----------
         sensitivity : str
-            TODO: update this once we implement POSYDON p_det calculation
             Choose which GW detector sensitivity you want to use, available:
-            'design': LVK target design sensitivity, see fig. 1 of arXiv:1304.0670v3
+            'O3actual_H1L1V1' : TODO add refs
+            'O4high_H1L1V1' : TODO add refs
+            'O4low_H1L1V1' : TODO add refs
+            'design_H1L1V1': LVK target design sensitivity, see fig. 1 of arXiv:1304.0670v3
             'infinite': intrinsic merging DCO population, i.e. p_det = 1
         flag_pdet : bool
             `True` if you use sensitivity != 'infinite'.
@@ -516,16 +518,16 @@ class SyntheticPopulation:
         # export the intrinsic DCO population
         self.df_intrinsic = self.resample_synthetic_population(index, z_formation, z_merger, w_ijk, export_cols=export_cols)
 
-    def get_dco_detection_rate(self, sensitivity='design', export_cols=None,  working_dir='./', load_data=False):
+    def get_dco_detection_rate(self, sensitivity='design_H1L1V1', export_cols=None,  working_dir='./', load_data=False):
         """Compute the detection rate per yr.
 
         Parameters
         ----------
         sensitivity : str
-            TODO: update this once we implement POSYDON p_det calculation
-            Choose which GW detector sensitivity you want to use, available:
-            'design': LVK target design sensitivity, see fig. 1 of arXiv:1304.0670v3
-            'infinite': intrinsic merging DCO population, i.e. p_det = 1
+            'O3actual_H1L1V1' : TODO add refs
+            'O4high_H1L1V1' : TODO add refs
+            'O4low_H1L1V1' : TODO add refs
+            'design_H1L1V1': LVK target design sensitivity, see fig. 1 of arXiv:1304.0670v3
         export_cols : list str
             List of additional columns to save in the underlying/detectable
             population.

--- a/posydon/popsyn/synthetic_population.py
+++ b/posydon/popsyn/synthetic_population.py
@@ -34,7 +34,7 @@ class SyntheticPopulation:
         """
 
         self.verbose = verbose
-        self.df_synthetic = None
+        self.df = None
 
         if path is None:
             return
@@ -158,21 +158,21 @@ class SyntheticPopulation:
             print('Total binaries found are', count)
 
         # save parsed population as synthetic population
-        if self.df_synthetic is not None:
-            warnings.warn('Overwriting the df_synthetic population!')
-        self.df_synthetic = df_sel
+        if self.df is not None:
+            warnings.warn('Overwriting the df population!')
+        self.df = df_sel
 
-    def save_synthetic_pop(self, path='./parsed_population.h5'):
-        if self.df_synthetic is None:
+    def save_pop(self, path='./parsed_population.h5'):
+        if self.df is None:
             raise ValueError('Nothing to save! The population was not parsed.')
         else:
-            self.df_synthetic.to_hdf(path, key='history')
+            self.df.to_hdf(path, key='history')
             if self.verbose:
                 print('Population successfully saved!')
 
-    def load_synthetic_pop(self, path):
-        if self.df_synthetic is None:
-            self.df_synthetic = pd.read_hdf(path, key='history')
+    def load_pop(self, path):
+        if self.df is None:
+            self.df = pd.read_hdf(path, key='history')
             if self.verbose:
                 print('Population successfully loaded!')
         else:

--- a/posydon/popsyn/synthetic_population.py
+++ b/posydon/popsyn/synthetic_population.py
@@ -77,6 +77,12 @@ class SyntheticPopulation:
 
     def apply_logic(self, df, S1_state=None, S2_state=None, binary_state=None,
                     binary_event=None, step_name=None, invert_S1S2=False):
+        if not invert_S1S2 and S1_state != S2_state:
+            warnings.warn('Note that invert_S1S2=False, hence you are not parsing '
+                          f'the dataset for {S1_state}-{S2_state} binaries and '
+                          f'and not for for {S1_state}-{S2_state}. If this is '
+                          'done on purpose, ignore this message!')
+
         sel_all = df['S1_state'].astype(bool)
 
         if S1_state is not None:
@@ -223,3 +229,16 @@ class SyntheticPopulation:
         # for convinience reindex the DataFrame
         n_rows = len(self.df_synthetic.index)
         self.df_synthetic = self.df_synthetic.set_index(np.linspace(0,n_rows-1,n_rows,dtype=int))
+
+    def get_dco_merger_efficiency(self):
+        total = 0.
+        metallicities = np.unique(self.df_synthetic['metallicity'])
+        for met in sorted(metallicities)[::-1]:
+            sel = (self.df_synthetic['metallicity'] == met)
+            count = self.df_synthetic[sel].shape[0]
+            underlying_stellar_mass = self.df_synthetic.loc[sel,'underlying_mass_for_met'].values[0]
+            eff = count/underlying_stellar_mass
+            total += eff
+            print(f'DCO merger efficiency at Z={met:1.2E}: {eff:1.2E} Msun^-1')
+        print('')
+        print(f'Total DCO merger efficiency: {total:1.2E} Msun^-1')

--- a/posydon/popsyn/synthetic_population.py
+++ b/posydon/popsyn/synthetic_population.py
@@ -254,7 +254,6 @@ class SyntheticPopulation:
             raise ValueError('You already have an synthetic population stored in memory!')
 
     def get_dco_merger_efficiency(self):
-        total = 0.
         metallicities = np.unique(self.df_synthetic['metallicity'])
         efficiencies = []
         self.met_merger_efficiency = sorted(metallicities)[::-1]
@@ -263,11 +262,8 @@ class SyntheticPopulation:
             count = self.df_synthetic[sel].shape[0]
             underlying_stellar_mass = self.df_synthetic.loc[sel,'underlying_mass_for_met'].values[0]
             eff = count/underlying_stellar_mass
-            total += eff
             efficiencies.append(eff)
             print(f'DCO merger efficiency at Z={met:1.2E}: {eff:1.2E} Msun^-1')
-        print('')
-        print(f'Total DCO merger efficiency: {total:1.2E} Msun^-1')
         self.met_merger_efficiency = np.array(self.met_merger_efficiency)
         self.merger_efficiency = np.array(efficiencies)
 

--- a/posydon/popsyn/synthetic_population.py
+++ b/posydon/popsyn/synthetic_population.py
@@ -123,7 +123,7 @@ class SyntheticPopulation:
             print('Binary count with (S1_state, S2_state, binary_state, binary_event) equal')
             print(f'to ({S1_state}, {S2_state}, {binary_state}, {binary_event})')
             if invert_S1S2:
-                print(f'and ({S1_state}, {S2_state}, {binary_state}, {binary_event})')
+                print(f'and ({S2_state}, {S1_state}, {binary_state}, {binary_event})')
         for k, file in enumerate(self.path_to_results):
             # read metallicity from path
             met = float(file.split('/')[-1].split('_Zsun')[0])*Zsun
@@ -168,12 +168,12 @@ class SyntheticPopulation:
         else:
             self.df_synthetic.to_hdf(path, key='history')
             if self.verbose:
-                print('Population succesfully saved!')
+                print('Population successfully saved!')
 
     def load_synthetic_pop(self, path):
         if self.df_synthetic is None:
             self.df_synthetic = pd.read_hdf(path, key='history')
             if self.verbose:
-                print('Population succesfully loaded!')
+                print('Population successfully loaded!')
         else:
             raise ValueError('You already have a population stored in memory!')

--- a/posydon/popsyn/synthetic_population.py
+++ b/posydon/popsyn/synthetic_population.py
@@ -10,15 +10,19 @@ __authors__ = [
     "Simone Bavera <Simone.Bavera@unige.ch>",
 ]
 
-
+import warnings
+import numpy as np
+import pandas as pd
 from posydon.popsyn.io import parse_inifile, binarypop_kwargs_from_ini
 from posydon.popsyn.binarypopulation import BinaryPopulation
 from posydon.utils.common_functions import convert_metallicity_to_string
+from posydon.popsyn.normalized_pop_mass import initial_total_underlying_mass
+from posydon.utils.common_functions import inspiral_timescale_from_orbital_period
 
 
 class SyntheticPopulation:
 
-    def __init__(self, path):
+    def __init__(self, path=None, verbose=False):
         """
         Parameters
         ----------
@@ -29,20 +33,27 @@ class SyntheticPopulation:
 
         """
 
-        synthetic_pop_params = binarypop_kwargs_from_ini(path)
+        self.verbose = verbose
+        self.df_synthetic = None
 
-        self.metallicity = synthetic_pop_params['metallicity']
+        if path is None:
+            return
+        elif '.ini' in path:
+            synthetic_pop_params = binarypop_kwargs_from_ini(path)
 
-        if not isinstance( self.metallicity, list):
-            self.metallicity = [self.metallicity]
+            self.metallicity = synthetic_pop_params['metallicity']
 
-        self.binary_populations = []
-        for met in self.metallicity:
-            ini_kw = binarypop_kwargs_from_ini(path)
-            ini_kw['metallicity'] = met
-            ini_kw['temp_directory'] = self.create_met_prefix(met) + ini_kw['temp_directory']
-            self.binary_populations.append(  BinaryPopulation(**ini_kw)  )
+            if not isinstance( self.metallicity, list):
+                self.metallicity = [self.metallicity]
 
+            self.binary_populations = []
+            for met in self.metallicity:
+                ini_kw = binarypop_kwargs_from_ini(path)
+                ini_kw['metallicity'] = met
+                ini_kw['temp_directory'] = self.create_met_prefix(met) + ini_kw['temp_directory']
+                self.binary_populations.append(BinaryPopulation(**ini_kw))
+        elif (isinstance(path, list) and '.h5' in path[0]) or ('.h5' in path):
+            self.path_to_results = path
 
     def evolve(self):
         """Evolve population(s) at given Z(s)."""
@@ -56,3 +67,113 @@ class SyntheticPopulation:
     def create_met_prefix(met):
         """Append a prefix to the name of directories for batch saving."""
         return convert_metallicity_to_string(met) + '_Zsun_'
+
+    def apply_logic(self, df, S1_state=None, S2_state=None, binary_state=None,
+                    binary_event=None, step_name=None, invert_S1S2=False):
+        sel_all = df['S1_state'].astype(bool)
+
+        if S1_state is not None:
+            S1_logic = (df['S1_state'] == S1_state)
+        else:
+            S1_logic = sel_all
+        if S2_state is not None:
+            S2_logic = (df['S2_state'] == S2_state)
+        else:
+            S2_logic = sel_all
+        if binary_state is not None:
+            binary_state_logic = (df['state'] == binary_state)
+        else:
+            binary_state_logic = sel_all
+        if binary_event is not None:
+            binary_event_logic = (df['event'] == binary_event)
+        else:
+            binary_event_logic = sel_all
+        if step_name is not None:
+            step_name_logic = (df['step_names'] == step_name)
+        else:
+            step_name_logic = sel_all
+
+        if invert_S1S2:
+            S1_logic_inverted = (df['S1_state'] == S2_state)
+            S2_logic_inverted = (df['S2_state'] == S1_state)
+            # find systems
+            logic = ((S1_logic & S2_logic & binary_state_logic &
+                        binary_event_logic & step_name_logic) |
+                     (S1_logic_inverted & S2_logic_inverted &
+                        binary_state_logic  & binary_event_logic &
+                        step_name_logic))
+        else:
+            # find systems
+            logic = (S1_logic & S2_logic & binary_state_logic &
+                        binary_event_logic & step_name_logic)
+
+        return logic
+
+
+    def parse(self, S1_state=None, S2_state=None, binary_state=None,
+               binary_event=None, invert_S1S2=False, chunksize=500000,
+               Zsun = 0.0142):
+
+        # TODO: we should also export the oneline dataframe
+
+        df_sel = pd.DataFrame()
+        count = 0
+        tmp = 0
+        if self.verbose:
+            print('Binary count with (S1_state, S2_state, binary_state, binary_event) equal')
+            print(f'to ({S1_state}, {S2_state}, {binary_state}, {binary_event})')
+            if invert_S1S2:
+                print(f'and ({S1_state}, {S2_state}, {binary_state}, {binary_event})')
+        for k, file in enumerate(self.path_to_results):
+            # read metallicity from path
+            met = float(file.split('/')[-1].split('_Zsun')[0])*Zsun
+            for i, df in enumerate(pd.read_hdf(file,  key='history', chunksize=chunksize)):
+
+                logic = self.apply_logic(df, S1_state=S1_state,
+                                    S2_state=S2_state,
+                                    binary_state=binary_state,
+                                    binary_event=binary_event,
+                                    invert_S1S2=invert_S1S2)
+
+                # select systems
+                # remove duplicate indicies, e.g. if selecting 'contact' state it appears twice
+                # if no specific event is selected (the second time is from the copied END event)
+                sel = df.loc[logic].index.drop_duplicates()
+
+                # count systems
+                count += len(np.unique(sel))
+
+                # sort systems
+                if any(sel):
+                    df_tmp = pd.DataFrame()
+                    df_tmp = df.loc[sel]
+                    df_tmp['metallicity'] = met
+                    df_sel = pd.concat([df_sel,df_tmp])
+
+            if self.verbose:
+                print(f'in {file} are {count-tmp}')
+            tmp = count
+
+        if self.verbose:
+            print('Total binaries found are', count)
+
+        # save parsed population as synthetic population
+        if self.df_synthetic is not None:
+            warnings.warn('Overwriting the df_synthetic population!')
+        self.df_synthetic = df_sel
+
+    def save_synthetic_pop(self, path='./parsed_population.h5'):
+        if self.df_synthetic is None:
+            raise ValueError('Nothing to save! The population was not parsed.')
+        else:
+            self.df_synthetic.to_hdf(path, key='history')
+            if self.verbose:
+                print('Population succesfully saved!')
+
+    def load_synthetic_pop(self, path):
+        if self.df_synthetic is None:
+            self.df_synthetic = pd.read_hdf(path, key='history')
+            if self.verbose:
+                print('Population succesfully loaded!')
+        else:
+            raise ValueError('You already have a population stored in memory!')

--- a/posydon/visualization/plot_dco.py
+++ b/posydon/visualization/plot_dco.py
@@ -1,0 +1,102 @@
+import os
+import matplotlib.pyplot as plt
+from posydon.utils.common_functions import PATH_TO_POSYDON
+from posydon.visualization.plot_defaults import DEFAULT_LABELS
+
+plt.style.use(os.path.join(PATH_TO_POSYDON, "posydon/visualization/posydon.mplstyle"))
+
+def plot_merger_efficiency(met, merger_efficiency, show=True, path=None, Zsun=0.0142):
+    title = r'Merger efficiency'
+    plt.figure()
+    plt.title(title)
+    plt.plot(met/Zsun, merger_efficiency)
+    plt.yscale('log')
+    plt.xscale('log')
+    plt.xlabel(r'$Z/Z_\odot$')
+    plt.ylabel(r'\#DCOs [$M_\odot^{-1}$]')
+    if path:
+        plt.savefig(path)
+    if show:
+        plt.show()
+
+def plot_merger_rate_density(z, rate_density, zmax=10., show=True, path=None):
+    title = r'Merger rate density'
+    plt.figure()
+    plt.title(title)
+    plt.plot(z[z<zmax], rate_density[z<zmax])
+    plt.yscale('log')
+    plt.ylabel(r'$\mathcal{R}_\mathrm{BBH}\,[\mathrm{Gpc}^{-3}\,\mathrm{yr}^{-1}]$')
+    plt.xlabel(r'$z$')
+    if path:
+        plt.savefig(path)
+    if show:
+        plt.show()
+
+def plot_hist_dco_properties(x, df_intrinsic=None, df_detectable=None,
+                             show=True, path=None, alpha=0.5,
+                             range=None, bins=20, ylog=False):
+    if df_intrinsic is not None and df_detectable is not None:
+        title = r'Intrinsic vs. detectable (dashed) population'
+    elif df_intrinsic is not None:
+        title = r'Intrinsic population'
+    elif f_detectable is not None:
+        title = r'Detectable population'
+    else:
+        raise ValueError('You should provide either an intrinsic or a '
+                         'detectable population.')
+
+    colors = ['tab:blue', 'tab:orange', 'tab:green', 'tab:red', 'tab:purple']
+    plt.figure()
+    plt.title(title)
+    if df_intrinsic is not None:
+        if isinstance(x, str):
+            plt.hist(df_intrinsic[x], weights=df_intrinsic['weight'], color=colors[0],
+                     alpha=alpha, density=True, range=range, bins=bins)
+        elif isinstance(x, list):
+            for i, x_i in enumerate(x):
+                if "S1" in x_i:
+                    label = 'S1'
+                elif "S2" in x_i:
+                    label = 'S2'
+                else:
+                    label = x_i
+                plt.hist(df_intrinsic[x_i], weights=df_intrinsic['weight'],
+                         color=colors[i], label=label,
+                         alpha=alpha, density=True, range=range, bins=bins)
+    if df_detectable is not None:
+        if isinstance(x, str):
+            plt.hist(df_detectable[x], weights=df_detectable['weight'],
+                     color=colors[0],
+                     histtype=u'step', linestyle='--',
+                     alpha=alpha, density=True, range=range, bins=bins)
+        elif isinstance(x, list):
+            for i, x_i in enumerate(x):
+                if "S1" in x_i:
+                    label = 'S1'
+                elif "S2" in x_i:
+                    label = 'S2'
+                else:
+                    label = x_i
+                plt.hist(df_detectable[x_i], weights=df_detectable['weight'],
+                         color=colors[i], label=label,
+                         histtype=u'step', linestyle='--',
+                         alpha=alpha, density=True, range=range, bins=bins)
+    if ylog:
+        plt.yscale('log')
+    plt.ylabel(r'PDF')
+    try:
+        if isinstance(x, str):
+            plt.xlabel(DEFAULT_LABELS[x])
+        else:
+            plt.xlabel(DEFAULT_LABELS[x[0]])
+    except:
+        if isinstance(x, str):
+            plt.xlabel(x)
+        else:
+            plt.xlabel(x[0])
+    if isinstance(x, list):
+        plt.legend(loc=1)
+    if path:
+        plt.savefig(path)
+    if show:
+        plt.show()

--- a/posydon/visualization/plot_defaults.py
+++ b/posydon/visualization/plot_defaults.py
@@ -769,4 +769,16 @@ DEFAULT_LABELS = {
     't_sync_conv_2':
         [r'$t^2_\mathrm{conv}\,[\mathrm{s}]$',
          r'$\log_{10}(t^2_\mathrm{conv}/\mathrm{s})$'],
+
+    # POSYDON population synthesis
+    'z_formation': r'$z_\mathrm{formation}$',
+    'z_merger': r'$z_\mathrm{merger}$',
+    'm_tot': r'$m_\mathrm{tot}\,[M_\odot]$',
+    'm_chirp': r'$m_\mathrm{chirp}\,[M_\odot]$',
+    'q': r'$q$',
+    'chi_eff': r'$\chi_\mathrm{eff}$',
+    'S1_mass': r'$m_\mathrm{CO}\,[M_\odot]$',
+    'S2_mass': r'$m_\mathrm{CO}\,[M_\odot]$',
+    'S1_spin': r'$\chi_\mathrm{CO}$',
+    'S2_spin': r'$\chi_\mathrm{CO}$',
 }

--- a/posydon/visualization/posydon.mplstyle
+++ b/posydon/visualization/posydon.mplstyle
@@ -1,0 +1,32 @@
+# matplotlib style sheet for POSYDON Instrument Papers
+
+figure.figsize		: 3.38, 2.535 # 4x3 with width=apjcolwidth
+lines.markersize	: 4
+lines.linewidth		: 1.5
+text.usetex		: True
+font.size		: 10
+font.family		: serif
+font.serif		: Computer Modern Roman # Times Roman?
+axes.titlesize		: medium
+axes.labelsize		: medium
+legend.fontsize		: 8
+legend.frameon		: False
+figure.dpi 		: 300
+
+
+xtick.minor.visible     : True
+ytick.minor.visible     : True
+
+savefig.bbox		: tight # standard
+savefig.pad_inches	: 0.1 # Padding when bbox is tight.
+savefig.dpi		: 300
+savefig.format		: pdf
+
+xtick.direction	    : in
+xtick.top	    : True
+ytick.direction	    : in
+ytick.right	    : True
+
+
+axes.formatter.use_mathtext : True
+#figure.autolayout	    : True


### PR DESCRIPTION
This is it, I have been waiting for this moment for the past 5 years. This PR aims to introduce rate calculations for DCO  populations run with POSYDON. I will be rolling out functionalities as I add them.

TODO list:
- [x] add parser method to sort out binaries of interest from a POSYDON v2 simulation output
- [x] add saving/loading functionalities for the parsed population
- [x] add a method to export the DCO synthetic population at formation
- [x] export columns t_inspiral, metallicity, simulated_mass_for_met, underlying_mass_for_met, oneline DF properties
- [x] clean and add the DCO rate calculation code
- [x] add gravitational-wave selection effects to compute GW detection rates p_det(m1,q,z,chi_eff)

# POSYDON v2 workflow demo

Each step can be independently resumed starting from a fresh initialisation of the SyntheticPopulation class. 

## STEP 1: POSYDON v2 population synthesis
Run your multi-metallicity POSYDON population synthesis model.
```py
from posydon.popsyn.synthetic_population import SyntheticPopulation
pop = SyntheticPopulation('./population_params.ini')
pop.evolve()
```

## STEP 2: Sort merging DCOs

Parse the entire simulation output and isolate the merging DCO with the `parse` method of the `SyntheticPopulation` class.
```py
import os
path = '/Volumes/T7/data_phd/datasets/posydon/posydon_v2/test_1M'
files = ['1.00e+00_Zsun_population.h5',
         '1.00e-01_Zsun_population.h5',
         '1.00e-02_Zsun_population.h5',
         '1.00e-03_Zsun_population.h5',
         '1.00e-04_Zsun_population.h5']
path_to_data = [os.path.join(path,file) for file in files] 

pop = SyntheticPopulation(path_to_ini='./population_params.ini', path_to_data=path_to_data, verbose=True)

# sort BHNHs
pop.parse(S1_state='BH', S2_state='NS', binary_state='contact', invert_S1S2=True)
pop.save_pop('./data/BHNS_population.h5')

# sort BBHs
pop.parse(S1_state='BH', S2_state='BH', binary_state='contact')
pop.save_pop('./data/BBH_population.h5')

pop.df.head(10)
```
```
Binary count with (S1_state, S2_state, binary_state, binary_event) equal
to (BH, NS, contact, None)
and (NS, BH, contact, None)
in /Volumes/T7/data_phd/datasets/posydon/posydon_v2/test_1M/1.00e+00_Zsun_population.h5 are 1294
in /Volumes/T7/data_phd/datasets/posydon/posydon_v2/test_1M/1.00e-01_Zsun_population.h5 are 3246
in /Volumes/T7/data_phd/datasets/posydon/posydon_v2/test_1M/1.00e-02_Zsun_population.h5 are 1330
in /Volumes/T7/data_phd/datasets/posydon/posydon_v2/test_1M/1.00e-03_Zsun_population.h5 are 1672
in /Volumes/T7/data_phd/datasets/posydon/posydon_v2/test_1M/1.00e-04_Zsun_population.h5 are 2284
Total binaries found are 9826
Population successfully saved!

Binary count with (S1_state, S2_state, binary_state, binary_event) equal
to (BH, BH, contact, None)
in /Volumes/T7/data_phd/datasets/posydon/posydon_v2/test_1M/1.00e+00_Zsun_population.h5 are 155
in /Volumes/T7/data_phd/datasets/posydon/posydon_v2/test_1M/1.00e-01_Zsun_population.h5 are 3598
in /Volumes/T7/data_phd/datasets/posydon/posydon_v2/test_1M/1.00e-02_Zsun_population.h5 are 4836
in /Volumes/T7/data_phd/datasets/posydon/posydon_v2/test_1M/1.00e-03_Zsun_population.h5 are 10736
in /Volumes/T7/data_phd/datasets/posydon/posydon_v2/test_1M/1.00e-04_Zsun_population.h5 are 14065
Total binaries found are 33390
---> UserWarning: Overwriting the df population!
Population successfully saved!
```
<img width="906" alt="Screenshot 2023-05-03 at 10 00 44" src="https://user-images.githubusercontent.com/32518238/235862057-7bd1b00b-07f6-4b8a-bb76-87aab1bce16a.png">

For convenience, the code automatically parses the oneline dataframe as well which is also saved in the same population h5 file.
```py
pop.df_oneline.head()
```
![Screenshot 2023-05-08 at 09 55 28](https://user-images.githubusercontent.com/32518238/236768565-bcc435cd-e06b-4a98-b459-314f48abd4da.png)


## STEP 3: DCO rates and distributions

### Synthetic population: DCO at formation

The `get_dco_at_formation` method of `SyntheticPopulation` parses each merging DCO and sorts the properties at DCO formation in the synthetic population data frame `df_synthetic`. It also takes care of 
1. adding the metallicity column
2. compute the inspiral timescale from the integrated orbit (we do not use Peters approximation) --> `t_delay`
3. convert the time of DCO formation and t_delay to Myr
4. read the total simulated mass per metalicity
5. convert the total simulated mass per metallicity to the underlying stellar mass given the IMF properties stored in the ini file
6. you can also ask to extract columns stored in the oneline dataframe, e.g. here I show how to sort kick magnitudes. right now only BH spin tilts are parsed automatically (if not available you get a warning like in this example).
```py
pop = SyntheticPopulation('./population_params.ini', verbose=True)
pop.load_pop('./data/BBH_population.h5')
#pop.df.head(10)
pop.get_dco_at_formation(S1_state='BH', S2_state='BH',  oneline_cols=['S1_natal_kick_array_0', 'S2_natal_kick_array_0']))
pop.save_synthetic_pop('./data/syntheticc_population.h5')
#pop.load_synthetic_pop('./data/synthetic_population.h5')
cols = ['metallicity','time','t_delay','S1_state','S2_state','S1_mass','S2_mass','S1_spin','S2_spin',
        'orbital_period','eccentricity','simulated_mass_for_met','underlying_mass_for_met',
        'S1_natal_kick_array_0', 'S2_natal_kick_array_0']
pop.df_synthetic[cols]
```
```
Population successfully loaded!
Synthetic population successfully saved!
--->  UserWarning: The column S1_spin_orbit_tilt is not present in the oneline dataframe.
--->  UserWarning: The column S2_spin_orbit_tilt is not present in the oneline dataframe.
```
![Screenshot 2023-05-08 at 09 59 16](https://user-images.githubusercontent.com/32518238/236769109-209dc1d4-17af-4a7e-95de-be73f05d1ea7.png)


### DCO merger efficiency

```py
pop.get_dco_merger_efficiency()
pop.plot_merger_efficiency()
```
```
DCO merger efficiency at Z=1.42E-02: 9.83E-07 Msun^-1
DCO merger efficiency at Z=1.42E-03: 2.28E-05 Msun^-1
DCO merger efficiency at Z=1.42E-04: 3.06E-05 Msun^-1
DCO merger efficiency at Z=1.42E-05: 6.80E-05 Msun^-1
DCO merger efficiency at Z=1.42E-06: 8.91E-05 Msun^-1
```
![Screenshot 2023-05-04 at 13 46 55](https://user-images.githubusercontent.com/32518238/236195104-8d994487-63cb-4d3f-af97-0f81030037be.png)


### Intrinsic population: DCO merger rate density

```py
pop.get_dco_merger_rate_density() # if already computed use load_data=True
pop.save_intrinsic_pop('./data/intrinsic_population.h5')
#pop.load_intrinsic_pop('./data/intrinsic_population.h5')
pop.df_intrinsic
```
```
---> tqdm bar
DCO merger rate density in the local Universe (0.00): 140.79 Gpc^-3 yr^-1
--->  UserWarning: Spin tilts not in dataset! Assuming spins are aligned to orbital angular momentum to compute chi_eff!
Intrinsic population successfully saved!
```
![intrinsic](https://user-images.githubusercontent.com/32518238/236157311-a0bb26bf-b99c-4efe-869f-49a6642fa0fa.png)

```py
pop.plot_merger_rate_density()
```
![Screenshot 2023-05-04 at 13 47 00](https://user-images.githubusercontent.com/32518238/236195305-b4b0ba2c-a487-4a6c-a40c-121ec665b659.png)


### Detectable population: DCO detection rate

```py
pop.get_dco_detection_rate(sensitivity='design_H1L1V1') # if already computed use load_data=True
pop.save_detectable_pop('./data/detectable_population.h5')
#pop.load_detectable_pop('./data/detectable_population.h5')
pop.df_detectable
```
```
---> tqdm bar (take a coffee because this takes a while, ~ 17 min for this example)
DCO detection rate at design sensitivity: 7976.29 yr^-1
--->  UserWarning: Spin tilts not in dataset! Assuming spins are aligned to orbital angular momentum to compute chi_eff!
Detectable population successfully saved!
```
![detectable](https://user-images.githubusercontent.com/32518238/236157594-655ea57a-1e83-4076-b45d-654269ce027f.png)

```py
pop.plot_hist_dco_properties('m_chirp', intrinsic=True, detectable=True)
pop.plot_hist_dco_properties('chi_eff', intrinsic=True, detectable=True)
pop.plot_hist_dco_properties('q', intrinsic=True, detectable=True)
pop.plot_hist_dco_properties(['S1_mass','S2_mass'], intrinsic=True, detectable=True)
pop.plot_hist_dco_properties(['S1_spin','S2_spin'], intrinsic=True, detectable=True)
```
```
--->  UserWarning: Spin tilts not in dataset! Assuming spins are aligned to orbital angular momentum to compute chi_eff!
```

<img width="712" alt="Screenshot 2023-05-23 at 11 00 42" src="https://github.com/POSYDON-code/POSYDON/assets/32518238/3ff41c38-4176-4f69-9a9d-01d4f3f4a634">
<img width="712" alt="Screenshot 2023-05-23 at 11 00 58" src="https://github.com/POSYDON-code/POSYDON/assets/32518238/13f9f5ce-1ad1-4aaf-9c4f-d4d8190f01fb">
<img width="712" alt="Screenshot 2023-05-23 at 11 02 01" src="https://github.com/POSYDON-code/POSYDON/assets/32518238/c9fc201f-8e3f-4778-b041-84871e2cb943">
<img width="712" alt="Screenshot 2023-05-23 at 11 01 14" src="https://github.com/POSYDON-code/POSYDON/assets/32518238/e5b442a5-bc52-4b53-bc4f-9bff696a1989">
<img width="712" alt="Screenshot 2023-05-23 at 11 01 30" src="https://github.com/POSYDON-code/POSYDON/assets/32518238/c8f83911-dd1d-40b5-817c-2f5c53713ce2">
