### PR TITLE
Allow grid end at He depletion (for massive stars)

### DIFF
--- a/bin/run-pipeline
+++ b/bin/run-pipeline
@@ -83,7 +83,7 @@ def create_grid_slice(i, path_to_csv_file, CO_HMS_GRID_START_AT_RLO, verbose=Fal
     grid_name = grid_path.split('/')[-1]
     otuput_path = os.path.join('/', os.path.join(*grid_path.split('/')[:-1]),
                                compression)
-    grid_output = os.path.join(otuput_path, grid_name+'_He_depletion.h5')
+    grid_output = os.path.join(otuput_path, grid_name+'.h5')
 
     # check that LITE/ or ORIGINAL/ directory exists
     if not os.path.isdir(otuput_path):

--- a/bin/run-pipeline
+++ b/bin/run-pipeline
@@ -83,7 +83,7 @@ def create_grid_slice(i, path_to_csv_file, CO_HMS_GRID_START_AT_RLO, verbose=Fal
     grid_name = grid_path.split('/')[-1]
     otuput_path = os.path.join('/', os.path.join(*grid_path.split('/')[:-1]),
                                compression)
-    grid_output = os.path.join(otuput_path, grid_name+'.h5')
+    grid_output = os.path.join(otuput_path, grid_name+'_He_depletion.h5')
 
     # check that LITE/ or ORIGINAL/ directory exists
     if not os.path.isdir(otuput_path):
@@ -124,6 +124,7 @@ def create_grid_slice(i, path_to_csv_file, CO_HMS_GRID_START_AT_RLO, verbose=Fal
                 profile_DS_interval=profile_DS_interval,
                 compression="gzip9",
                 start_at_RLO=start_at_RLO,
+                stop_at_He_depletion=True,
                 initial_RLO_fix=True)
     grid.close()
 

--- a/bin/run-pipeline
+++ b/bin/run-pipeline
@@ -124,7 +124,7 @@ def create_grid_slice(i, path_to_csv_file, CO_HMS_GRID_START_AT_RLO, verbose=Fal
                 profile_DS_interval=profile_DS_interval,
                 compression="gzip9",
                 start_at_RLO=start_at_RLO,
-                stop_at_He_depletion=True,
+                stop_before_carbon_depletion=True,
                 initial_RLO_fix=True)
     grid.close()
 

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -757,7 +757,7 @@ class PSyGrid:
                     continue
 
                 # check whether stop at He depletion is requested
-                if stop_at_He_depletion:
+                if stop_at_He_depletion and initial_values[i]["star_1_mass"]>=100.0:
                     kept = keep_till_He_depletion(binary_history, history1,
                                   history2, THRESHOLD_CENTRAL_ABUNDANCE, 0.1)
                     binary_history, history1, history2, newTF1 = kept

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -209,7 +209,7 @@ from posydon.utils.gridutils import (read_MESA_data_file, read_EEP_data_file,
 from posydon.visualization.plot2D import plot2D
 from posydon.visualization.plot1D import plot1D
 from posydon.grids.downsampling import TrackDownsampler
-from posydon.grids.scrubbing import scrub, keep_after_RLO, keep_till_He_depletion
+from posydon.grids.scrubbing import scrub, keep_after_RLO, keep_till_central_abundance_He_C
 
 
 HDF5_MEMBER_SIZE = 2**31 - 1            # maximum HDF5 file size when splitting
@@ -347,7 +347,7 @@ GRIDPROPERTIES = {
     "final_value_columns": None,
     # grid-specific arguments
     "start_at_RLO": False,
-    "stop_at_He_depletion": False,
+    "stop_before_carbon_depletion": False,
     "binary": True,
     "eep": None,    # path to EEP files
     "initial_RLO_fix": False,
@@ -539,7 +539,7 @@ class PSyGrid:
         binary_grid = self.config["binary"]
         initial_RLO_fix = self.config["initial_RLO_fix"]
         start_at_RLO = self.config["start_at_RLO"]
-        stop_at_He_depletion = self.config["stop_at_He_depletion"]
+        stop_before_carbon_depletion = self.config["stop_before_carbon_depletion"]
         eep = self.config["eep"]
 
         if eep is not None:
@@ -757,8 +757,8 @@ class PSyGrid:
                     continue
 
                 # check whether stop at He depletion is requested
-                if stop_at_He_depletion and initial_values[i]["star_1_mass"]>=100.0:
-                    kept = keep_till_He_depletion(binary_history, history1,
+                if stop_before_carbon_depletion and initial_values[i]["star_1_mass"]>=100.0:
+                    kept = keep_till_central_abundance_He_C(binary_history, history1,
                                   history2, THRESHOLD_CENTRAL_ABUNDANCE, 0.1)
                     binary_history, history1, history2, newTF1 = kept
                     
@@ -1981,7 +1981,7 @@ PROPERTIES_TO_BE_NONE = {
 }
 
 PROPERTIES_TO_BE_CONSISTENT = ["binary", "eep", "start_at_RLO",
-                               "stop_at_He_depletion",
+                               "stop_before_carbon_depletion",
                                "initial_RLO_fix", "He_core_fix",
                                "accept_missing_profile", "history_DS_error",
                                "history_DS_exclude", "profile_DS_error",

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -759,7 +759,7 @@ class PSyGrid:
                 # check whether stop at He depletion is requested
                 if stop_at_He_depletion:
                     kept = keep_till_He_depletion(binary_history, history1,
-                                         history2, THRESHOLD_CENTRAL_ABUNDANCE)
+                                  history2, THRESHOLD_CENTRAL_ABUNDANCE, 0.08)
                     binary_history, history1, history2, newTF1 = kept
                     
                 # check whether start at RLO is requested, and chop the history

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -757,7 +757,7 @@ class PSyGrid:
                 # check whether stop at He depletion is requested
                 if stop_at_He_depletion:
                     kept = keep_till_He_depletion(binary_history, history1,
-                                                  history2)
+                                                  history2, 0.01)
                     binary_history, history1, history2 = kept
                     
                 # check whether start at RLO is requested, and chop the history

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -757,7 +757,7 @@ class PSyGrid:
                     continue
 
                 # check whether stop at He depletion is requested
-                if stop_before_carbon_depletion and initial_values[i]["star_1_mass"]>=100.0:
+                if stop_before_carbon_depletion and self.initial_values[i]["star_1_mass"]>=100.0:
                     kept = keep_till_central_abundance_He_C(binary_history, history1,
                                   history2, THRESHOLD_CENTRAL_ABUNDANCE, 0.1)
                     binary_history, history1, history2, newTF1 = kept

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -202,7 +202,8 @@ from posydon.grids.termination_flags import (get_flags_from_MESA_run,
 from posydon.utils.configfile import ConfigFile
 from posydon.utils.common_functions import (orbital_separation_from_period,
                                             initialize_empty_array,
-                                            infer_star_state)
+                                            infer_star_state,
+                                            THRESHOLD_CENTRAL_ABUNDANCE)
 from posydon.utils.gridutils import (read_MESA_data_file, read_EEP_data_file,
                                      add_field, join_lists, fix_He_core)
 from posydon.visualization.plot2D import plot2D
@@ -634,6 +635,7 @@ class PSyGrid:
             # Select the ith run
             run = grid.runs[i]
             ignore_data = False    # if failed run, do not save any data
+            newTF1 = ''
             self._say('Processing {}'.format(run.path))
 
             # Restrict number of runs if limit is set inside config
@@ -757,8 +759,8 @@ class PSyGrid:
                 # check whether stop at He depletion is requested
                 if stop_at_He_depletion:
                     kept = keep_till_He_depletion(binary_history, history1,
-                                                  history2, 0.01)
-                    binary_history, history1, history2 = kept
+                                         history2, THRESHOLD_CENTRAL_ABUNDANCE)
+                    binary_history, history1, history2, newTF1 = kept
                     
                 # check whether start at RLO is requested, and chop the history
                 if start_at_RLO:
@@ -945,7 +947,7 @@ class PSyGrid:
                     termination_flags = get_flags_from_MESA_run(
                         run.out_txt_path, binary_history=binary_history,
                         history1=history1, history2=history2,
-                        start_at_RLO=start_at_RLO)
+                        start_at_RLO=start_at_RLO, newTF1=newTF1)
             else:
                 if ignore_data:
                     termination_flags = [ignore_reason] * N_FLAGS_SINGLE

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -759,7 +759,7 @@ class PSyGrid:
                 # check whether stop at He depletion is requested
                 if stop_at_He_depletion:
                     kept = keep_till_He_depletion(binary_history, history1,
-                                  history2, THRESHOLD_CENTRAL_ABUNDANCE, 0.08)
+                                  history2, THRESHOLD_CENTRAL_ABUNDANCE, 0.1)
                     binary_history, history1, history2, newTF1 = kept
                     
                 # check whether start at RLO is requested, and chop the history

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -208,7 +208,7 @@ from posydon.utils.gridutils import (read_MESA_data_file, read_EEP_data_file,
 from posydon.visualization.plot2D import plot2D
 from posydon.visualization.plot1D import plot1D
 from posydon.grids.downsampling import TrackDownsampler
-from posydon.grids.scrubbing import scrub, keep_after_RLO
+from posydon.grids.scrubbing import scrub, keep_after_RLO, keep_till_He_depletion
 
 
 HDF5_MEMBER_SIZE = 2**31 - 1            # maximum HDF5 file size when splitting
@@ -346,6 +346,7 @@ GRIDPROPERTIES = {
     "final_value_columns": None,
     # grid-specific arguments
     "start_at_RLO": False,
+    "stop_at_He_depletion": False,
     "binary": True,
     "eep": None,    # path to EEP files
     "initial_RLO_fix": False,
@@ -537,6 +538,7 @@ class PSyGrid:
         binary_grid = self.config["binary"]
         initial_RLO_fix = self.config["initial_RLO_fix"]
         start_at_RLO = self.config["start_at_RLO"]
+        stop_at_He_depletion = self.config["stop_at_He_depletion"]
         eep = self.config["eep"]
 
         if eep is not None:
@@ -752,6 +754,12 @@ class PSyGrid:
                                   " history in: {}\n".format(run.path))
                     continue
 
+                # check whether stop at He depletion is requested
+                if stop_at_He_depletion:
+                    kept = keep_till_He_depletion(binary_history, history1,
+                                                  history2)
+                    binary_history, history1, history2 = kept
+                    
                 # check whether start at RLO is requested, and chop the history
                 if start_at_RLO:
                     kept = keep_after_RLO(binary_history, history1, history2)
@@ -1971,6 +1979,7 @@ PROPERTIES_TO_BE_NONE = {
 }
 
 PROPERTIES_TO_BE_CONSISTENT = ["binary", "eep", "start_at_RLO",
+                               "stop_at_He_depletion",
                                "initial_RLO_fix", "He_core_fix",
                                "accept_missing_profile", "history_DS_error",
                                "history_DS_exclude", "profile_DS_error",

--- a/posydon/grids/scrubbing.py
+++ b/posydon/grids/scrubbing.py
@@ -208,14 +208,22 @@ def keep_till_He_depletion(bh, h1, h2, Ystop=1.0e-5, XCstop=1.0):
         return bh, h1, h2, ''
     
     if depleted1:
-        where_conditions_met1 = np.where((h1["center_he4"]<Ystop) and (h1["center_c12"]<XCstop))[0]
+#        where_conditions_met1 = np.where((h1["center_he4"]<Ystop) and (h1["center_c12"]<XCstop))[0]
+        where_conditions_met1 = []
+        for i in range(len(h1["center_he4"])):
+            if (h1["center_he4"][i]<Ystop) and (h1["center_c12"][i]<XCstop):
+                where_conditions_met1 += [i]
         if len(where_conditions_met1) == 0:
             warnings.warn("No He depletion found in h1, while expected.")
             return bh, h1, h2, ''
         last_index = where_conditions_met1[0]
         newTF1 = 'Primary has depleted central helium'
     if depleted2:
-        where_conditions_met2 = np.where((h2["center_he4"]<Ystop) and (h2["center_c12"]<XCstop))[0]
+#        where_conditions_met2 = np.where((h2["center_he4"]<Ystop) and (h2["center_c12"]<XCstop))[0]
+        where_conditions_met2 = []
+        for i in range(len(h2["center_he4"])):
+            if (h2["center_he4"][i]<Ystop) and (h2["center_c12"][i]<XCstop):
+                where_conditions_met2 += [i]
         if len(where_conditions_met2) == 0:
             warnings.warn("No He depletion found in h2, while expected.")
             return bh, h1, h2, ''

--- a/posydon/grids/scrubbing.py
+++ b/posydon/grids/scrubbing.py
@@ -186,12 +186,18 @@ def keep_till_He_depletion(bh, h1, h2, Ystop=1.0e-5):
     
     h1_colnames = h1.dtype.names
     if "center_he4" in h1_colnames:
-        depleted1 = (h1["center_he4"][-1]<Ystop)
+        if len(h1["center_he4"])>0:
+            depleted1 = (h1["center_he4"][-1]<Ystop)
+        else:
+            depleted1 = False
     else:
         depleted1 = False
     h2_colnames = h2.dtype.names
     if "center_he4" in h2_colnames:
-        depleted2 = (h2["center_he4"][-1]<Ystop)
+        if len(h2["center_he4"])>0:
+            depleted2 = (h2["center_he4"][-1]<Ystop)
+        else:
+            depleted2 = False
     else:
         depleted2 = False
 

--- a/posydon/grids/scrubbing.py
+++ b/posydon/grids/scrubbing.py
@@ -155,8 +155,9 @@ def keep_after_RLO(bh, h1, h2):
     return new_bh, new_h1, new_h2
 
 
-def keep_till_He_depletion(bh, h1, h2, Ystop=1.0e-5, XCstop=1.0):
-    """Scrub histories to stop at He depletion.
+def keep_till_central_abundance_He_C(bh, h1, h2, Ystop=1.0e-5, XCstop=1.0):
+    """Scrub histories to stop when central helium and carbon abundance are
+    below the stopping criteria.
 
     Parameters
     ----------
@@ -167,16 +168,16 @@ def keep_till_He_depletion(bh, h1, h2, Ystop=1.0e-5, XCstop=1.0):
     h2 : array
         The `history2` array.
     Ystop : float
-        The He abundance threshold for depletion
+        The He abundance threshold for stopping
     XCstop : float
-        The C abundance threshold for depletion
+        The C abundance threshold for stopping
 
     Returns
     -------
     tuple
         The binary, history1 and history2 arrays after removing the final
-        steps after He depletion. If He depletion is not reached the
-        histories will be returned unchanged.
+        steps after He depletion. If the stopping criteria are not reached
+        the histories will be returned unchanged.
 
     """
     if (bh is None) or (h1 is None) or (h2 is None):
@@ -217,7 +218,7 @@ def keep_till_He_depletion(bh, h1, h2, Ystop=1.0e-5, XCstop=1.0):
             warnings.warn("No He depletion found in h1, while expected.")
             return bh, h1, h2, ''
         last_index = where_conditions_met1[0]
-        newTF1 = 'Primary has depleted central helium'
+        newTF1 = 'Primary got stopped before central carbon depletion'
     if depleted2:
 #        where_conditions_met2 = np.where((h2["center_he4"]<Ystop) and (h2["center_c12"]<XCstop))[0]
         where_conditions_met2 = []
@@ -241,10 +242,10 @@ def keep_till_He_depletion(bh, h1, h2, Ystop=1.0e-5, XCstop=1.0):
             if age_He_depletion1>age_He_depletion2:
                 #take star which reached He depletion first
                 last_index = last_index2
-                newTF1 = 'Secondary has depleted central helium'
+                newTF1 = 'Secondary got stopped before central carbon depletion'
         else:
             last_index = where_conditions_met2[0]
-            newTF1 = 'Secondary has depleted central helium'
+            newTF1 = 'Secondary got stopped before central carbon depletion'
     
     new_bh = bh[:last_index]
     new_h1 = h1[:last_index]

--- a/posydon/grids/scrubbing.py
+++ b/posydon/grids/scrubbing.py
@@ -178,8 +178,8 @@ def keep_till_He_depletion(bh, h1, h2, Ystop=1.0e-5):
     if (bh is None) or (h1 is None) or (h2 is None):
         #at least one histroy is missing
         return bh, h1, h2
-    elif (!("age" in bh.dtype.names) or ("star_age" in h1.dtype.names) or
-          !("star_age" in h2.dtype.names)):
+    elif ((not ("age" in bh.dtype.names)) or (not ("star_age" in h1.dtype.names))
+          or (not ("star_age" in h2.dtype.names))):
         #at least one histroy doesn't contain an age column
         return bh, h1, h2
     
@@ -194,7 +194,7 @@ def keep_till_He_depletion(bh, h1, h2, Ystop=1.0e-5):
     else:
         depleted2 = False
 
-    if !depleted1 and !depleted2:
+    if (not depleted1) and (not depleted2):
         #none of the stars reached He depletion
         return bh, h1, h2
     

--- a/posydon/grids/scrubbing.py
+++ b/posydon/grids/scrubbing.py
@@ -155,7 +155,7 @@ def keep_after_RLO(bh, h1, h2):
     return new_bh, new_h1, new_h2
 
 
-def keep_till_He_depletion(bh, h1, h2, Ystop=1.0e-5):
+def keep_till_He_depletion(bh, h1, h2, Ystop=1.0e-5, XCstop=1.0):
     """Scrub histories to stop at He depletion.
 
     Parameters
@@ -168,6 +168,8 @@ def keep_till_He_depletion(bh, h1, h2, Ystop=1.0e-5):
         The `history2` array.
     Ystop : float
         The He abundance threshold for depletion
+    XCstop : float
+        The C abundance threshold for depletion
 
     Returns
     -------
@@ -185,17 +187,17 @@ def keep_till_He_depletion(bh, h1, h2, Ystop=1.0e-5):
         return bh, h1, h2, ''
     
     h1_colnames = h1.dtype.names
-    if "center_he4" in h1_colnames:
-        if len(h1["center_he4"])>0:
-            depleted1 = (h1["center_he4"][-1]<Ystop)
+    if ("center_he4" in h1_colnames) and ("center_c12" in h1_colnames):
+        if (len(h1["center_he4"])>0) and (len(h1["center_c12"])>0):
+            depleted1 = ((h1["center_he4"][-1]<Ystop) and (h1["center_c12"][-1]<XCstop))
         else:
             depleted1 = False
     else:
         depleted1 = False
     h2_colnames = h2.dtype.names
-    if "center_he4" in h2_colnames:
-        if len(h2["center_he4"])>0:
-            depleted2 = (h2["center_he4"][-1]<Ystop)
+    if ("center_he4" in h1_colnames) and ("center_c12" in h1_colnames):
+        if (len(h2["center_he4"])>0) and (len(h2["center_c12"])>0):
+            depleted2 = ((h2["center_he4"][-1]<Ystop) and (h2["center_c12"][-1]<XCstop))
         else:
             depleted2 = False
     else:
@@ -206,14 +208,14 @@ def keep_till_He_depletion(bh, h1, h2, Ystop=1.0e-5):
         return bh, h1, h2, ''
     
     if depleted1:
-        where_conditions_met1 = np.where(h1["center_he4"]<Ystop)[0]
+        where_conditions_met1 = np.where((h1["center_he4"]<Ystop) and (h1["center_c12"]<XCstop))[0]
         if len(where_conditions_met1) == 0:
             warnings.warn("No He depletion found in h1, while expected.")
             return bh, h1, h2, ''
         last_index = where_conditions_met1[0]
         newTF1 = 'Primary has depleted central helium'
     if depleted2:
-        where_conditions_met2 = np.where(h2["center_he4"]<Ystop)[0]
+        where_conditions_met2 = np.where((h2["center_he4"]<Ystop) and (h2["center_c12"]<XCstop))[0]
         if len(where_conditions_met2) == 0:
             warnings.warn("No He depletion found in h2, while expected.")
             return bh, h1, h2, ''

--- a/posydon/grids/termination_flags.py
+++ b/posydon/grids/termination_flags.py
@@ -187,7 +187,8 @@ def check_state_from_history(history, mass, model_index=-1):
 
 
 def get_flags_from_MESA_run(MESA_log_path, binary_history=None,
-                            history1=None, history2=None, start_at_RLO=False):
+                            history1=None, history2=None, start_at_RLO=False,
+                            newTF1=''):
     """Return the four termination flags.
 
     Parameters
@@ -196,6 +197,8 @@ def get_flags_from_MESA_run(MESA_log_path, binary_history=None,
         path to the MESA terminal output
     binary_history, history1, history2: np.array
         MESA output histories.
+    newTF1: str
+        replacement for the termination flag from the MESA output
 
     Returns
     -------
@@ -205,7 +208,10 @@ def get_flags_from_MESA_run(MESA_log_path, binary_history=None,
         final_state_1, final_state_2: describe the final evolutionary
             state of the two stars. None if history star is not provided.
     """
-    flag_out = get_flag_from_MESA_output(MESA_log_path)
+    if newTF1=='':
+        flag_out = get_flag_from_MESA_output(MESA_log_path)
+    else:
+        flag_out = newTF1
     final_state_1 = check_state_from_history(history1,
                                              binary_history["star_1_mass"])
     final_state_2 = check_state_from_history(history2,

--- a/posydon/visualization/combine_TF.py
+++ b/posydon/visualization/combine_TF.py
@@ -13,6 +13,8 @@ import numpy as np
 
 TF1_POOL_STABLE = ['Primary has depleted central carbon',
                    'Secondary has depleted central carbon',
+                   'Primary has depleted central helium',
+                   'Secondary has depleted central helium',
                    'Primary enters pair-instability regime',
                    'Secondary enters pair-instability regime',
                    'Primary enters pulsational pair-instability regime',

--- a/posydon/visualization/combine_TF.py
+++ b/posydon/visualization/combine_TF.py
@@ -13,8 +13,8 @@ import numpy as np
 
 TF1_POOL_STABLE = ['Primary has depleted central carbon',
                    'Secondary has depleted central carbon',
-                   'Primary has depleted central helium',
-                   'Secondary has depleted central helium',
+                   'Primary got stopped before central carbon depletion',
+                   'Secondary got stopped before central carbon depletion',
                    'Primary enters pair-instability regime',
                    'Secondary enters pair-instability regime',
                    'Primary enters pulsational pair-instability regime',

--- a/posydon/visualization/plot_defaults.py
+++ b/posydon/visualization/plot_defaults.py
@@ -117,6 +117,10 @@ DEFAULT_MARKERS_COLORS_LEGENDS = {
             ['s', 2, None, TF1_label_stable],
         'Secondary has depleted central carbon':
             ['o', 2, None, TF1_label_stable],
+        'Primary has depleted central helium':
+            ['s', 2, None, TF1_label_stable],
+        'Secondary has depleted central helium':
+            ['o', 2, None, TF1_label_stable],
         'Primary enters pair-instability regime':
             ['s', 2, None, TF1_label_stable],
         'Secondary enters pair-instability regime':
@@ -434,6 +438,10 @@ DEFAULT_MARKERS_COLORS_LEGENDS = {
         'Primary has depleted central carbon':
             ['s', 2, None, TF1_label_stable],
         'Secondary has depleted central carbon':
+            ['o', 2, None, TF1_label_stable],
+        'Primary has depleted central helium':
+            ['s', 2, None, TF1_label_stable],
+        'Secondary has depleted central helium':
             ['o', 2, None, TF1_label_stable],
         'Primary enters pair-instability regime':
             ['s', 2, None, TF1_label_stable],

--- a/posydon/visualization/plot_defaults.py
+++ b/posydon/visualization/plot_defaults.py
@@ -117,9 +117,9 @@ DEFAULT_MARKERS_COLORS_LEGENDS = {
             ['s', 2, None, TF1_label_stable],
         'Secondary has depleted central carbon':
             ['o', 2, None, TF1_label_stable],
-        'Primary has depleted central helium':
+        'Primary got stopped before central carbon depletion':
             ['s', 2, None, TF1_label_stable],
-        'Secondary has depleted central helium':
+        'Secondary got stopped before central carbon depletion':
             ['o', 2, None, TF1_label_stable],
         'Primary enters pair-instability regime':
             ['s', 2, None, TF1_label_stable],
@@ -439,9 +439,9 @@ DEFAULT_MARKERS_COLORS_LEGENDS = {
             ['s', 2, None, TF1_label_stable],
         'Secondary has depleted central carbon':
             ['o', 2, None, TF1_label_stable],
-        'Primary has depleted central helium':
+        'Primary got stopped before central carbon depletion':
             ['s', 2, None, TF1_label_stable],
-        'Secondary has depleted central helium':
+        'Secondary got stopped before central carbon depletion':
             ['o', 2, None, TF1_label_stable],
         'Primary enters pair-instability regime':
             ['s', 2, None, TF1_label_stable],


### PR DESCRIPTION
- [x] new option for pysgrid creation `stop_before_carbon_depletion` similar to `start_at_RLO`
- additionally it requires an initial mass to be at least 100Msun
- [x] new function `keep_till_central_abundance_He_C` similar to `keep_after_RLO`
- It takes upper limits of the He and C abundance to stop as arguments. Function defaults 10^-5 and 1, respectively. Called with our common `THRESHOLD_CENTRAL_ABUNDANCE` used for helium and 0.1 for carbon if psygrid is created with `stop_before_carbon_depletion=True`.
- [x] add of `get_flags_from_MESA_run` a way to set a TF1 (needed to overwrite the TF taken from the MESA output files in case we crop some late evolution)