### PR TITLE
Fix missing Z values in case of missing history files

### DIFF
--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -1083,6 +1083,12 @@ class PSyGrid:
                 for colname, value in grid_point.items():
                     if colname in self.initial_values.dtype.names:
                         self.initial_values[i][colname] = value
+                if np.isnan(self.initial_values[i]["Z"]):
+                    # try to get metallicity from directory name
+                    params_from_path = initial_values_from_dirname(run.path)
+                    if (len(params_from_path)==4) or\
+                       (len(params_from_path)==2):
+                        self.initial_values[i]["Z"] = params_from_path[-1]
             else:
                 for flag, col in zip(termination_flags,
                                      termination_flag_columns):


### PR DESCRIPTION
At the moment the metallicity values are set to nan if there are no history files, because the metallicity is not part of the grid point data taken from `inlist_grid_points`
- [x] read the Z value from the directory name