### PR TITLE
Catch corrupted mesa files for creating a psygrid

### DIFF
--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -656,9 +656,6 @@ class PSyGrid:
                 history1 = None
             elif self.eeps is None:
                 history1 = read_MESA_data_file(run.history1_path, H1_columns)
-                if history1 is None:
-                    ignore_data = True
-                    ignore_reason = "corrupted_history1"
             else:
                 try:
                     eep_path = self.eeps[os.path.basename(run.path)]
@@ -681,9 +678,6 @@ class PSyGrid:
                 history2 = None
             else:
                 history2 = read_MESA_data_file(run.history2_path, H2_columns)
-                if history2 is None:
-                    ignore_data = True
-                    ignore_reason = "corrupted_history2"
             if self.config["He_core_fix"]:
                 history2 = fix_He_core(history2)
 

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -770,14 +770,22 @@ class PSyGrid:
                     )
 
                 # if scubbing wiped all the binary history, discard run
-                if binary_grid and len(binary_history) == 0:
+                if binary_history is not None:
+                    binary_history_len = len(binary_history)
+                else:
+                    binary_history_len = 0
+                if binary_grid and binary_history_len == 0:
                     ignore_data = True
                     ignore_reason = "ignored_scrubbed"
                     warnings.warn("Ignored MESA run because of scrubbed binary"
                                   " history in: {}\n".format(run.path))
                     if not initial_RLO_fix:
                         continue
-                if not binary_grid and len(history1) == 0:
+                if history1 is not None:
+                    history1_len = len(history1)
+                else:
+                    history1_len = 0
+                if not binary_grid and history1_len == 0:
                     ignore_data = True
                     warnings.warn("Ignored MESA run because of scrubbed"
                                   " history in: {}\n".format(run.path))

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -686,40 +686,52 @@ class PSyGrid:
                 # read the model numbers and ages from the histories
                 colname = "model_number"
                 if history1 is not None:
-                    history1_mod = np.int_(read_MESA_data_file(
-                        run.history1_path, [colname])[colname])
-                    if len(history1_mod) == len(history1) + 1:
-                        history1_mod = history1_mod[:-1]
+                    history1_mod = read_MESA_data_file(
+                        run.history1_path, [colname])
+                    if history1_mod is not None:
+                        history1_mod = np.int_(history1_mod[colname])
+                        if len(history1_mod) == len(history1) + 1:
+                            history1_mod = history1_mod[:-1]
                     history1_age = read_MESA_data_file(
-                        run.history1_path, ["star_age"])["star_age"]
-                    if len(history1_age) == len(history1) + 1:
-                        history1_age = history1_age[:-1]
+                        run.history1_path, ["star_age"])
+                    if history1_age is not None:
+                        history1_age = history1_age["star_age"]
+                        if len(history1_age) == len(history1) + 1:
+                            history1_age = history1_age[:-1]
                 else:
                     history1_mod = None
                     history1_age = None
 
                 if history2 is not None:
-                    history2_mod = np.int_(read_MESA_data_file(
-                        run.history2_path, [colname])[colname])
-                    if len(history2_mod) == len(history2) + 1:
-                        history2_mod = history2_mod[:-1]
+                    history2_mod = read_MESA_data_file(
+                        run.history2_path, [colname]
+                    if history2_mod is not None:
+                        history2_mod = np.int_(history2_mod[colname])
+                        if len(history2_mod) == len(history2) + 1:
+                            history2_mod = history2_mod[:-1]
                     history2_age = read_MESA_data_file(
-                        run.history2_path, ["star_age"])["star_age"]
-                    if len(history2_age) == len(history2) + 1:
-                        history2_age = history2_age[:-1]
+                        run.history2_path, ["star_age"])
+                    if history2_age is not None:
+                        history2_age = history2_age["star_age"]
+                        if len(history2_age) == len(history2) + 1:
+                            history2_age = history2_age[:-1]
                 else:
                     history2_mod = None
                     history2_age = None
 
                 if binary_history is not None:
-                    binary_history_mod = np.int_(read_MESA_data_file(
-                        run.binary_history_path, [colname])[colname])
-                    if len(binary_history_mod) == len(binary_history) + 1:
-                        binary_history_mod = binary_history_mod[:-1]
+                    binary_history_mod = read_MESA_data_file(
+                        run.binary_history_path, [colname])
+                    if binary_history_mod is not None:
+                        binary_history_mod = np.int_(binary_history_mod[colname])
+                        if len(binary_history_mod) == len(binary_history) + 1:
+                            binary_history_mod = binary_history_mod[:-1]
                     binary_history_age = read_MESA_data_file(
-                        run.binary_history_path, ["age"])["age"]
-                    if len(binary_history_age) == len(binary_history) + 1:
-                        binary_history_age = binary_history_age[:-1]
+                        run.binary_history_path, ["age"])
+                    if binary_history_age is not None:
+                        binary_history_age = binary_history_age["age"]
+                        if len(binary_history_age) == len(binary_history) + 1:
+                            binary_history_age = binary_history_age[:-1]
                 else:
                     binary_history_mod = None
                     binary_history_age = None

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -716,7 +716,7 @@ class PSyGrid:
 
                 if history2 is not None:
                     history2_mod = read_MESA_data_file(
-                        run.history2_path, [colname]
+                        run.history2_path, [colname])
                     if history2_mod is not None:
                         history2_mod = np.int_(history2_mod[colname])
                         if len(history2_mod) == len(history2) + 1:

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -656,6 +656,9 @@ class PSyGrid:
                 history1 = None
             elif self.eeps is None:
                 history1 = read_MESA_data_file(run.history1_path, H1_columns)
+                if history1 is None:
+                    ignore_data = True
+                    ignore_reason = "corrupted_history1"
             else:
                 try:
                     eep_path = self.eeps[os.path.basename(run.path)]
@@ -678,6 +681,9 @@ class PSyGrid:
                 history2 = None
             else:
                 history2 = read_MESA_data_file(run.history2_path, H2_columns)
+                if history2 is None:
+                    ignore_data = True
+                    ignore_reason = "corrupted_history2"
             if self.config["He_core_fix"]:
                 history2 = fix_He_core(history2)
 
@@ -692,12 +698,18 @@ class PSyGrid:
                         history1_mod = np.int_(history1_mod[colname])
                         if len(history1_mod) == len(history1) + 1:
                             history1_mod = history1_mod[:-1]
+                    else:
+                        ignore_data = True
+                        ignore_reason = "corrupted_history1"
                     history1_age = read_MESA_data_file(
                         run.history1_path, ["star_age"])
                     if history1_age is not None:
                         history1_age = history1_age["star_age"]
                         if len(history1_age) == len(history1) + 1:
                             history1_age = history1_age[:-1]
+                    else:
+                        ignore_data = True
+                        ignore_reason = "corrupted_history1"
                 else:
                     history1_mod = None
                     history1_age = None
@@ -709,12 +721,18 @@ class PSyGrid:
                         history2_mod = np.int_(history2_mod[colname])
                         if len(history2_mod) == len(history2) + 1:
                             history2_mod = history2_mod[:-1]
+                    else:
+                        ignore_data = True
+                        ignore_reason = "corrupted_history2"
                     history2_age = read_MESA_data_file(
                         run.history2_path, ["star_age"])
                     if history2_age is not None:
                         history2_age = history2_age["star_age"]
                         if len(history2_age) == len(history2) + 1:
                             history2_age = history2_age[:-1]
+                    else:
+                        ignore_data = True
+                        ignore_reason = "corrupted_history2"
                 else:
                     history2_mod = None
                     history2_age = None
@@ -726,12 +744,18 @@ class PSyGrid:
                         binary_history_mod = np.int_(binary_history_mod[colname])
                         if len(binary_history_mod) == len(binary_history) + 1:
                             binary_history_mod = binary_history_mod[:-1]
+                    else:
+                        ignore_data = True
+                        ignore_reason = "corrupted_binary_history"
                     binary_history_age = read_MESA_data_file(
                         run.binary_history_path, ["age"])
                     if binary_history_age is not None:
                         binary_history_age = binary_history_age["age"]
                         if len(binary_history_age) == len(binary_history) + 1:
                             binary_history_age = binary_history_age[:-1]
+                    else:
+                        ignore_data = True
+                        ignore_reason = "corrupted_binary_history"
                 else:
                     binary_history_mod = None
                     binary_history_age = None

--- a/posydon/grids/scrubbing.py
+++ b/posydon/grids/scrubbing.py
@@ -33,7 +33,7 @@ def scrub(tables, models, ages):
     scr_tables = []
     scr_models = []
     for table, model, age in zip(tables, models, ages):
-        if table is None:
+        if (table is None) or (model is None) or (age is None):
             scr_tables.append(None)
             scr_models.append(None)
         else:

--- a/posydon/utils/gridutils.py
+++ b/posydon/utils/gridutils.py
@@ -69,17 +69,25 @@ def read_MESA_data_file(path, columns):
     if path is None:
         return None
     elif os.path.exists(path):
-        return np.atleast_1d(np.genfromtxt(path, skip_header=5, names=True,
-                                           usecols=columns,
-                                           invalid_raise=False))
+        try:
+            return np.atleast_1d(np.genfromtxt(path, skip_header=5, names=True,
+                                               usecols=columns,
+                                               invalid_raise=False))
+        except:
+            warnings.warn("Problems with reading file "+path)
+            return None
     else:
         return None
 
 
 def read_EEP_data_file(path, columns):
     """Read an EEP file (can be `.gz`) - similar to `read_MESA_data_file()`."""
-    return np.atleast_1d(np.genfromtxt(path, skip_header=11, names=True,
-                                       usecols=columns, invalid_raise=False))
+    try:
+        return np.atleast_1d(np.genfromtxt(path, skip_header=11, names=True,
+                                           usecols=columns, invalid_raise=False))
+    except:
+        warnings.warn("Problems with reading file "+path)
+        return None
 
 
 def fix_He_core(history):


### PR DESCRIPTION
Currently, the codes assumes a lot about the structure of the history.data files without checking it nor having catches, if the files are not as they should.
This PR is aimed to improve on this:
- [x] use a `try`, when reading the MESA files, if it fails add a warning and rerun a None object (change in `gridutils.py`)
- [x] add ignore for not well read history files in `psygrid.py`
- [x] in the case only one column is corrupted in `history.data`, the `tables`, `models` and `ages` might not be aligned and need to be checked for `None` separately (change in `scrubbing.py`)
- [x] as a consequence, we may set the histories to `None` only after the scrubbing, where we can't surely measure the length of them, because a `None` causes a runtime error there, hence this needed to be fixed, too. (change in `psygrid.py`)

With this functionality, we don't need to remove all corrupted files (e.g. caused by issues on the file system or the hard drive), instead we can rerun them and layer them over in step_2 of the post processing.