### PR TITLE
Seth TPAGBwind pipeline

### DIFF
--- a/bin/run-pipeline
+++ b/bin/run-pipeline
@@ -608,7 +608,7 @@ def copy_ini_file(grid, rerun_type, destination, cluster):
     elif rerun_type == 'opacity_max_hms-hms':
         replace_text = "zepei_fix_implicit-afa1860ddf9894aa1d82742ee2a73e8e92acd4a9"
     elif rerun_type == 'TPAGBwind':
-        replace_text = "agbwind-27f4fa05c4ebabaa85a67c2845818a36e1ecab01"
+        replace_text = "development-22c1bb9e730343558c3e70984a99b3fc1f3c346e"
     elif rerun_type == 'other': # e.g. 'envelope_mass_limit', 'fe_core_infall_limit'
         # this rerun uses the default inlist commit
         return

--- a/bin/run-pipeline
+++ b/bin/run-pipeline
@@ -607,6 +607,8 @@ def copy_ini_file(grid, rerun_type, destination, cluster):
         replace_text = "matthias_PISN-d68228338b91fd487ef5d55c9b6ebb8cc5f0e668"
     elif rerun_type == 'opacity_max_hms-hms':
         replace_text = "zepei_fix_implicit-afa1860ddf9894aa1d82742ee2a73e8e92acd4a9"
+    elif rerun_type == 'agb_wind':
+        replace_text = "agbwind-27f4fa05c4ebabaa85a67c2845818a36e1ecab01"
     elif rerun_type == 'other': # e.g. 'envelope_mass_limit', 'fe_core_infall_limit'
         # this rerun uses the default inlist commit
         return
@@ -667,6 +669,29 @@ def logic_rerun(grid, rerun_type):
               reverse = np.logical_and(rl1<-0.05, rl2>-0.05)
               transfer = np.logical_and(reverse, w_wcrit>0.9)
               if np.max(transfer) == True:
+                runs_to_rerun += [i]
+        runs_to_rerun = np.array(runs_to_rerun)
+    elif rerun_type == 'agb_wind':
+        N_runs = len(grid)
+        runs_to_rerun = []
+        for i in range(N_runs):
+          if  grid[i].binary_history is not None and grid[i].history1 is not None:
+              hot_wind_full_on_T = 1.2e4
+              s1_mass = grid[i].binary_history['star_1_mass']
+              s2_mass = grid[i].binary_history['star_2_mass']
+              s1_Teff = 10**grid[i].history1['log_Teff']
+              s2_Teff = 10**grid[i].history2['log_Teff']
+              s1_Yc = grid[i].history1['center_he4']
+              s2_Yc = grid[i].history2['center_he4']
+              s1_he_shell_mass = grid[i].history1['he_core_mass'] - grid[i].history1['co_core_mass']
+              s2_he_shell_mass = grid[i].history2['he_core_mass'] - grid[i].history2['co_core_mass']
+              tpagb_1 = np.logical_and(s1_Teff <= hot_wind_full_on_T, s1_mass <= 10.0)
+              tpagb_1 = np.logical_and(tpagb_1, s1_Yc <= 1e-6)
+              tpagb_1 = np.logical_and(tpagb_1, s1_he_shell_mass <= 1e-1)
+              tpagb_2 = np.logical_and(s2_Teff <= hot_wind_full_on_T, s2_mass <= 10.0)
+              tpagb_2 = np.logical_and(tpagb_2, s2_Yc <= 1e-6)
+              tpagb_2 = np.logical_and(tpagb_2, s2_he_shell_mass <= 1e-1)
+              if np.max(np.logical_or(tpagb_1, tpagb_2)) == True:
                 runs_to_rerun += [i]
         runs_to_rerun = np.array(runs_to_rerun)
     elif rerun_type == 'envelope_mass_limit': # maybe 'fe_core_infall_limit' as well?

--- a/bin/run-pipeline
+++ b/bin/run-pipeline
@@ -607,7 +607,7 @@ def copy_ini_file(grid, rerun_type, destination, cluster):
         replace_text = "matthias_PISN-d68228338b91fd487ef5d55c9b6ebb8cc5f0e668"
     elif rerun_type == 'opacity_max_hms-hms':
         replace_text = "zepei_fix_implicit-afa1860ddf9894aa1d82742ee2a73e8e92acd4a9"
-    elif rerun_type == 'agb_wind':
+    elif rerun_type == 'TPAGBwind':
         replace_text = "agbwind-27f4fa05c4ebabaa85a67c2845818a36e1ecab01"
     elif rerun_type == 'other': # e.g. 'envelope_mass_limit', 'fe_core_infall_limit'
         # this rerun uses the default inlist commit
@@ -671,25 +671,21 @@ def logic_rerun(grid, rerun_type):
               if np.max(transfer) == True:
                 runs_to_rerun += [i]
         runs_to_rerun = np.array(runs_to_rerun)
-    elif rerun_type == 'agb_wind':
+    elif rerun_type == 'TPAGBwind':
         N_runs = len(grid)
         runs_to_rerun = []
         for i in range(N_runs):
           if  grid[i].binary_history is not None and grid[i].history1 is not None:
-              hot_wind_full_on_T = 1.2e4
-              s1_mass = grid[i].binary_history['star_1_mass']
-              s2_mass = grid[i].binary_history['star_2_mass']
+              hot_wind_full_on_T = 1.2e4 # inlist value
               s1_Teff = 10**grid[i].history1['log_Teff']
               s2_Teff = 10**grid[i].history2['log_Teff']
               s1_Yc = grid[i].history1['center_he4']
               s2_Yc = grid[i].history2['center_he4']
               s1_he_shell_mass = grid[i].history1['he_core_mass'] - grid[i].history1['co_core_mass']
               s2_he_shell_mass = grid[i].history2['he_core_mass'] - grid[i].history2['co_core_mass']
-              tpagb_1 = np.logical_and(s1_Teff <= hot_wind_full_on_T, s1_mass <= 10.0)
-              tpagb_1 = np.logical_and(tpagb_1, s1_Yc <= 1e-6)
+              tpagb_1 = np.logical_and(s1_Teff <= hot_wind_full_on_T, s1_Yc <= 1e-6)
               tpagb_1 = np.logical_and(tpagb_1, s1_he_shell_mass <= 1e-1)
-              tpagb_2 = np.logical_and(s2_Teff <= hot_wind_full_on_T, s2_mass <= 10.0)
-              tpagb_2 = np.logical_and(tpagb_2, s2_Yc <= 1e-6)
+              tpagb_2 = np.logical_and(s2_Teff <= hot_wind_full_on_T, s2_Yc <= 1e-6)
               tpagb_2 = np.logical_and(tpagb_2, s2_he_shell_mass <= 1e-1)
               if np.max(np.logical_or(tpagb_1, tpagb_2)) == True:
                 runs_to_rerun += [i]


### PR DESCRIPTION
This PR adds a new rerun type to `posydon/bin/run-pipline` called `TPAGBwind`. This rerun turns on the AGB winds, which were previously disabled unintentionally. It uses the new logic introduced in our `run_star_extras.f` (see the corresponding PR: [corresponding PR#18](https://github.com/POSYDON-code/POSYDON-MESA-INLISTS/pull/18) in POSYDON-MESA-INLISTS) to identify the TP-AGB phase.