### PR TITLE
fix grid post processing of WD and BH above PISN

### DIFF
--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -555,8 +555,11 @@ class StepSN(object):
                     star.state = "WD"
                     star.spin = 0.
                     star.log_R = np.log10(CO_radius(star.mass, star.state))
+                    star.m_disk_accreted = np.nan
+                    star.m_disk_radiated = np.nan
                     for key in STARPROPERTIES:
-                        if key not in ["state", "mass", "log_R", "spin"]:
+                        if key not in ["state", "mass", "log_R", "spin",
+                                       "m_disk_accreted", "m_disk_radiated"]:
                             setattr(star, key, None)
                     return
 
@@ -659,8 +662,11 @@ class StepSN(object):
                     star.state = "WD"
                     star.spin = 0.
                     star.log_R = np.log10(CO_radius(star.mass, star.state))
+                    star.m_disk_accreted = np.nan
+                    star.m_disk_radiated = np.nan
                     for key in STARPROPERTIES:
-                        if key not in ["state", "mass", "log_R", "spin"]:
+                        if key not in ["state", "mass", "log_R", "spin",
+                                       "m_disk_accreted", "m_disk_radiated"]:
                             setattr(star, key, None)
                     return
 

--- a/posydon/grids/post_processing.py
+++ b/posydon/grids/post_processing.py
@@ -285,11 +285,11 @@ def post_process_grid(grid, index=None, star_2_CO=True, MODELS=MODELS,
                             if quantity in ['state', 'SN_type']:
                                 if not isinstance(getattr(star_copy, quantity), str):
                                     flush = True
-                                    warnings.warn(f'{MODEL_NAME} {mechanism} state/SN_type not a string!')
+                                    warnings.warn(f'{MODEL_NAME} {mechanism} {quantity} is not a string!')
                             else:
-                                if not isinstance(getattr(star_copy, quantity), (float, None)):
+                                if not isinstance(getattr(star_copy, quantity), float):
                                     flush = True
-                                    warnings.warn(f'{MODEL_NAME} {mechanism} {quantity} not a float!')
+                                    warnings.warn(f'{MODEL_NAME} {mechanism} {quantity} is not a float!')
                     except Exception as e:
                         flush = True
                         if verbose:
@@ -329,11 +329,11 @@ def post_process_grid(grid, index=None, star_2_CO=True, MODELS=MODELS,
                             if quantity in ['state', 'SN_type']:
                                 if not isinstance(getattr(star_copy, quantity), str):
                                     flush = True
-                                    warnings.warn(f'{MODEL_NAME} {mechanism} state/SN_type not a string!')
+                                    warnings.warn(f'{MODEL_NAME} {mechanism} {quantity} is not a string!')
                             else:
-                                if not isinstance(getattr(star_copy, quantity), (float, None)):
+                                if not isinstance(getattr(star_copy, quantity), float):
                                     flush = True
-                                    warnings.warn(f'{MODEL_NAME} {mechanism} {quantity} not a float!')
+                                    warnings.warn(f'{MODEL_NAME} {mechanism} {quantity} is not a float!')
                     except Exception as e:
                         flush = True
                         if verbose:

--- a/posydon/grids/scrubbing.py
+++ b/posydon/grids/scrubbing.py
@@ -247,6 +247,14 @@ def keep_till_central_abundance_He_C(bh, h1, h2, Ystop=1.0e-5, XCstop=1.0):
             last_index = where_conditions_met2[0]
             newTF1 = 'Secondary got stopped before central carbon depletion'
     
+    # include the point above the stopping criteria so that the last inferred
+    # stellar state will be XXX_Central_He_depleted. This is essential to find
+    # the core mass at He depletion with the calculate_Patton20_values_at_He_depl
+    # method used to calculate the core collapse properties with the 
+    # Patton&Sukhbold mechanism.
+    if len(bh) >= last_index+2:
+        last_index += 1
+        
     new_bh = bh[:last_index]
     new_h1 = h1[:last_index]
     new_h2 = h2[:last_index]


### PR DESCRIPTION
This small PR fixes the issues:
- WD collapsed quantities were not saved because the disk masses were not set to np.nan
- BH formation above the PISN. It turns out that systems having the carbon burning history removed did not have the first history point of stellar state with central_He_depleted saved. Hence, the util function was not finding the core mass as He depletion for the Patton&Sukhbold core collapse.