### PR TITLE
Post processing pipeline prepare master ini

### DIFF
--- a/bin/run-pipeline
+++ b/bin/run-pipeline
@@ -51,6 +51,7 @@ call STEP 4: ['gird_low_res_combined_rerun_1.h5']
 
 __authors__ = [
     "Simone Bavera <Simone.Bavera@unige.ch>",
+    "Matthias Kruckow <Matthias.Kruckow@unige.ch>",
 ]
 
 import os
@@ -72,6 +73,7 @@ from posydon.grids.post_processing import (post_process_grid,
                                            add_post_processed_quantities)
 from posydon.interpolation.IF_interpolation import IFInterpolator
 from posydon.utils.common_functions import PATH_TO_POSYDON
+from posydon.utils.gridutils import get_new_grid_name
 
 
 def create_grid_slice(i, path_to_csv_file, CO_HMS_GRID_START_AT_RLO, verbose=False):
@@ -80,14 +82,16 @@ def create_grid_slice(i, path_to_csv_file, CO_HMS_GRID_START_AT_RLO, verbose=Fal
     grid_path = df.loc[i,'path_to_grid']
     compression = df.loc[i,'compression']
 
-    grid_name = grid_path.split('/')[-1]
-    otuput_path = os.path.join('/', os.path.join(*grid_path.split('/')[:-1]),
-                               compression)
-    grid_output = os.path.join(otuput_path, grid_name+'.h5')
-
-    # check that LITE/ or ORIGINAL/ directory exists
-    if not os.path.isdir(otuput_path):
-        os.makedirs(otuput_path)
+#    grid_name = grid_path.split('/')[-1]
+#    otuput_path = os.path.join('/', os.path.join(*grid_path.split('/')[:-1]),
+#                               compression)
+#    grid_output = os.path.join(otuput_path, grid_name+'.h5')
+#
+#    # check that LITE/ or ORIGINAL/ directory exists
+#    if not os.path.isdir(otuput_path):
+#        os.makedirs(otuput_path)
+    grid_output = get_new_grid_name(grid_path, compression,
+                                    create_missing_directories=True)
 
     if verbose:
         print('processing ', grid_path)

--- a/bin/setup-pipeline
+++ b/bin/setup-pipeline
@@ -386,38 +386,67 @@ def create_csv(GRID_TYPES, METALLICITIES, GRID_SLICES, COMPRESSIONS,
         if DROP_MISSING_FILES:
             drop_rows = []
             for row in range(df.shape[0]):
-                path = df.loc[row,'path_to_grid']
+                path = df.at[row,'path_to_grid']
                 if not os.path.exists(path):
                     drop_rows.append(row)
             if any(drop_rows):
                 print('')
                 print(f'----------- {step_name} -----------')
-                print('The following grids will not be processed '
-                      'because the files are missing! If this warning message is '
-                      'unexpected to you, please check the file paths!')
-                for i in drop_rows:
-                    print(df.loc[i,'path_to_grid'])
+                print('The following grids will not be processed because the '
+                      'files/directories are missing! If this warning message '
+                      'is unexpected to you, please check the file paths!')
+                for row in drop_rows:
+                    print(df.loc[row,'path_to_grid'])
                 print('')
             df = df.drop(index=drop_rows)
     else:
         # step 2
         # drop columns when psygrid files are not found
         if DROP_MISSING_FILES:
+            first_time = True
             drop_columns = []
             for column in df.keys():
-                for path in df[column].dropna().to_list():
-                    if not os.path.exists(path):
+                drop_rows = []
+                for row in range(df.shape[0]):
+                    path = df.at[row,column]
+                    if pd.notna(path):
+                        if not os.path.exists(path):
+                            drop_rows.append(row)
+                if any(drop_rows):
+                    if first_time:
+                        print('')
+                        print(f'----------- {step_name} -----------')
+                        print('If this warning message is unexpected to you, '
+                              'please check that step 1 occoured '
+                              'succesffully!')
+                        first_time = False
+                    print(f'In {column} the following grids are skipped!')
+                    for row in drop_rows:
+                        print(df.loc[row,column])
+                        df.at[row,column] = np.NaN
+                    print('')
+                    newcol = df[column].dropna().to_list()
+                    if len(newcol)==0:
                         drop_columns.append(column)
+#                        print(f'No grids left drop {column}')
+#                        print('')
+                    newcol.extend((df.shape[0]-len(newcol))*[np.nan])
+                    df[column] = newcol
             if any(drop_columns):
+                if first_time:
+                    print('')
+                    print(f'----------- {step_name} -----------')
+                    print('If this warning message is unexpected to you, '
+                          'please check that step 1 occoured '
+                          'succesffully!')
+                    first_time = False
+                print('The following grids will not be combined as all grid '
+                      'slices are missing!')
+                for column in drop_columns
+                    print(column)
                 print('')
-                print(f'----------- {step_name} -----------')
-                print('The following grids will not be combined as one or more '
-                      'grid slices are missing! If this warning message is '
-                      'unexpected to you, please check that step 1 occoured '
-                      'succesffully!')
-                print(drop_columns)
-                print('')
-            df = df.drop(columns=drop_columns)
+#            df = df.drop(columns=drop_columns)
+            df = df.dropna(how='all')
 
     output_fname = f'{step_name}.csv'
     df.to_csv(os.path.join(PATH, output_fname), index=False)

--- a/bin/setup-pipeline
+++ b/bin/setup-pipeline
@@ -395,7 +395,7 @@ def create_csv(GRID_TYPES, METALLICITIES, GRID_SLICES, COMPRESSIONS,
                 if (not os.path.exists(path) and
                     path not in previously_created_files):
                     drop_rows.append(row)
-            if any(drop_rows):
+            if len(drop_rows)>0:
                 print('')
                 print(f'----------- {step_name} -----------')
                 print('The following grids will not be processed because the '
@@ -432,7 +432,7 @@ def create_csv(GRID_TYPES, METALLICITIES, GRID_SLICES, COMPRESSIONS,
                         if (not os.path.exists(path) and
                             path not in previously_created_files):
                             drop_rows.append(row)
-                if any(drop_rows):
+                if len(drop_rows)>0:
                     if first_time:
                         print('')
                         print(f'----------- {step_name} -----------')
@@ -452,7 +452,7 @@ def create_csv(GRID_TYPES, METALLICITIES, GRID_SLICES, COMPRESSIONS,
 #                        print('')
                     newcol.extend((df.shape[0]-len(newcol))*[np.nan])
                     df[column] = newcol
-            if any(drop_columns):
+            if len(drop_columns)>0:
                 if first_time:
                     print('')
                     print(f'----------- {step_name} -----------')

--- a/bin/setup-pipeline
+++ b/bin/setup-pipeline
@@ -8,6 +8,7 @@ __authors__ = [
 import os
 import sys
 import ast
+import shutil
 import pandas as pd
 import numpy as np
 from pprint import pprint, pformat
@@ -238,30 +239,76 @@ def slurm_job(job_name,
         slurm_array = '$SLURM_ARRAY_TASK_ID'
 
         if job_name == 'step_1':
+            f.write("#SBATCH --open-mode=truncate\n")
             f.write(f"#SBATCH --output={PATH}/logs/grid_slice_%a.out\n")
 
         if job_name == 'step_2':
-            f.write(f"#SBATCH --output={PATH}/logs/combine_grid_slices.out\n")
+            path_to_out_file = os.path.join(PATH, 'logs',
+                                            'combine_grid_slices.out')
+            if os.path.exists(path_to_out_file): # move old data to a copy
+                path_to_old_out_file = os.path.join(PATH, 'logs',
+                                                 'combine_grid_slices.old.out')
+                if os.path.exists(path_to_old_out_file): # delete old copy
+                    os.remove(path_to_old_out_file)
+                shutil.move(path_to_out_file, path_to_old_out_file)
+            f.write("#SBATCH --open-mode=append\n")
+            f.write(f"#SBATCH --output={path_to_out_file}\n")
 
         if job_name == 'step_3':
-            f.write(f"#SBATCH --output={PATH}/logs/plot_grid.out\n")
+            path_to_out_file = os.path.join(PATH, 'logs', 'plot_grid.out')
+            if os.path.exists(path_to_out_file): # move old data to a copy
+                path_to_old_out_file = os.path.join(PATH, 'logs',
+                                                    'plot_grid.old.out')
+                if os.path.exists(path_to_old_out_file): # delete old copy
+                    os.remove(path_to_old_out_file)
+                shutil.move(path_to_out_file, path_to_old_out_file)
+            f.write("#SBATCH --open-mode=append\n")
+            f.write(f"#SBATCH --output={path_to_out_file}\n")
             f.write("unset DISPLAY\n")
 
         if job_name == 'step_4':
-            f.write(f"#SBATCH --output={PATH}/logs/check_failure_rate.out\n")
+            path_to_out_file = os.path.join(PATH, 'logs',
+                                            'check_failure_rate.out')
+            if os.path.exists(path_to_out_file): # move old data to a copy
+                path_to_old_out_file = os.path.join(PATH, 'logs',
+                                                  'check_failure_rate.old.out')
+                if os.path.exists(path_to_old_out_file): # delete old copy
+                    os.remove(path_to_old_out_file)
+                shutil.move(path_to_out_file, path_to_old_out_file)
+            f.write("#SBATCH --open-mode=append\n")
+            f.write(f"#SBATCH --output={path_to_out_file}\n")
 
         if job_name == 'step_5':
+            f.write("#SBATCH --open-mode=truncate\n")
             f.write(f"#SBATCH --output={PATH}/logs/post_processing_%a.out\n")
             f.write(f"export PATH_TO_POSYDON={PATH_TO_POSYDON}\n")
 
         if job_name == 'step_6':
+            f.write("#SBATCH --open-mode=truncate\n")
             f.write(f"#SBATCH --output={PATH}/logs/train_interpolators_%a.out\n")
 
         if job_name == 'step_7':
-            f.write(f"#SBATCH --output={PATH}/logs/export_dataset.out\n")
+            path_to_out_file = os.path.join(PATH, 'logs',
+                                            'export_dataset.out')
+            if os.path.exists(path_to_out_file): # move old data to a copy
+                path_to_old_out_file = os.path.join(PATH, 'logs',
+                                                    'export_dataset.old.out')
+                if os.path.exists(path_to_old_out_file): # delete old copy
+                    os.remove(path_to_old_out_file)
+                shutil.move(path_to_out_file, path_to_old_out_file)
+            f.write("#SBATCH --open-mode=append\n")
+            f.write(f"#SBATCH --output={path_to_out_file}\n")
 
         if job_name == 'rerun':
-            f.write(f"#SBATCH --output={PATH}/logs/rerun.out\n")
+            path_to_out_file = os.path.join(PATH, 'logs', 'rerun.out')
+            if os.path.exists(path_to_out_file): # move old data to a copy
+                path_to_old_out_file = os.path.join(PATH, 'logs',
+                                                    'rerun.old.out')
+                if os.path.exists(path_to_old_out_file): # delete old copy
+                    os.remove(path_to_old_out_file)
+                shutil.move(path_to_out_file, path_to_old_out_file)
+            f.write("#SBATCH --open-mode=append\n")
+            f.write(f"#SBATCH --output={path_to_out_file}\n")
 
         f.write(f"\nsrun python {PATH_TO_POSYDON}/bin/run-pipeline {PATH_TO_GRIDS} {path_to_csv_file} {slurm_array} {CO_HMS_GRID_START_AT_RLO} {RERUN_TYPE}")
 

--- a/bin/setup-pipeline
+++ b/bin/setup-pipeline
@@ -231,6 +231,9 @@ def slurm_job(job_name,
             N = df.shape[1]-1
         else:
             raise ValueError('This should never happen!')
+        if N<0:
+            raise ValueError(f'{job_name} has no jobs to run, please check '
+                             f'{path_to_csv_file}')
         f.write(f"#SBATCH --array=0-{N}\n")
         slurm_array = '$SLURM_ARRAY_TASK_ID'
 

--- a/bin/setup-pipeline
+++ b/bin/setup-pipeline
@@ -86,6 +86,7 @@ class PostProcessingPipeline:
         return pipeline_kwargs
 
     def create_csv_and_slurm_job_files(self):
+        previously_created_files = []
         setup_kwargs = self.pipeline_kwargs['pipeline setup']
         account_kwargs = self.pipeline_kwargs['account']
 
@@ -113,8 +114,9 @@ class PostProcessingPipeline:
                         print( pformat(step_kwargs, indent=2) )
 
 
-                    create_csv(
+                    previously_created_files += create_csv(
                         step_name=step_number,
+                        previously_created_files=previously_created_files,
                         **{**step_kwargs, **setup_kwargs}
                     )
                     slurm_job(
@@ -263,7 +265,7 @@ def create_csv(GRID_TYPES, METALLICITIES, GRID_SLICES, COMPRESSIONS,
                step_name=None, VERSION=None, GRIDS_COMBINED=None,
                INTERPOLATION_METHODS=None, RERUN_TYPE='',
                DROP_MISSING_FILES=False, PATH_TO_GRIDS=None,
-               PATH=None, **kwargs):
+               PATH=None, previously_created_files=[], **kwargs):
 
     # number of grid types
     N = len(GRID_TYPES)
@@ -279,6 +281,7 @@ def create_csv(GRID_TYPES, METALLICITIES, GRID_SLICES, COMPRESSIONS,
     interpolators = []
     export_path = []
     rerun_path = []
+    newly_created_files = []
     df = pd.DataFrame()
     for l, grid_type in enumerate(GRID_TYPES):
 
@@ -387,7 +390,8 @@ def create_csv(GRID_TYPES, METALLICITIES, GRID_SLICES, COMPRESSIONS,
             drop_rows = []
             for row in range(df.shape[0]):
                 path = df.at[row,'path_to_grid']
-                if not os.path.exists(path):
+                if (not os.path.exists(path) and
+                    path not in previously_created_files):
                     drop_rows.append(row)
             if any(drop_rows):
                 print('')
@@ -399,6 +403,18 @@ def create_csv(GRID_TYPES, METALLICITIES, GRID_SLICES, COMPRESSIONS,
                     print(df.at[row,'path_to_grid'])
                 print('')
             df = df.drop(index=drop_rows)
+        if step_name == 'step_1':
+            newly_created_files = df['compression'].to_list()
+        elif step_name == 'step_3':
+            newly_created_files = df['path_to_plot'].to_list()
+        elif step_name == 'step_5':
+            newly_created_files = df['path_to_processed_grid'].to_list()
+        elif step_name == 'step_6':
+            newly_created_files = df['path_to_interpolator'].to_list()
+        elif step_name == 'step_7':
+            newly_created_files = df['export_path'].to_list()
+        elif step_name == 'rerun':
+            newly_created_files = df['rerun_path'].to_list()
     else:
         # step 2
         # drop columns when psygrid files are not found
@@ -410,7 +426,8 @@ def create_csv(GRID_TYPES, METALLICITIES, GRID_SLICES, COMPRESSIONS,
                 for row in range(df.shape[0]):
                     path = df.at[row,column]
                     if pd.notna(path):
-                        if not os.path.exists(path):
+                        if (not os.path.exists(path) and
+                            path not in previously_created_files):
                             drop_rows.append(row)
                 if any(drop_rows):
                     if first_time:
@@ -447,9 +464,12 @@ def create_csv(GRID_TYPES, METALLICITIES, GRID_SLICES, COMPRESSIONS,
                 print('')
 #            df = df.drop(columns=drop_columns)
             df = df.dropna(how='all')
+        newly_created_files = df.keys()
 
     output_fname = f'{step_name}.csv'
     df.to_csv(os.path.join(PATH, output_fname), index=False)
+    
+    return newly_created_files
 
 if __name__ == '__main__':
 

--- a/bin/setup-pipeline
+++ b/bin/setup-pipeline
@@ -396,7 +396,7 @@ def create_csv(GRID_TYPES, METALLICITIES, GRID_SLICES, COMPRESSIONS,
                       'files/directories are missing! If this warning message '
                       'is unexpected to you, please check the file paths!')
                 for row in drop_rows:
-                    print(df.loc[row,'path_to_grid'])
+                    print(df.at[row,'path_to_grid'])
                 print('')
             df = df.drop(index=drop_rows)
     else:
@@ -422,7 +422,7 @@ def create_csv(GRID_TYPES, METALLICITIES, GRID_SLICES, COMPRESSIONS,
                         first_time = False
                     print(f'In {column} the following grids are skipped!')
                     for row in drop_rows:
-                        print(df.loc[row,column])
+                        print(df.at[row,column])
                         df.at[row,column] = np.NaN
                     print('')
                     newcol = df[column].dropna().to_list()
@@ -442,7 +442,7 @@ def create_csv(GRID_TYPES, METALLICITIES, GRID_SLICES, COMPRESSIONS,
                     first_time = False
                 print('The following grids will not be combined as all grid '
                       'slices are missing!')
-                for column in drop_columns
+                for column in drop_columns:
                     print(column)
                 print('')
 #            df = df.drop(columns=drop_columns)

--- a/bin/setup-pipeline
+++ b/bin/setup-pipeline
@@ -464,7 +464,7 @@ def create_csv(GRID_TYPES, METALLICITIES, GRID_SLICES, COMPRESSIONS,
                 print('')
 #            df = df.drop(columns=drop_columns)
             df = df.dropna(how='all')
-        newly_created_files = df.keys()
+        newly_created_files = df.keys().to_list()
 
     output_fname = f'{step_name}.csv'
     df.to_csv(os.path.join(PATH, output_fname), index=False)

--- a/bin/setup-pipeline
+++ b/bin/setup-pipeline
@@ -516,7 +516,7 @@ def create_csv(GRID_TYPES, METALLICITIES, GRID_SLICES, COMPRESSIONS,
                     print(column)
                 print('')
 #            df = df.drop(columns=drop_columns)
-            df = df.dropna(how='all')
+            df = df.dropna(axis=0, how='all').dropna(axis=1, how='all')
         newly_created_files = df.keys().to_list()
 
     output_fname = f'{step_name}.csv'

--- a/bin/setup-pipeline
+++ b/bin/setup-pipeline
@@ -2,6 +2,7 @@
 __authors__ = [
     "Simone Bavera <Simone.Bavera@unige.ch>",
     "Kyle Akira Rocha <kylerocha2024@u.northwestern.edu>",
+    "Matthias Kruckow <Matthias.Kruckow@unige.ch>",
 ]
 
 import os
@@ -12,6 +13,7 @@ import numpy as np
 from pprint import pprint, pformat
 from posydon.popsyn.io import parse_inifile
 from posydon.utils.common_functions import PATH_TO_POSYDON
+from posydon.utils.gridutils import get_new_grid_name
 
 # this data processing pipeline was designed assuming POSYDON v2 data structure
 '''
@@ -404,9 +406,10 @@ def create_csv(GRID_TYPES, METALLICITIES, GRID_SLICES, COMPRESSIONS,
                 print('')
             df = df.drop(index=drop_rows)
         if step_name == 'step_1':
-            newly_created_files = df['compression'].to_list()
-        elif step_name == 'step_3':
-            newly_created_files = df['path_to_plot'].to_list()
+            for row in range(df.shape[0]):
+                path = df.at[row,'path_to_grid']
+                compression = df.at[row,'compression']
+                newly_created_files.append(get_new_grid_name(path,compression))
         elif step_name == 'step_5':
             newly_created_files = df['path_to_processed_grid'].to_list()
         elif step_name == 'step_6':

--- a/bin/setup-pipeline
+++ b/bin/setup-pipeline
@@ -390,7 +390,7 @@ def create_csv(GRID_TYPES, METALLICITIES, GRID_SLICES, COMPRESSIONS,
         # drop lines when grid directories are not found
         if DROP_MISSING_FILES:
             drop_rows = []
-            for row in range(df.shape[0]):
+            for row in df.index:
                 path = df.at[row,'path_to_grid']
                 if (not os.path.exists(path) and
                     path not in previously_created_files):
@@ -406,7 +406,7 @@ def create_csv(GRID_TYPES, METALLICITIES, GRID_SLICES, COMPRESSIONS,
                 print('')
             df = df.drop(index=drop_rows)
         if step_name == 'step_1':
-            for row in range(df.shape[0]):
+            for row in df.index:
                 path = df.at[row,'path_to_grid']
                 compression = df.at[row,'compression']
                 newly_created_files.append(get_new_grid_name(path,compression))
@@ -426,7 +426,7 @@ def create_csv(GRID_TYPES, METALLICITIES, GRID_SLICES, COMPRESSIONS,
             drop_columns = []
             for column in df.keys():
                 drop_rows = []
-                for row in range(df.shape[0]):
+                for row in df.index:
                     path = df.at[row,column]
                     if pd.notna(path):
                         if (not os.path.exists(path) and

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -687,12 +687,13 @@ class PSyGrid:
                 colname = "model_number"
                 if history1 is not None:
                     if colname in H1_columns:
-                        history1_mod = history1[colname].copy()
+                        history1_mod = np.int_(history1[colname].copy())
                     else:
                         history1_mod = read_MESA_data_file(run.history1_path, 
                                                            [colname])
+                        if history1_mod is not None:
+                            history1_mod = np.int_(history1_mod[colname])
                     if history1_mod is not None:
-                        history1_mod = np.int_(history1_mod[colname])
                         len_diff = len(history1)-len(history1_mod)
                         if len_diff<0: #shorten history1_mod
                             history1_mod = history1_mod[:len_diff]
@@ -709,8 +710,9 @@ class PSyGrid:
                     else:
                         history1_age = read_MESA_data_file(run.history1_path, 
                                                            ["star_age"])
+                        if history1_age is not None:
+                            history1_age = history1_age["star_age"]
                     if history1_age is not None:
-                        history1_age = history1_age["star_age"]
                         len_diff = len(history1)-len(history1_age)
                         if len_diff<0: #shorten history1_age
                             history1_age = history1_age[:len_diff]
@@ -728,12 +730,13 @@ class PSyGrid:
 
                 if history2 is not None:
                     if colname in H2_columns:
-                        history2_mod = history2[colname].copy()
+                        history2_mod = np.int_(history2[colname].copy())
                     else:
                         history2_mod = read_MESA_data_file(run.history2_path, 
                                                            [colname])
+                        if history2_mod is not None:
+                            history2_mod = np.int_(history2_mod[colname])
                     if history2_mod is not None:
-                        history2_mod = np.int_(history2_mod[colname])
                         len_diff = len(history2)-len(history2_mod)
                         if len_diff<0: #shorten history2_mod
                             history2_mod = history2_mod[:len_diff]
@@ -750,8 +753,9 @@ class PSyGrid:
                     else:
                         history2_age = read_MESA_data_file(run.history2_path, 
                                                            ["star_age"])
+                        if history2_age is not None:
+                            history2_age = history2_age["star_age"]
                     if history2_age is not None:
-                        history2_age = history2_age["star_age"]
                         len_diff = len(history2)-len(history2_age)
                         if len_diff<0: #shorten history2_age
                             history2_age = history2_age[:len_diff]
@@ -769,12 +773,13 @@ class PSyGrid:
 
                 if binary_history is not None:
                     if colname in BH_columns:
-                        binary_history_mod = binary_history[colname].copy()
+                        binary_history_mod = np.int_(binary_history[colname].copy())
                     else:
                         binary_history_mod = read_MESA_data_file(
                             run.binary_history_path, [colname])
+                        if binary_history_mod is not None:
+                            binary_history_mod = np.int_(binary_history_mod[colname])
                     if binary_history_mod is not None:
-                        binary_history_mod = np.int_(binary_history_mod[colname])
                         len_diff = len(binary_history)-len(binary_history_mod)
                         if len_diff<0: #shorten binary_history_mod
                             binary_history_mod = binary_history_mod[:len_diff]
@@ -791,8 +796,9 @@ class PSyGrid:
                     else:
                         binary_history_age = read_MESA_data_file(
                             run.binary_history_path, ["age"])
+                        if binary_history_age is not None:
+                            binary_history_age = binary_history_age["age"]
                     if binary_history_age is not None:
-                        binary_history_age = binary_history_age["age"]
                         len_diff = len(binary_history)-len(binary_history_age)
                         if len_diff<0: #shorten binary_history_age
                             binary_history_age = binary_history_age[:len_diff]

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -690,8 +690,12 @@ class PSyGrid:
                         run.history1_path, [colname])
                     if history1_mod is not None:
                         history1_mod = np.int_(history1_mod[colname])
-                        if len(history1_mod) == len(history1) + 1:
-                            history1_mod = history1_mod[:-1]
+                        len_diff = len(history1)-len(history1_mod)
+                        if len_diff<0: #shorten history1_mod
+                            history1_mod = history1_mod[:len_diff]
+                        elif len_diff>0: #entend history1_mod
+                            add_mod = np.full(len_diff,history1_mod[-1])
+                            history1_mod = np.concatenate((history1_mod, add_mod))
                     else:
                         ignore_data = True
                         ignore_reason = "corrupted_history1"
@@ -699,8 +703,12 @@ class PSyGrid:
                         run.history1_path, ["star_age"])
                     if history1_age is not None:
                         history1_age = history1_age["star_age"]
-                        if len(history1_age) == len(history1) + 1:
-                            history1_age = history1_age[:-1]
+                        len_diff = len(history1)-len(history1_age)
+                        if len_diff<0: #shorten history1_age
+                            history1_age = history1_age[:len_diff]
+                        elif len_diff>0: #entend history1_age
+                            add_age = np.full(len_diff,history1_age[-1])
+                            history1_age = np.concatenate((history1_age, add_age))
                     else:
                         ignore_data = True
                         ignore_reason = "corrupted_history1"
@@ -713,8 +721,12 @@ class PSyGrid:
                         run.history2_path, [colname])
                     if history2_mod is not None:
                         history2_mod = np.int_(history2_mod[colname])
-                        if len(history2_mod) == len(history2) + 1:
-                            history2_mod = history2_mod[:-1]
+                        len_diff = len(history2)-len(history2_mod)
+                        if len_diff<0: #shorten history2_mod
+                            history2_mod = history2_mod[:len_diff]
+                        elif len_diff>0: #entend history2_mod
+                            add_mod = np.full(len_diff,history2_mod[-1])
+                            history2_mod = np.concatenate((history2_mod, add_mod))
                     else:
                         ignore_data = True
                         ignore_reason = "corrupted_history2"
@@ -722,8 +734,12 @@ class PSyGrid:
                         run.history2_path, ["star_age"])
                     if history2_age is not None:
                         history2_age = history2_age["star_age"]
-                        if len(history2_age) == len(history2) + 1:
-                            history2_age = history2_age[:-1]
+                        len_diff = len(history2)-len(history2_age)
+                        if len_diff<0: #shorten history2_age
+                            history2_age = history2_age[:len_diff]
+                        elif len_diff>0: #entend history2_age
+                            add_age = np.full(len_diff,history2_age[-1])
+                            history2_age = np.concatenate((history2_age, add_age))
                     else:
                         ignore_data = True
                         ignore_reason = "corrupted_history2"
@@ -736,8 +752,12 @@ class PSyGrid:
                         run.binary_history_path, [colname])
                     if binary_history_mod is not None:
                         binary_history_mod = np.int_(binary_history_mod[colname])
-                        if len(binary_history_mod) == len(binary_history) + 1:
-                            binary_history_mod = binary_history_mod[:-1]
+                        len_diff = len(binary_history)-len(binary_history_mod)
+                        if len_diff<0: #shorten binary_history_mod
+                            binary_history_mod = binary_history_mod[:len_diff]
+                        elif len_diff>0: #entend binary_history_mod
+                            add_mod = np.full(len_diff,binary_history_mod[-1])
+                            binary_history_mod = np.concatenate((binary_history_mod, add_mod))
                     else:
                         ignore_data = True
                         ignore_reason = "corrupted_binary_history"
@@ -745,8 +765,12 @@ class PSyGrid:
                         run.binary_history_path, ["age"])
                     if binary_history_age is not None:
                         binary_history_age = binary_history_age["age"]
-                        if len(binary_history_age) == len(binary_history) + 1:
-                            binary_history_age = binary_history_age[:-1]
+                        len_diff = len(binary_history)-len(binary_history_age)
+                        if len_diff<0: #shorten binary_history_age
+                            binary_history_age = binary_history_age[:len_diff]
+                        elif len_diff>0: #entend binary_history_age
+                            add_age = np.full(len_diff,binary_history_age[-1])
+                            binary_history_age = np.concatenate((binary_history_age, add_age))
                     else:
                         ignore_data = True
                         ignore_reason = "corrupted_binary_history"

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -686,29 +686,39 @@ class PSyGrid:
                 # read the model numbers and ages from the histories
                 colname = "model_number"
                 if history1 is not None:
-                    history1_mod = read_MESA_data_file(
-                        run.history1_path, [colname])
+                    if colname in H1_columns:
+                        history1_mod = history1[colname].copy()
+                    else:
+                        history1_mod = read_MESA_data_file(run.history1_path, 
+                                                           [colname])
                     if history1_mod is not None:
                         history1_mod = np.int_(history1_mod[colname])
                         len_diff = len(history1)-len(history1_mod)
                         if len_diff<0: #shorten history1_mod
                             history1_mod = history1_mod[:len_diff]
+                            warnings.warn("Reduce mod in {}\n".format(run.history1_path))
                         elif len_diff>0: #entend history1_mod
                             add_mod = np.full(len_diff,history1_mod[-1])
                             history1_mod = np.concatenate((history1_mod, add_mod))
+                            warnings.warn("Expand mod in {}\n".format(run.history1_path))
                     else:
                         ignore_data = True
                         ignore_reason = "corrupted_history1"
-                    history1_age = read_MESA_data_file(
-                        run.history1_path, ["star_age"])
+                    if "star_age" in H1_columns:
+                        history1_age = history1["star_age"].copy()
+                    else:
+                        history1_age = read_MESA_data_file(run.history1_path, 
+                                                           ["star_age"])
                     if history1_age is not None:
                         history1_age = history1_age["star_age"]
                         len_diff = len(history1)-len(history1_age)
                         if len_diff<0: #shorten history1_age
                             history1_age = history1_age[:len_diff]
+                            warnings.warn("Reduce age in {}\n".format(run.history1_path))
                         elif len_diff>0: #entend history1_age
                             add_age = np.full(len_diff,history1_age[-1])
                             history1_age = np.concatenate((history1_age, add_age))
+                            warnings.warn("Expand age in {}\n".format(run.history1_path))
                     else:
                         ignore_data = True
                         ignore_reason = "corrupted_history1"
@@ -717,29 +727,39 @@ class PSyGrid:
                     history1_age = None
 
                 if history2 is not None:
-                    history2_mod = read_MESA_data_file(
-                        run.history2_path, [colname])
+                    if colname in H2_columns:
+                        history2_mod = history2[colname].copy()
+                    else:
+                        history2_mod = read_MESA_data_file(run.history2_path, 
+                                                           [colname])
                     if history2_mod is not None:
                         history2_mod = np.int_(history2_mod[colname])
                         len_diff = len(history2)-len(history2_mod)
                         if len_diff<0: #shorten history2_mod
                             history2_mod = history2_mod[:len_diff]
+                            warnings.warn("Reduce mod in {}\n".format(run.history2_path))
                         elif len_diff>0: #entend history2_mod
                             add_mod = np.full(len_diff,history2_mod[-1])
                             history2_mod = np.concatenate((history2_mod, add_mod))
+                            warnings.warn("Expand mod in {}\n".format(run.history2_path))
                     else:
                         ignore_data = True
                         ignore_reason = "corrupted_history2"
-                    history2_age = read_MESA_data_file(
-                        run.history2_path, ["star_age"])
+                    if "star_age" in H2_columns:
+                        history2_age = history2["star_age"].copy()
+                    else:
+                        history2_age = read_MESA_data_file(run.history2_path, 
+                                                           ["star_age"])
                     if history2_age is not None:
                         history2_age = history2_age["star_age"]
                         len_diff = len(history2)-len(history2_age)
                         if len_diff<0: #shorten history2_age
                             history2_age = history2_age[:len_diff]
+                            warnings.warn("Reduce age in {}\n".format(run.history2_path))
                         elif len_diff>0: #entend history2_age
                             add_age = np.full(len_diff,history2_age[-1])
                             history2_age = np.concatenate((history2_age, add_age))
+                            warnings.warn("Expand age in {}\n".format(run.history2_path))
                     else:
                         ignore_data = True
                         ignore_reason = "corrupted_history2"
@@ -748,29 +768,39 @@ class PSyGrid:
                     history2_age = None
 
                 if binary_history is not None:
-                    binary_history_mod = read_MESA_data_file(
-                        run.binary_history_path, [colname])
+                    if colname in BH_columns:
+                        binary_history_mod = binary_history[colname].copy()
+                    else:
+                        binary_history_mod = read_MESA_data_file(
+                            run.binary_history_path, [colname])
                     if binary_history_mod is not None:
                         binary_history_mod = np.int_(binary_history_mod[colname])
                         len_diff = len(binary_history)-len(binary_history_mod)
                         if len_diff<0: #shorten binary_history_mod
                             binary_history_mod = binary_history_mod[:len_diff]
+                            warnings.warn("Reduce mod in {}\n".format(run.binary_history_path))
                         elif len_diff>0: #entend binary_history_mod
                             add_mod = np.full(len_diff,binary_history_mod[-1])
                             binary_history_mod = np.concatenate((binary_history_mod, add_mod))
+                            warnings.warn("Expand mod in {}\n".format(run.binary_history_path))
                     else:
                         ignore_data = True
                         ignore_reason = "corrupted_binary_history"
-                    binary_history_age = read_MESA_data_file(
-                        run.binary_history_path, ["age"])
+                    if "age" in BH_columns:
+                        binary_history_age = binary_history["age"].copy()
+                    else:
+                        binary_history_age = read_MESA_data_file(
+                            run.binary_history_path, ["age"])
                     if binary_history_age is not None:
                         binary_history_age = binary_history_age["age"]
                         len_diff = len(binary_history)-len(binary_history_age)
                         if len_diff<0: #shorten binary_history_age
                             binary_history_age = binary_history_age[:len_diff]
+                            warnings.warn("Reduce age in {}\n".format(run.binary_history_path))
                         elif len_diff>0: #entend binary_history_age
                             add_age = np.full(len_diff,binary_history_age[-1])
                             binary_history_age = np.concatenate((binary_history_age, add_age))
+                            warnings.warn("Expand age in {}\n".format(run.binary_history_path))
                     else:
                         ignore_data = True
                         ignore_reason = "corrupted_binary_history"

--- a/posydon/grids/termination_flags.py
+++ b/posydon/grids/termination_flags.py
@@ -57,10 +57,10 @@ def get_flag_from_MESA_output(MESA_log_path):
     """
     if MESA_log_path is not None and os.path.isfile(MESA_log_path):
         if MESA_log_path.endswith(".gz"):
-            with gzip.open(MESA_log_path, "rt") as log_file:
+            with gzip.open(MESA_log_path, "rt", errors='ignore') as log_file:
                 log_lines = log_file.readlines()
         else:
-            with open(MESA_log_path, "r") as log_file:
+            with open(MESA_log_path, "r", errors='ignore') as log_file:
                 log_lines = log_file.readlines()
 
         for line in reversed(log_lines):

--- a/posydon/utils/gridutils.py
+++ b/posydon/utils/gridutils.py
@@ -19,6 +19,7 @@ __authors__ = [
     "Emmanouil Zapartas <ezapartas@gmail.com>",
     "Kyle Akira Rocha <kylerocha2024@u.northwestern.edu>",
     "Jeffrey Andrews <jeffrey.andrews@northwestern.edu>",
+    "Matthias Kruckow <Matthias.Kruckow@unige.ch>",
 ]
 
 
@@ -524,3 +525,33 @@ def clean_inlist_file(inlist, **kwargs):
                     i.split('=', 1)[1].strip()
 
     return dict_of_parameters
+
+def get_new_grid_name(path, compression, create_missing_directories=False):
+    """Get the name of a new grid slice based on the path and the compression.
+
+    Parameters
+    ----------
+    path : str
+        Path to grid slice data.
+    compression : str
+        Compression value. (Directory to put the new grid slice in.)
+    create_missing_directories : bool
+        Flag to create missing directories.
+
+    Returns
+    -------
+    grid_output
+        File name for the new grid slice.
+
+    """
+    grid_name = path.split('/')[-1]
+    output_path = os.path.join('/', os.path.join(*path.split('/')[:-1]),
+                               compression)
+    grid_output = os.path.join(output_path, grid_name+'.h5')
+    if create_missing_directories:
+        # check that LITE/ or ORIGINAL/ directory exists
+        if not os.path.isdir(output_path):
+            os.makedirs(output_path)
+    return grid_output
+
+


### PR DESCRIPTION
#### I have created a master-ini for the post processing pipeline. To take good care of missing files I had to do some changes to the pipeline scripts (mainly to the setup-pipeline):
- [x] Allow to drop individual missing files/directories for each of the post-processing steps. [`setup-pipeline`]
- Especially for step_2, it was important to not skip all the combining, if there is one grid slice missing. Now it removes missing slices and only drops to make a combined grid if all grids to combine are missing.
- [x] Taking the files created in previous steps into account. [`setup-pipeline`]
- With getting the dependency in the post processing pipeline, it might be well the case that files are not there at the moment, when the pipeline is set up, but will be there, when the pipeline is getting to this step.
- Thus, the setup needed to recognize, which files are created by previous steps, hence will be there. Here it required some special treatment for step_1, because the csv file does not contain the new file names, which so far were only created when running the pipeline.
- [x] Hence, I moved the name generation into a function `get_new_grid_name` and moved this to `posydon.utils.gridutils`. This part got replaced in the `run-pipeline` as well, that both will use the same function to get the names.
- Beside generating the name, this function has the option, to check for directories and create them as previously done in `run-pipeline`
- [x] Additionally, I made some fixes of typos, errors, and making the code more flexible or faster.
- `otuput_path` -> `output_path`
- using pandas `at` instead of `loc` to get a single element, like recommended by pandas
- adding a check, that a slurm job cannot run from 0 to -1
- replace `range(df.shape[0])` by `df.index`, because the old version required the index to start with 0 and have no missing rows
- replace `any(drop_rows)` by `len(drop_rows)>0`, because the old version failed on `drop_row=[0]`
- when history arrays differ by more than one: add or remove more entries [`posydon.grids.psygrid`]
- reuse data once read from histories to generate the columns of the models and ages
- correct slurm output to always specify to `append` or `truncate` (remove old files in case of appending during setup, but make a copy of the old.)
- allow to skip bad characters in the MESA log files [`posydon.grids.termination_flags`]

#### After several small tests, I'm now running a big test of the master-ini on the CO-HeMS grid.
- [x] To do so, I cleaned the files in `/srv/beegfs/scratch/shares/astro/posydon/POSYDON_GRIDS_v2/CO-HeMS`:
1. I removed different naming, hence now we use the naming `grid_GRIDTYPE_N` for the base grid and `rerun_RERUNTYPE_grid_GRIDTYPE_combined` for the reruns. Here `GRIDTYPE` is `low_res` or `random`, `N` is a number or `rerun` (where a few parts of the grid needed to be rerun because of issues on the cluster, similarly we will get `rerun_XXX` to indicate and take care of the missing column reruns on Quest later), `RERUNTYPE` is `PISN` or `opacity_max` (similarly we will take care of the other reruns, like `reverse_MT` or what will be done in the future).
2. I renamed some reruns to `norerun_XXX` those are directories created to check, whether there was a rerun needed, but it turned out that no system needed to be rerun here. Hence, they give a record where we check for a rerun, but is wasn't needed. (I had to rename them, because the grid creation throws and error in case there are no MESA runs to fill this grid. I had the choice to either remove the error message or to rename/remove. I found the error useful, hence I decided to rename those directories, to a least keep a record in this way.)
3. I moved all the previously created files of the post-processing into directories called `old` within each metallicity directory. As soon as the master-pipeline is approved, this old data can be removed.

#### Now, the data set was ready for the test run. Here the shorthand output (the full version I saved in an `out.txt` file) during setting up the pipeline:
>++++++++++++++++++++SETUP++++++++++++++++++++
{ 'CHECK_FAILURE_RATE': True,
  'COMBINE_GRID_SLICES': True,
  'CO_HMS_GRID_START_AT_RLO': 0,
  'CREATE_GRID_SLICES': True,
  'EXPORT_DATASET': True,
  'PATH': '.',
  'PATH_TO_GRIDS': '/srv/beegfs/scratch/shares/astro/posydon/POSYDON_GRIDS_v2/',
  'PLOT_GRIDS': True,
  'POST_PROCESSING': True,
  'RERUN': False,
  'TRAIN_INTERPOLATORS': True,
  'VERBOSE': True,
  'VERSION': ''}
-------------CREATE_GRID_SLICES--------------  step_1 : True 
{ 'COMPRESSIONS': [['LITE', 'ORIGINAL']],
  'DROP_MISSING_FILES': True,
  'GRID_SLICES': [ [ 'grid_low_res_0',
                     'grid_low_res_1',
                     'grid_low_res_2',
                     'rerun_PISN_grid_low_res_combined',
                     'rerun_opacity_max_grid_low_res_combined',
                     'grid_random_1',
                     'grid_random_rerun',
                     'rerun_PISN_grid_random_combined',
                     'rerun_opacity_max_grid_random_combined']],
  'GRID_TYPES': ['CO-HeMS'],
  'METALLICITIES': [ [ '2e+00_Zsun',
                       '1e+00_Zsun',
                       '4.5e-01_Zsun',
                       '2e-01_Zsun',
                       '1e-01_Zsun',
                       '1e-02_Zsun',
                       '1e-03_Zsun',
                       '1e-04_Zsun']]}
----------- step_1 -----------
The following grids will not be processed because the files/directories are missing! If this warning message is unexpected to you, please check the file paths!
/srv/beegfs/scratch/shares/astro/posydon/POSYDON_GRIDS_v2/CO-HeMS/2e+00_Zsun/rerun_PISN_grid_low_res_combined
/srv/beegfs/scratch/shares/astro/posydon/POSYDON_GRIDS_v2/CO-HeMS/2e+00_Zsun/rerun_PISN_grid_low_res_combined
/srv/beegfs/scratch/shares/astro/posydon/POSYDON_GRIDS_v2/CO-HeMS/2e+00_Zsun/grid_random_rerun
...

Here it lists all the grids which are not there to create a psygrid object. They all appear twice, because it loops through the two compression types `LITE` and `ORIGINAL`.
> -------------COMBINE_GRID_SLICES-------------  step_2 : True 
{ 'COMPRESSIONS': [['LITE', 'ORIGINAL']],
  'DROP_MISSING_FILES': True,
  'GRIDS_COMBINED': [ [ 'grid_low_res_combined',
                        'grid_low_res_combined_rerun1_PISN',
                        'grid_low_res_combined_rerun3_opacity_max',
                        'grid_random_combined',
                        'grid_random_combined_rerun1_PISN',
                        'grid_random_combined_rerun3_opacity_max']],
  'GRID_SLICES': [ [ ['grid_low_res_0', 'grid_low_res_1', 'grid_low_res_2'],
                     [ 'grid_low_res_0',
                       'grid_low_res_1',
                       'grid_low_res_2',
                       'rerun_PISN_grid_low_res_combined'],
                     [ 'grid_low_res_0',
                       'grid_low_res_1',
                       'grid_low_res_2',
                       'rerun_PISN_grid_low_res_combined',
                       'rerun_opacity_max_grid_low_res_combined'],
                     ['grid_random_1', 'grid_random_rerun'],
                     [ 'grid_random_1',
                       'grid_random_rerun',
                       'rerun_PISN_grid_random_combined'],
                     [ 'grid_random_1',
                       'grid_random_rerun',
                       'rerun_PISN_grid_random_combined',
                       'rerun_opacity_max_grid_random_combined']]],
  'GRID_TYPES': ['CO-HeMS'],
  'METALLICITIES': [ [ '2e+00_Zsun',
                       '1e+00_Zsun',
                       '4.5e-01_Zsun',
                       '2e-01_Zsun',
                       '1e-01_Zsun',
                       '1e-02_Zsun',
                       '1e-03_Zsun',
                       '1e-04_Zsun']]}
----------- step_2 -----------
If this warning message is unexpected to you, please check that step 1 occoured succesffully!
In /srv/beegfs/scratch/shares/astro/posydon/POSYDON_GRIDS_v2/CO-HeMS/2e+00_Zsun/LITE/grid_low_res_combined_rerun1_PISN.h5 the following grids are skipped!
/srv/beegfs/scratch/shares/astro/posydon/POSYDON_GRIDS_v2/CO-HeMS/2e+00_Zsun/LITE/rerun_PISN_grid_low_res_combined.h5
...
In /srv/beegfs/scratch/shares/astro/posydon/POSYDON_GRIDS_v2/CO-HeMS/2e+00_Zsun/ORIGINAL/grid_random_combined_rerun1_PISN.h5 the following grids are skipped!
/srv/beegfs/scratch/shares/astro/posydon/POSYDON_GRIDS_v2/CO-HeMS/2e+00_Zsun/ORIGINAL/grid_random_rerun.h5
/srv/beegfs/scratch/shares/astro/posydon/POSYDON_GRIDS_v2/CO-HeMS/2e+00_Zsun/ORIGINAL/rerun_PISN_grid_random_combined.h5
...

Here it lists, for which combined grid, which file is skipped, when checking it carefully, this is all expected and intended.
> -----------------PLOT_GRIDS------------------  step_3 : True 
{ 'COMPRESSIONS': [['LITE']],
  'DROP_MISSING_FILES': True,
  'GRID_SLICES': [ [ 'grid_low_res_combined',
                     'grid_low_res_combined_rerun1_PISN',
                     'grid_low_res_combined_rerun3_opacity_max',
                     'grid_random_combined',
                     'grid_random_combined_rerun1_PISN',
                     'grid_random_combined_rerun3_opacity_max']],
  'GRID_TYPES': ['CO-HeMS'],
  'METALLICITIES': [ [ '2e+00_Zsun',
                       '1e+00_Zsun',
                       '4.5e-01_Zsun',
                       '2e-01_Zsun',
                       '1e-01_Zsun',
                       '1e-02_Zsun',
                       '1e-03_Zsun',
                       '1e-04_Zsun']]}
-------------CHECK_FAILURE_RATE--------------  step_4 : True 
{ 'COMPRESSIONS': [['LITE']],
  'DROP_MISSING_FILES': True,
  'GRID_SLICES': [ [ 'grid_low_res_combined',
                     'grid_low_res_combined_rerun1_PISN',
                     'grid_low_res_combined_rerun3_opacity_max',
                     'grid_random_combined',
                     'grid_random_combined_rerun1_PISN',
                     'grid_random_combined_rerun3_opacity_max']],
  'GRID_TYPES': ['CO-HeMS'],
  'METALLICITIES': [ [ '2e+00_Zsun',
                       '1e+00_Zsun',
                       '4.5e-01_Zsun',
                       '2e-01_Zsun',
                       '1e-01_Zsun',
                       '1e-02_Zsun',
                       '1e-03_Zsun',
                       '1e-04_Zsun']]}
---------------POST_PROCESSING---------------  step_5 : True 
{ 'COMPRESSIONS': [['LITE']],
  'DROP_MISSING_FILES': True,
  'GRID_SLICES': [['grid_low_res_combined_rerun3_opacity_max']],
  'GRID_TYPES': ['CO-HeMS'],
  'METALLICITIES': [ [ '2e+00_Zsun',
                       '1e+00_Zsun',
                       '4.5e-01_Zsun',
                       '2e-01_Zsun',
                       '1e-01_Zsun',
                       '1e-02_Zsun',
                       '1e-03_Zsun',
                       '1e-04_Zsun']]}
-------------TRAIN_INTERPOLATORS-------------  step_6 : True 
{ 'COMPRESSIONS': [['LITE']],
  'DROP_MISSING_FILES': True,
  'GRID_SLICES': [['grid_low_res_combined_rerun3_opacity_max_processed']],
  'GRID_TYPES': ['CO-HeMS'],
  'INTERPOLATION_METHODS': ['linear', '1NN'],
  'METALLICITIES': [ [ '2e+00_Zsun',
                       '1e+00_Zsun',
                       '4.5e-01_Zsun',
                       '2e-01_Zsun',
                       '1e-01_Zsun',
                       '1e-02_Zsun',
                       '1e-03_Zsun',
                       '1e-04_Zsun']]}
---------------EXPORT_DATASET----------------  step_7 : True 
{ 'COMPRESSIONS': [['LITE']],
  'DROP_MISSING_FILES': True,
  'GRID_SLICES': [['grid_low_res_combined_rerun3_opacity_max_processed']],
  'GRID_TYPES': ['CO-HeMS'],
  'METALLICITIES': [ [ '2e+00_Zsun',
                       '1e+00_Zsun',
                       '4.5e-01_Zsun',
                       '2e-01_Zsun',
                       '1e-01_Zsun',
                       '1e-02_Zsun',
                       '1e-03_Zsun',
                       '1e-04_Zsun']]}
--------------------RERUN--------------------  rerun  :False 

It is a lot of output, but all as it should. In total it creates 108 psygrid objects; which lead to 96=8x2x2x3 combined objects; of which 48=8x2x3 will be plotted and check for the failure rate; 8 will be send to calculate the post-processing quantities; 16=8x2 interpolators will get trained and 24=8x3 final product files will get created.
- [x] In case someone wants to follow the test in more detail and inspect the csv files or the log files, you can find it here: `/srv/beegfs/scratch/shares/astro/posydon/master_post_processing/save_post_processing_pipeline_CO-HeMS_all_steps`
- [x] The second test goes on the CO-HMS_RLO grid, you can find it here:
`/srv/beegfs/scratch/shares/astro/posydon/master_post_processing/save_post_processing_pipeline_CO-HMS_RLO_all_steps`
- [x] The third test goes on the HMS-HMS (yggdrasil) grid, you can find it here:
`/srv/beegfs/scratch/shares/astro/posydon/master_post_processing/save_post_processing_pipeline_HMS-HMS_all_steps`
- [x] The final test goes on the HMS-HMS (Quest) grid

Future prospects:
- add new reruns