### PR TITLE
introducing step_CO_HeMS_RLO

### DIFF
--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -1359,7 +1359,6 @@ class CO_HMS_RLO_step(MesaGridStep):
             if self.binary.star_1.state == 'H-rich_Central_C_depletion':
                 self.binary.event = 'CC1'
                 return
-            # super().__call__(binary)
         elif (state_1 in ["WD", "NS", "BH"] and (state_2 in FOR_RLO_STATES)
                 and event == "oRLO2"):
             self.flip_stars_before_step = True
@@ -1367,7 +1366,6 @@ class CO_HMS_RLO_step(MesaGridStep):
             if self.binary.star_2.state == 'H-rich_Central_C_depletion':
                 self.binary.event = 'CC2'
                 return
-            # super().__call__(binary)
         else:
             raise ValueError(
                 'The star_1.state = %s, star_2.state = %s, binary.state = %s, '
@@ -1446,18 +1444,16 @@ class CO_HeMS_RLO_step(MesaGridStep):
                 and (state_1 in CO_He_STATES) and event == "oRLO1"):
             self.flip_stars_before_step = False
             # catch and redirect double core collapse, this happens if q=1:
-            if self.binary.star_1.state == 'H-rich_Central_C_depletion':
+            if self.binary.star_1.state == 'stripped_He_Central_C_depletion':
                 self.binary.event = 'CC1'
                 return
-            # super().__call__(binary)
         elif (state_1 in ["WD", "NS", "BH"] and (state_2 in CO_He_STATES)
                 and event == "oRLO2"):
             self.flip_stars_before_step = True
             # catch and redirect double core collapse, this happens if q=1:
-            if self.binary.star_2.state == 'H-rich_Central_C_depletion':
+            if self.binary.star_2.state == 'stripped_He_Central_C_depletion':
                 self.binary.event = 'CC2'
                 return
-            # super().__call__(binary)
         else:
             raise ValueError(
                 'The star_1.state = %s, star_2.state = %s, binary.state = %s, '

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -1461,7 +1461,7 @@ class CO_HeMS_RLO_step(MesaGridStep):
         else:
             raise ValueError(
                 'The star_1.state = %s, star_2.state = %s, binary.state = %s, '
-                'binary.event = %s and not CO - HMS - oRLO1/oRLO2!'
+                'binary.event = %s and not CO - HeMS - oRLO1/oRLO2!'
                 % (state_1, state_2, state, event))
         # redirect if outside grids
         if ((not self.flip_stars_before_step and

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -787,24 +787,25 @@ class MesaGridStep:
             for key in key_post_processed:
                 setattr(star, key, cb.final_values['S%d_%s' % (k+1, key)])
 
-        # update nearest neighbor core collapse quantites
+        # update nearest neighbor core collapse quantites                            
         if interpolation_class != 'unstable_MT':
             for MODEL_NAME in MODELS.keys():
                 for i, star in enumerate(stars):
-                    if not stars_CO[i]:
+                    if (not stars_CO[i] and 
+                        cb.final_values[f'S{i+1}_{MODEL_NAME}_CO_type'] != 'None'):
                         values = {}
                         for key in ['state', 'SN_type', 'f_fb', 'mass', 'spin',
                                     'm_disk_accreted', 'm_disk_radiated']:
-                            if key == 'state': 
-                                key = 'CO_type'
-                            values[key] = cb.final_values[f'S{i+1}_{MODEL_NAME}_{key}']
-                        state = cb.final_values[f'S{i+1}_{MODEL_NAME}_CO_type'] 
-                        if state is None or state == 'None':
-                            # privent to any quantities for star that did not
-                            # reach core collpase
-                            setattr(star, MODEL_NAME, None)
-                        else:
-                            setattr(star, MODEL_NAME, values)
+                            if key == "state": 
+                                state = cb.final_values[f'S{i+1}_{MODEL_NAME}_CO_type']
+                                values[key] = state
+                            elif key == "SN_type":
+                                values[key] = cb.final_values[f'S{i+1}_{MODEL_NAME}_{key}']
+                            else:
+                                values[key] = cb.final_values[f'S{i+1}_{MODEL_NAME}_{key}']
+                        setattr(star, MODEL_NAME, values)
+                    else:
+                        setattr(star, key, None)
 
     def initial_final_interpolation(self, star_1_CO=False, star_2_CO=False):
         """Update the binary through initial-final interpolation."""
@@ -967,14 +968,14 @@ class MesaGridStep:
                         values = {}
                         for key in ['state', 'SN_type', 'f_fb', 'mass', 'spin',
                                     'm_disk_accreted', 'm_disk_radiated']:
-                            if key == "state" in key: 
+                            if key == "state": 
                                 state = self.classes[f'S{i+1}_{MODEL_NAME}_CO_type']
                                 values[key] = state
                             elif key == "SN_type":
                                 values[key] = self.classes[f'S{i+1}_{MODEL_NAME}_{key}']
                             else:
                                 values[key] = fv[f'S{i+1}_{MODEL_NAME}_{key}']
-                            setattr(star, MODEL_NAME, values)
+                        setattr(star, MODEL_NAME, values)
                     else:
                         setattr(star, key, None)
 

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -1275,7 +1275,7 @@ class MS_MS_step(MesaGridStep):
               state_2 == 'H-rich_Core_H_burning' and 
               event == 'ZAMS' and
               self.m1_min <= m2 <= self.m1_max and
-              1./self.q_min >= mass_ratio > self.q_max and 
+              self.q_min <= 1./mass_ratio <= self.q_max and 
               self.p_min <= p <= self.p_max):
             self.flip_stars_before_step = True
             super().__call__(self.binary)
@@ -1341,7 +1341,7 @@ class CO_HMS_RLO_step(MesaGridStep):
         p = self.binary.orbital_period
         ecc = self.binary.eccentricity
 
-        # TODO: import from flow_chart.py
+        # TODO: import states from flow_chart.py
         FOR_RLO_STATES = ["H-rich_Core_H_burning",
                           "H-rich_Shell_H_burning",
                           "H-rich_Core_He_burning",
@@ -1352,6 +1352,7 @@ class CO_HMS_RLO_step(MesaGridStep):
                           "H-rich_non_burning"]
 
         # check the star states
+        # TODO: import states from flow_chart.py
         if (state_2 in ["WD", "NS", "BH"]
                 and (state_1 in FOR_RLO_STATES) and event == "oRLO1"):
             self.flip_stars_before_step = False
@@ -1359,6 +1360,7 @@ class CO_HMS_RLO_step(MesaGridStep):
             if self.binary.star_1.state == 'H-rich_Central_C_depletion':
                 self.binary.event = 'CC1'
                 return
+        # TODO: import states from flow_chart.py
         elif (state_1 in ["WD", "NS", "BH"] and (state_2 in FOR_RLO_STATES)
                 and event == "oRLO2"):
             self.flip_stars_before_step = True
@@ -1427,7 +1429,7 @@ class CO_HeMS_RLO_step(MesaGridStep):
         p = self.binary.orbital_period
         ecc = self.binary.eccentricity
 
-        # TODO: import from flow_chart.py
+        # TODO: import states from flow_chart.py
         CO_He_STATES = [
             'stripped_He_Core_He_burning',
             'stripped_He_Shell_He_burning',
@@ -1440,6 +1442,7 @@ class CO_HeMS_RLO_step(MesaGridStep):
                         ]
 
         # check the star states
+        # TODO: import states from flow_chart.py
         if (state_2 in ["WD", "NS", "BH"]
                 and (state_1 in CO_He_STATES) and event == "oRLO1"):
             self.flip_stars_before_step = False
@@ -1447,6 +1450,7 @@ class CO_HeMS_RLO_step(MesaGridStep):
             if self.binary.star_1.state == 'stripped_He_Central_C_depletion':
                 self.binary.event = 'CC1'
                 return
+        # TODO: import states from flow_chart.py
         elif (state_1 in ["WD", "NS", "BH"] and (state_2 in CO_He_STATES)
                 and event == "oRLO2"):
             self.flip_stars_before_step = True
@@ -1514,6 +1518,7 @@ class CO_HeMS_step(MesaGridStep):
         p = self.binary.orbital_period
         ecc = self.binary.eccentricity
 
+        # TODO: import states from flow_chart.py
         CO_He_STATES = [
             'stripped_He_Core_He_burning',
             'stripped_He_Shell_He_burning',
@@ -1524,7 +1529,7 @@ class CO_HeMS_step(MesaGridStep):
             # include systems post CE with core_definition_H_fraction=0.1
             'H-rich_non_burning'
                         ]
-
+        # TODO: import states from flow_chart.py
         if (state_2 in ['WD', 'NS', 'BH']
                 and state_1 in CO_He_STATES and event is None):
             self.flip_stars_before_step = False
@@ -1539,6 +1544,7 @@ class CO_HeMS_step(MesaGridStep):
                 #     new_separation, m1, m2)
                 # self.binary.eccentricity = 0.
                 return
+        # TODO: import states from flow_chart.py
         elif (state_1 in ['WD', 'NS', 'BH']
                 and state_2 in CO_He_STATES and event is None):
             self.flip_stars_before_step = True

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -1240,6 +1240,14 @@ class MS_MS_step(MesaGridStep):
                          *args, **kwargs)
         # special stuff for my step goes here
         # If nothing to do, no init necessary
+        
+        # load grid boundaries
+        self.m1_min = min(self._psyTrackInterp.grid.initial_values['star_1_mass'])
+        self.m1_max = max(self._psyTrackInterp.grid.initial_values['star_1_mass'])
+        self.q_min = 0.05 # can be computed m2_min/m1_min
+        self.q_max = 1. # note that for MESA stability we actually run q_max = 0.99
+        self.p_min = min(self._psyTrackInterp.grid.initial_values['period_days'])
+        self.p_max = max(self._psyTrackInterp.grid.initial_values['period_days'])
 
     def __call__(self, binary):
         """Apply the MS-MS step on a BinaryStar."""
@@ -1251,29 +1259,39 @@ class MS_MS_step(MesaGridStep):
         state_1 = self.binary.star_1.state
         state_2 = self.binary.star_2.state
         event = self.binary.event
-        mass_ratio = self.binary.star_2.mass/self.binary.star_1.mass
+        m1 = self.binary.star_1.mass
+        m2 = self.binary.star_2.mass
+        mass_ratio = m2/m1
         p = self.binary.orbital_period
-        p_max_HMS_grid = 6500
-        if (state_1 == 'H-rich_Core_H_burning'
-                and state_2 == 'H-rich_Core_H_burning' and event == 'ZAMS'
-                and mass_ratio <= 1. and p <= p_max_HMS_grid):
+        if (state_1 == 'H-rich_Core_H_burning' and 
+            state_2 == 'H-rich_Core_H_burning' and 
+            event == 'ZAMS' and
+            self.m1_min <= m1 <= self.m1_max and 
+            self.q_min <= mass_ratio <= self.q_max and 
+            self.p_min <= p <= self.p_max):
             self.flip_stars_before_step = False
             super().__call__(self.binary)
-        elif (state_1 == 'H-rich_Core_H_burning'
-              and state_2 == 'H-rich_Core_H_burning'
-              and event == 'ZAMS' and mass_ratio > 1. and p <= p_max_HMS_grid):
+        elif (state_1 == 'H-rich_Core_H_burning' and 
+              state_2 == 'H-rich_Core_H_burning' and 
+              event == 'ZAMS' and
+              self.m1_min <= m2 <= self.m1_max and
+              1./self.q_min >= mass_ratio > self.q_max and 
+              self.p_min <= p <= self.p_max):
             self.flip_stars_before_step = True
             super().__call__(self.binary)
-        elif (state_1 == 'H-rich_Core_H_burning'
-              and state_2 == 'H-rich_Core_H_burning'
-              and event == 'ZAMS'
-              and p > p_max_HMS_grid):              # redirect if outside grid
+        # redirect if outside grid
+        elif (state_1 == 'H-rich_Core_H_burning' and 
+              state_2 == 'H-rich_Core_H_burning' and 
+              event == 'ZAMS' and 
+              p > self.p_max):
             self.binary.event = 'redirect'
             return
-        elif (state_1 == 'H-rich_Central_C_depletion'):     # redirect if CC1
+        # redirect if CC1
+        elif (state_1 == 'H-rich_Central_C_depletion'):     
             self.binary.event = 'CC1'
             return
-        elif (state_2 == 'H-rich_Central_C_depletion'):     # redirect if CC2
+        # redirect if CC2
+        elif (state_2 == 'H-rich_Central_C_depletion'):     
             self.binary.event = 'CC2'
             return
         else:
@@ -1284,7 +1302,7 @@ class MS_MS_step(MesaGridStep):
 
 
 class CO_HMS_RLO_step(MesaGridStep):
-    """Class for performing the MESA step for a CO-HMS binary."""
+    """Class for performing the MESA step for a CO-HMS_RLO binary."""
 
     def __init__(self, metallicity=1., grid_name=None, *args, **kwargs):
         """Initialize a CO_HMS_RLO_step instance."""
@@ -1298,6 +1316,14 @@ class CO_HMS_RLO_step(MesaGridStep):
                          *args, **kwargs)
         # special stuff for my step goes here
         # If nothing to do, no init necessary
+        
+        # load grid boundaries
+        self.m1_min = min(self._psyTrackInterp.grid.initial_values['star_1_mass'])
+        self.m1_max = max(self._psyTrackInterp.grid.initial_values['star_1_mass'])
+        self.m2_min = min(self._psyTrackInterp.grid.initial_values['star_2_mass'])
+        self.m2_max = max(self._psyTrackInterp.grid.initial_values['star_2_mass'])
+        self.p_min = min(self._psyTrackInterp.grid.initial_values['period_days'])
+        self.p_max = max(self._psyTrackInterp.grid.initial_values['period_days'])
 
     def __call__(self, binary):
         """Evolve a binary using the MESA step."""
@@ -1310,8 +1336,12 @@ class CO_HMS_RLO_step(MesaGridStep):
         state = binary.state
         state_1 = binary.star_1.state
         state_2 = binary.star_2.state
+        m1 = self.binary.star_1.mass
+        m2 = self.binary.star_2.mass
         p = self.binary.orbital_period
+        ecc = self.binary.eccentricity
 
+        # TODO: import from flow_chart.py
         FOR_RLO_STATES = ["H-rich_Core_H_burning",
                           "H-rich_Shell_H_burning",
                           "H-rich_Core_He_burning",
@@ -1325,8 +1355,6 @@ class CO_HMS_RLO_step(MesaGridStep):
         if (state_2 in ["WD", "NS", "BH"]
                 and (state_1 in FOR_RLO_STATES) and event == "oRLO1"):
             self.flip_stars_before_step = False
-            m1 = self.binary.star_1.mass
-            m2 = self.binary.star_2.mass
             # catch and redirect double core collapse, this happens if q=1:
             if self.binary.star_1.state == 'H-rich_Central_C_depletion':
                 self.binary.event = 'CC1'
@@ -1335,8 +1363,6 @@ class CO_HMS_RLO_step(MesaGridStep):
         elif (state_1 in ["WD", "NS", "BH"] and (state_2 in FOR_RLO_STATES)
                 and event == "oRLO2"):
             self.flip_stars_before_step = True
-            m1 = self.binary.star_2.mass
-            m2 = self.binary.star_1.mass
             # catch and redirect double core collapse, this happens if q=1:
             if self.binary.star_2.state == 'H-rich_Central_C_depletion':
                 self.binary.event = 'CC2'
@@ -1348,13 +1374,110 @@ class CO_HMS_RLO_step(MesaGridStep):
                 'binary.event = %s and not CO - HMS - oRLO1/oRLO2!'
                 % (state_1, state_2, state, event))
         # redirect if outside grids
-        if 0.466 <= m1 <= 128.735 and 0.092 <= m2 <= 39.25 and p <= 3780.83:
+        if ((not self.flip_stars_before_step and
+            self.m1_min <= m1 <= self.m1_max and 
+            self.m2_min <= m2 <= self.m2_max and 
+            self.p_min <= p <= self.p_max and
+            ecc == 0.) or (self.flip_stars_before_step and
+            self.m1_min <= m2 <= self.m1_max and 
+            self.m2_min <= m1 <= self.m2_max and 
+            self.p_min <= p <= self.p_max and
+            ecc == 0.)):
             super().__call__(self.binary)
         else:
             self.binary.state = "detached"
             self.binary.event = "redirect"
             return
 
+class CO_HeMS_RLO_step(MesaGridStep):
+    """Class for performing the MESA step for a CO-HeMS_RLO binary."""
+
+    def __init__(self, metallicity=1., grid_name=None, *args, **kwargs):
+        """Initialize a CO_HeMS_RLO_step instance."""
+        self.grid_type = 'CO_HeMS_RLO'
+        self.interp_in_q = False
+        if grid_name is None:
+            metallicity = convert_metallicity_to_string(metallicity)
+            grid_name = 'CO-HeMS_RLO/' + metallicity + '_Zsun.h5'
+        super().__init__(metallicity=metallicity,
+                         grid_name=grid_name,
+                         *args, **kwargs)
+        # special stuff for my step goes here
+        # If nothing to do, no init necessary
+        
+        # load grid boundaries
+        self.m1_min = min(self._psyTrackInterp.grid.initial_values['star_1_mass'])
+        self.m1_max = max(self._psyTrackInterp.grid.initial_values['star_1_mass'])
+        self.m2_min = min(self._psyTrackInterp.grid.initial_values['star_2_mass'])
+        self.m2_max = max(self._psyTrackInterp.grid.initial_values['star_2_mass'])
+        self.p_min = min(self._psyTrackInterp.grid.initial_values['period_days'])
+        self.p_max = max(self._psyTrackInterp.grid.initial_values['period_days'])
+
+    def __call__(self, binary):
+        """Evolve a binary using the MESA step."""
+        # grid set up assume CO is star_2
+        self.star_1_CO = False
+        self.star_2_CO = True
+        # check binary is ready before calling the step
+        self.binary = binary
+        event = self.binary.event
+        state = binary.state
+        state_1 = binary.star_1.state
+        state_2 = binary.star_2.state
+        m1 = self.binary.star_1.mass
+        m2 = self.binary.star_2.mass
+        p = self.binary.orbital_period
+        ecc = self.binary.eccentricity
+
+        # TODO: import from flow_chart.py
+        CO_He_STATES = [
+            'stripped_He_Core_He_burning',
+            'stripped_He_Shell_He_burning',
+            'stripped_He_Central_He_depleted',
+            'stripped_He_Central_C_depletion',  # filtered out below
+            # include systems that are on the brink of He exhaustion
+            'stripped_He_non_burning',
+            # include systems post CE with core_definition_H_fraction=0.1
+            'H-rich_non_burning'
+                        ]
+
+        # check the star states
+        if (state_2 in ["WD", "NS", "BH"]
+                and (state_1 in CO_He_STATES) and event == "oRLO1"):
+            self.flip_stars_before_step = False
+            # catch and redirect double core collapse, this happens if q=1:
+            if self.binary.star_1.state == 'H-rich_Central_C_depletion':
+                self.binary.event = 'CC1'
+                return
+            # super().__call__(binary)
+        elif (state_1 in ["WD", "NS", "BH"] and (state_2 in CO_He_STATES)
+                and event == "oRLO2"):
+            self.flip_stars_before_step = True
+            # catch and redirect double core collapse, this happens if q=1:
+            if self.binary.star_2.state == 'H-rich_Central_C_depletion':
+                self.binary.event = 'CC2'
+                return
+            # super().__call__(binary)
+        else:
+            raise ValueError(
+                'The star_1.state = %s, star_2.state = %s, binary.state = %s, '
+                'binary.event = %s and not CO - HMS - oRLO1/oRLO2!'
+                % (state_1, state_2, state, event))
+        # redirect if outside grids
+        if ((not self.flip_stars_before_step and
+            self.m1_min <= m1 <= self.m1_max and 
+            self.m2_min <= m2 <= self.m2_max and 
+            self.p_min <= p <= self.p_max and
+            ecc == 0.) or (self.flip_stars_before_step and
+            self.m1_min <= m2 <= self.m1_max and 
+            self.m2_min <= m1 <= self.m2_max and 
+            self.p_min <= p <= self.p_max and
+            ecc == 0.)):
+            super().__call__(self.binary)
+        else:
+            self.binary.state = "detached"
+            self.binary.event = "redirect"
+            return
 
 class CO_HeMS_step(MesaGridStep):
     """Class for performing the MESA step for a CO-HeMS binary."""
@@ -1371,6 +1494,14 @@ class CO_HeMS_step(MesaGridStep):
                          *args, **kwargs)
         # special stuff for my step goes here
         # If nothing to do, no init necessary
+        
+        # load grid boundaries
+        self.m1_min = min(self._psyTrackInterp.grid.initial_values['star_1_mass'])
+        self.m1_max = max(self._psyTrackInterp.grid.initial_values['star_1_mass'])
+        self.m2_min = min(self._psyTrackInterp.grid.initial_values['star_2_mass'])
+        self.m2_max = max(self._psyTrackInterp.grid.initial_values['star_2_mass'])
+        self.p_min = min(self._psyTrackInterp.grid.initial_values['period_days'])
+        self.p_max = max(self._psyTrackInterp.grid.initial_values['period_days'])
 
     def __call__(self, binary):
         """Apply the CO_HeMS step to a BinaryStar object."""
@@ -1382,7 +1513,10 @@ class CO_HeMS_step(MesaGridStep):
         state_1 = self.binary.star_1.state
         state_2 = self.binary.star_2.state
         event = self.binary.event
+        m1 = self.binary.star_1.mass
+        m2 = self.binary.star_2.mass
         p = self.binary.orbital_period
+        ecc = self.binary.eccentricity
 
         CO_He_STATES = [
             'stripped_He_Core_He_burning',
@@ -1398,8 +1532,6 @@ class CO_HeMS_step(MesaGridStep):
         if (state_2 in ['WD', 'NS', 'BH']
                 and state_1 in CO_He_STATES and event is None):
             self.flip_stars_before_step = False
-            m1 = self.binary.star_2.mass
-            m2 = self.binary.star_1.mass
             # catch and redirect double core collapse, this happens if q=1:
             if self.binary.star_1.state == 'stripped_He_Central_C_depletion':
                 self.binary.event = 'CC1'
@@ -1414,8 +1546,6 @@ class CO_HeMS_step(MesaGridStep):
         elif (state_1 in ['WD', 'NS', 'BH']
                 and state_2 in CO_He_STATES and event is None):
             self.flip_stars_before_step = True
-            m1 = self.binary.star_1.mass
-            m2 = self.binary.star_2.mass
             # catch and redirect double core collapse, this happens if q=1:
             if self.binary.star_2.state == 'stripped_He_Central_C_depletion':
                 self.binary.event = 'CC2'
@@ -1426,7 +1556,16 @@ class CO_HeMS_step(MesaGridStep):
                 'not supported by CO - HeMS grid!' % (state_1, state_2, event))
 
         # redirect if outside grids
-        if 0.91 <= m1 <= 39.24 and 0.47 <= m2 <= 85.38 and p <= 1203.84:
+        # remember that in MESA the CO object is star_2
+        if ((not self.flip_stars_before_step and
+            self.m1_min <= m1 <= self.m1_max and 
+            self.m2_min <= m2 <= self.m2_max and 
+            self.p_min <= p <= self.p_max and
+            ecc == 0.) or (self.flip_stars_before_step and
+            self.m1_min <= m2 <= self.m1_max and 
+            self.m2_min <= m1 <= self.m2_max and 
+            self.p_min <= p <= self.p_max and
+            ecc == 0.)):
             super().__call__(binary)
         else:
             self.binary.event = 'redirect'

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -1391,163 +1391,6 @@ class StepSN(object):
                 mean_anomaly = np.random.uniform(0, 2 * np.pi)
                 binary.star_2.natal_kick_array[3] = mean_anomaly
 
-
-        # The binary exist: flag_binary is True if the binary is not disrupted
-        flag_binary = True
-
-        # eccentricity before the SN
-        epre = binary.eccentricity
-        # the orbital semimajor axis is the orbital separation
-        Apre = binary.separation
-        # Eq 16, Wong, T.-W., Valsecchi, F., Fragos, T., & Kalogera, V. 2012, ApJ, 747, 111
-        # for eccentric anomaly
-        E_ma = sp.optimize.brentq(
-            lambda x: mean_anomaly - x + epre * np.sin(x), 0, 2 * np.pi
-        )
-        # Eq 15, Wong, T.-W., Valsecchi, F., Fragos, T., & Kalogera, V. 2012, ApJ, 747, 111
-        # orbital separation at the time of the exlosion
-        rpre = Apre * (1.0 - epre * np.cos(E_ma))
-
-        # load constants in CGS
-        G = const.standard_cgrav
-
-        # Convert inputs to CGS
-        M_he_star = M_he_star * const.Msun
-        M_companion = M_companion * const.Msun
-        M_compact_object = M_compact_object * const.Msun
-        Apre = Apre * const.Rsun
-        Vkick = Vkick * const.km2cm
-        rpre = rpre * const.Rsun
-        Mtot_pre = M_he_star + M_companion
-        Mtot_post = M_compact_object + M_companion
-
-        # get useful quantity
-        sin_theta = np.sqrt(1 - (cos_theta ** 2))
-
-        # Eq 1, in Kalogera, V. 1996, ApJ, 471, 352
-        # extended to Eq 17 in Wong, T.-W., Valsecchi, F., Fragos, T., & Kalogera, V. 2012, ApJ, 747, 111
-        # Vr is velocity of preSN He core relative to M_companion, NOT necessarily
-        # in the direction of the Y axis if eccentric
-        # Eq from conservation of energy
-        Vr = np.sqrt(G * (Mtot_pre) * (2.0 / rpre - 1.0 / Apre))
-
-        # Eq 18, Wong, T.-W., Valsecchi, F., Fragos, T., & Kalogera, V. 2012, ApJ, 747, 111
-        # psi is the polar angle of the position vector of the CO with respect
-        # to its pre-SN orbital velocity in the companions frame. i.e. angle between Vr and X axis
-        # If epre = 0, sin_psi should be 1
-        # Eq from setting specific angular momentum r X Vr = sqrt(G*M*A*(1-e**2))
-        sin_psi = np.round(
-            np.sqrt(G * (Mtot_pre) * (1 - epre ** 2) * Apre)
-            / (rpre * Vr), 5)
-        cos_psi = np.sqrt(1 - sin_psi ** 2)
-        # Allow for -cos_psi (Vr in the -X, +Y quadrant)
-        if E_ma > np.pi: cos_psi *= -1
-
-        # Eq 3, in Kalogera, V. 1996, ApJ, 471, 352
-        # extended to Eq 13, in Wong, T.-W., Valsecchi, F., Fragos, T., & Kalogera, V. 2012, ApJ, 747, 111
-        # get the orbital separation post SN
-        # Eq from conservation of energy
-        Apost = ((2.0 / rpre)
-                 - (((Vkick ** 2) + (Vr ** 2) + (2 * (Vkick * cos_theta) * Vr)) / (G * Mtot_post))
-                 ) ** -1
-
-
-                # get kicks componets in the coordinate system
-        Vkx = Vkick * (sin_theta * np.sin(phi) * sin_psi + cos_theta * cos_psi)
-        Vky = Vkick * (-sin_theta * np.sin(phi) * cos_psi + cos_theta * sin_psi)
-        Vkz = Vkick * sin_theta * np.cos(phi)
-
-
-        # Eq 4, in Kalogera, V. 1996, ApJ, 471, 352
-        # extended to Eq 14 in Wong, T.-W., Valsecchi, F., Fragos, T., & Kalogera, V. 2012, ApJ, 747, 111
-        # get the eccentricity post SN
-        # Eq from setting specific angular momentum r X Vr = sqrt(G*M*A*(1-e**2))
-
-
-        x = ((Vkz ** 2 + (Vky + Vr * sin_psi)** 2)
-             * rpre ** 2
-             / (G * Mtot_post * Apost))
-
-        # catch negative values, i.e. disrupted binaries
-        if 1.-x < 0.:
-            epost = np.nan
-        else:
-            epost = np.sqrt(1 - x)
-
-        # Compute COM velocity, VS, post SN
-        # VS_pre in COM frame is 0. So VS_post in COM frame is 
-        # VS_post - VS_pre in our working frame
-        
-        VC0x = M_he_star * Vr * cos_psi / Mtot_pre
-        VC0y = M_he_star * Vr * sin_psi / Mtot_pre
-        VC0z = 0
-
-        VC1x = M_compact_object * (Vkx + Vr * cos_psi) / Mtot_post
-        VC1y = M_compact_object * (Vky + Vr * sin_psi) / Mtot_post
-        VC1z = M_compact_object * Vkz / Mtot_post
-
-
-        VSx = VC1x - VC0x
-        VSy = VC1y - VC0y
-        VSz = VC1z - VC0z
-
-
-        # V_sys = np.sqrt(VSx ** 2 + VSy ** 2 + VSz ** 2)
-
-        # Calculate the angle between the pre and post-SN orbital angular momentum vectors
-        # Lpre || Z axis
-        # Lpost || X axis cross the post SN velocity of the compact object
-        # cos(tilt) = Lpre dot Lpost / ||Lpre||||Lpost||
-        # For epre=0 (sin_psi=1), reduces to Eq 4, in Kalogera, V. 1996, ApJ, 471, 352
-
-        tilt = np.arccos((Vky + Vr * sin_psi) / np.sqrt( Vkz ** 2 + (Vky + Vr * sin_psi) ** 2 ))
-
-        def SNCheck(
-            M_he_star,
-            M_companion,
-            M_compact_object,
-            rpre,
-            Apost,
-            epost,
-            Vr,
-            Vkick,
-            cos_theta,
-            verbose,
-        ):
-            """Check that the binary is not disrupted.
-
-            Parameters
-            ----------
-            M_he_star : double
-                Helium star mass before the SN in g.
-            M_companion : double
-                Companion star mass in g.
-            M_compact_object : double
-                Compact object mass left  by the SN in g.
-            rpre : double
-                Oribtal separation at the time of the exlosion in cm. If the
-                eccentricity pre SN is 0 this correpond to Apre.
-            Apost : double
-                Orbital separtion after the SN in cm.
-            epost : double
-                Eccentricity after the SN.
-            Vr : double
-                Velocity of pre-SN He core relative to M_companion, directed
-                along the positive y axis in cm/s.
-            Vkick : double
-                Kick velocity in cm/s.
-            cos_theta : double
-                The cosine of the angle between pre- & post-SN orbital planes.
-
-            Returns
-            -------
-            flag_binary : bool
-                flag_binary is True if the binary is not disrupted.
-
-            References
-            ----------
-            .. [1] Willems, B., Henninger, M., Levin, T., et al. 2005, ApJ, 625, 324
-            """
         # update the orbit
         if binary.state == "disrupted" or binary.state == "initially_single_star" or binary.state == "merged":
             #the binary was already disrupted before the SN
@@ -1566,8 +1409,8 @@ class StepSN(object):
             binary.mass_transfer_case = 'None'
             
         else:
-            # the binary is not disrupted at least before the SN
-            # The binary exists : flag_binary is True at least before the SN
+                
+            # The binary exist: flag_binary is True if the binary is not disrupted
             flag_binary = True
 
             # eccentricity before the SN
@@ -1593,43 +1436,55 @@ class StepSN(object):
             Apre = Apre * const.Rsun
             Vkick = Vkick * const.km2cm
             rpre = rpre * const.Rsun
+            Mtot_pre = M_he_star + M_companion
+            Mtot_post = M_compact_object + M_companion
 
             # get useful quantity
             sin_theta = np.sqrt(1 - (cos_theta ** 2))
 
-            # get kicks componets in the coordinate system
-            Vkx = Vkick * sin_theta * np.sin(phi)
-            Vky = Vkick * cos_theta
-            Vkz = Vkick * sin_theta * np.cos(phi)
-
             # Eq 1, in Kalogera, V. 1996, ApJ, 471, 352
             # extended to Eq 17 in Wong, T.-W., Valsecchi, F., Fragos, T., & Kalogera, V. 2012, ApJ, 747, 111
-            # Vr is velocity of preSN He core relative to M_companion, directed
-            # along the positive y axis
-            Vr = np.sqrt(G * (M_he_star + M_companion) * (2.0 / rpre - 1.0 / Apre))
-            Mtot = M_compact_object + M_companion
+            # Vr is velocity of preSN He core relative to M_companion, NOT necessarily
+            # in the direction of the Y axis if eccentric
+            # Eq from conservation of energy
+            Vr = np.sqrt(G * (Mtot_pre) * (2.0 / rpre - 1.0 / Apre))
+
+            # Eq 18, Wong, T.-W., Valsecchi, F., Fragos, T., & Kalogera, V. 2012, ApJ, 747, 111
+            # psi is the polar angle of the position vector of the CO with respect
+            # to its pre-SN orbital velocity in the companions frame. i.e. angle between Vr and X axis
+            # If epre = 0, sin_psi should be 1
+            # Eq from setting specific angular momentum r X Vr = sqrt(G*M*A*(1-e**2))
+            sin_psi = np.round(
+                np.sqrt(G * (Mtot_pre) * (1 - epre ** 2) * Apre)
+                / (rpre * Vr), 5)
+            cos_psi = np.sqrt(1 - sin_psi ** 2)
+            # Allow for -cos_psi (Vr in the -X, +Y quadrant)
+            if E_ma > np.pi: cos_psi *= -1
 
             # Eq 3, in Kalogera, V. 1996, ApJ, 471, 352
             # extended to Eq 13, in Wong, T.-W., Valsecchi, F., Fragos, T., & Kalogera, V. 2012, ApJ, 747, 111
             # get the orbital separation post SN
+            # Eq from conservation of energy
             Apost = ((2.0 / rpre)
-                     - (((Vkick ** 2) + (Vr ** 2) + (2 * Vky * Vr)) / (G * Mtot))
-                     ) ** -1
+                    - (((Vkick ** 2) + (Vr ** 2) + (2 * (Vkick * cos_theta) * Vr)) / (G * Mtot_post))
+                    ) ** -1
 
-            # Eq 18, Wong, T.-W., Valsecchi, F., Fragos, T., & Kalogera, V. 2012, ApJ, 747, 111
-            # psi: is the polar angle of the position vector of the CO with respect
-            # to its pre-SN orbital velocity in the companions frame.
-            sin_psi = np.round(
-                np.sqrt(G * (M_he_star + M_companion) * (1 - epre ** 2) * Apre)
-                / (rpre * Vr), 5)
-            cos_psi = np.sqrt(1 - sin_psi ** 2)
+
+                    # get kicks componets in the coordinate system
+            Vkx = Vkick * (sin_theta * np.sin(phi) * sin_psi + cos_theta * cos_psi)
+            Vky = Vkick * (-sin_theta * np.sin(phi) * cos_psi + cos_theta * sin_psi)
+            Vkz = Vkick * sin_theta * np.cos(phi)
+
 
             # Eq 4, in Kalogera, V. 1996, ApJ, 471, 352
             # extended to Eq 14 in Wong, T.-W., Valsecchi, F., Fragos, T., & Kalogera, V. 2012, ApJ, 747, 111
             # get the eccentricity post SN
-            x = ((Vkz ** 2 + (sin_psi * (Vr + Vky) - cos_psi * Vkx) ** 2)
-                 * rpre ** 2
-                 / (G * Mtot * Apost))
+            # Eq from setting specific angular momentum r X Vr = sqrt(G*M*A*(1-e**2))
+
+
+            x = ((Vkz ** 2 + (Vky + Vr * sin_psi)** 2)
+                * rpre ** 2
+                / (G * Mtot_post * Apost))
 
             # catch negative values, i.e. disrupted binaries
             if 1.-x < 0.:
@@ -1637,26 +1492,33 @@ class StepSN(object):
             else:
                 epost = np.sqrt(1 - x)
 
-            # Eq 34, in Kalogera, V. 1996, ApJ, 471, 352
-            # V_sys: is the resulting center of mass velocity of the system
-            # IN THE TRANSLATED COMOVING FRAME, imparted by the SN
-            VSx = M_compact_object * Vkx / Mtot
-            VSy = (
-                M_compact_object * Vky
-                - (
-                    (M_he_star - M_compact_object)
-                    * M_companion
-                    * Vr
-                    / (M_he_star + M_companion)
-                )
-            ) / Mtot
-            VSz = M_compact_object * Vkz / Mtot
+            # Compute COM velocity, VS, post SN
+            # VS_pre in COM frame is 0. So VS_post in COM frame is 
+            # VS_post - VS_pre in our working frame
+            
+            VC0x = M_he_star * Vr * cos_psi / Mtot_pre
+            VC0y = M_he_star * Vr * sin_psi / Mtot_pre
+            VC0z = 0
+
+            VC1x = M_compact_object * (Vkx + Vr * cos_psi) / Mtot_post
+            VC1y = M_compact_object * (Vky + Vr * sin_psi) / Mtot_post
+            VC1z = M_compact_object * Vkz / Mtot_post
+
+
+            VSx = VC1x - VC0x
+            VSy = VC1y - VC0y
+            VSz = VC1z - VC0z
+
+
             # V_sys = np.sqrt(VSx ** 2 + VSy ** 2 + VSz ** 2)
 
-            # Eq 5, in Kalogera, V. 1996, ApJ, 471, 352:
-            # calculate the tilt of the orbital plane after the SN
-            tilt = np.arccos((Vky + Vr) / ((Vky + Vr) ** 2 + Vkz ** 2) ** (1. / 2))
+            # Calculate the angle between the pre and post-SN orbital angular momentum vectors
+            # Lpre || Z axis
+            # Lpost || X axis cross the post SN velocity of the compact object
+            # cos(tilt) = Lpre dot Lpost / ||Lpre||||Lpost||
+            # For epre=0 (sin_psi=1), reduces to Eq 4, in Kalogera, V. 1996, ApJ, 471, 352
 
+            tilt = np.arccos((Vky + Vr * sin_psi) / np.sqrt( Vkz ** 2 + (Vky + Vr * sin_psi) ** 2 ))
 
             def SNCheck(
                 M_he_star,
@@ -1703,7 +1565,6 @@ class StepSN(object):
                 References
                 ----------
                 .. [1] Willems, B., Henninger, M., Levin, T., et al. 2005, ApJ, 625, 324
-
                 .. [2] Kalogera, V. & Lorimer, D.R. 2000, ApJ, 530, 890
 
                 """

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -523,7 +523,8 @@ class StepSN(object):
                                         "m_disk_accreted ", "m_disk_radiated"]:
                             setattr(star, key, None)
                     
-                    star.log_R = np.log10(CO_radius(star.mass, star.state))
+                    if getattr(star, 'SN_type') != 'PISN':
+                        star.log_R = np.log10(CO_radius(star.mass, star.state))
                     
                     return
 

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -165,7 +165,7 @@ class BinaryStar:
         #     self.V_sys = [0, 0, 0]
         
         # store innterpolation_class for each step_MESA
-        for grid_type in ['HMS_HMS','CO_HMS_RLO','CO_HeMS']:
+        for grid_type in ['HMS_HMS','CO_HMS_RLO','CO_HeMS','CO_HeMS_RLO']:
             if not hasattr(self, f'interp_class_{grid_type}'):
                 setattr(self, f'interp_class_{grid_type}', None)
 

--- a/posydon/binary_evol/flow_chart.py
+++ b/posydon/binary_evol/flow_chart.py
@@ -145,6 +145,12 @@ for s1 in STAR_STATES_H_RICH_EVOLVABLE:
     for s2 in STAR_STATES_CO:
         POSYDON_FLOW_CHART[(s1, s2, 'RLO1', 'oRLO1')] = 'step_CO_HMS_RLO'
         POSYDON_FLOW_CHART[(s2, s1, 'RLO2', 'oRLO2')] = 'step_CO_HMS_RLO'
+        
+# He-rich star roche-lobe overflow onto a compact object
+for s1 in STAR_STATES_HE_RICH_EVOLVABLE:
+    for s2 in STAR_STATES_CO:
+        POSYDON_FLOW_CHART[(s1, s2, 'RLO1', 'oRLO1')] = 'step_CO_HeMS_RLO'
+        POSYDON_FLOW_CHART[(s2, s1, 'RLO2', 'oRLO2')] = 'step_CO_HeMS_RLO'
 
 # H-rich star on a detached binary with a compact object
 # that fall outside the grid and has been returned by step_CO_HMS_RLO

--- a/posydon/interpolation/IF_interpolation.py
+++ b/posydon/interpolation/IF_interpolation.py
@@ -1109,7 +1109,8 @@ class MC_Interpolator:
             which = np.zeros_like(zpred, dtype=bool)
             for j in range(len(self.classes[i])):
                 which += zpred == self.classes[i][j]
-            Ypred[which, :] = self.interpolators[i].predict(Xt[which, :])
+            if which.any():
+                Ypred[which, :] = self.interpolators[i].predict(Xt[which, :])
         return Ypred
 
 

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -50,13 +50,13 @@ from posydon.utils.constants import Zsun
 
 
 # 'event' usually 10 but 'detached (Integration failure)' can occur
-HISTORY_MIN_ITEMSIZE = {'state': 30, 'event': 10, 'step_names': 15,
+HISTORY_MIN_ITEMSIZE = {'state': 30, 'event': 10, 'step_names': 20,
                         'S1_state': 31, 'S2_state': 31,
                         'mass_transfer_case': 7,
                         'S1_SN_type': 5, 'S2_SN_type': 5}
 ONELINE_MIN_ITEMSIZE = {'state_i': 30, 'state_f': 30,
                         'event_i': 10, 'event_f': 10,
-                        'step_names_i': 15, 'step_names_f': 15,
+                        'step_names_i': 20, 'step_names_f': 20,
                         'S1_state_i': 31, 'S1_state_f': 31,
                         'S2_state_i': 31, 'S2_state_f': 31,
                         'mass_transfer_case_i': 7, 'mass_transfer_case_f': 7,

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -62,12 +62,12 @@ ONELINE_MIN_ITEMSIZE = {'state_i': 30, 'state_f': 30,
                         'mass_transfer_case_i': 7, 'mass_transfer_case_f': 7,
                         'S1_SN_type': 5, 'S2_SN_type': 5,
                         'interp_class_HMS_HMS' : 15, 'interp_class_CO_HeMS' : 15,
-                        'interp_class_CO_HMS_RLO' : 15}
+                        'interp_class_CO_HMS_RLO' : 15, 'interp_class_CO_HeMS_RLO' : 15}
 
 # BinaryPopulation will enforce a constant metallicity accross all steps that
 # load stellar or binary models by checked this list of steps.
 STEP_NAMES_LOADING_GRIDS = [
-    'step_HMS_HMS', 'step_CO_HeMS', 'step_CO_HMS_RLO', 'step_detached','step_isolated','step_disrupted','step_initially_single', 'step_merged'
+    'step_HMS_HMS', 'step_CO_HeMS', 'step_CO_HMS_RLO', 'step_CO_HeMS_RLO', 'step_detached','step_isolated','step_disrupted','step_initially_single', 'step_merged'
 ]
 
 class BinaryPopulation:

--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -95,6 +95,33 @@
   verbose = False
     # True False
 
+[step_CO_HeMS_RLO]
+  import = ['posydon.binary_evol.MESA.step_mesa', 'CO_HeMS_RLO_step']
+  absolute_import = None
+    # 'package' kwarg for importlib.import_module
+  interpolation_path = None
+    # found by default
+  interpolation_filename = None
+    # found by default
+  interpolation_method = 'linear3c_kNN'
+    # 'nearest_neighbour' 'linear3c_kNN' '1NN_1NN'
+  save_initial_conditions = True
+    # only for interpolation_method='nearest_neighbour'
+  track_interpolation = False
+    # True False
+  stop_method = 'stop_at_max_time'
+    # 'stop_at_end' 'stop_at_max_time' 'stop_at_condition'
+  stop_star = 'star_1'
+    # only for stop_method='stop_at_condition' 'star_1' 'star_2'
+  stop_var_name = None
+    # only for stop_method='stop_at_condition' str
+  stop_value = None
+    # only for stop_method='stop_at_condition' float
+  stop_interpolate = True
+    # True False
+  verbose = False
+    # True False
+
 
 [step_detached]
   import = ['posydon.binary_evol.DT.step_detached', 'detached_step']
@@ -324,6 +351,7 @@
               'interp_class_HMS_HMS',
               'interp_class_CO_HMS_RLO',
               'interp_class_CO_HeMS',
+              'interp_class_CO_HeMS_RLO',
               ]
 
 [SingleStar_1_output]

--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -323,7 +323,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 [BinaryStar_output]
-  extra_columns=['step_names', 'step_times']
+  extra_columns = {'step_names':'string', 'step_times':'float64'}
   # 'step_times' with from posydon.binary_evol.simulationproperties import TimingHooks
 
   # LIST BINARY PROPERTIES

--- a/posydon/visualization/plot_pop.py
+++ b/posydon/visualization/plot_pop.py
@@ -21,9 +21,9 @@ COLORS = ['tab:blue', 'tab:orange', 'tab:green', 'tab:red', 'tab:purple',
 COLORS *= 10
 
 def plot_merger_rate_density(z, rate_density, ylim=(1e-1,4e2), zmax=10., show=True, 
-                             path=None, channels=False, GWTC3=False, **kwargs):
+                             path=None, channels=False, GWTC3=False, label='DCO', **kwargs):
 
-    plt.plot(z[z<zmax], rate_density['total'][z<zmax], label='BBH total', color='black')
+    plt.plot(z[z<zmax], rate_density['total'][z<zmax], label=f'{label} total', color='black')
     if channels:
         for ch in [key for key in rate_density.keys() if key != 'total']:
             if ch != 'total':


### PR DESCRIPTION
This PR solves an outstanding issue from v1; namely, we want eccentric CO-stripped_He binaries emerging from >Zsun HMS-HMS grids to be redirected to step_detached instead of being evolved with circular CO-HeMS grids, which are supposed to be used only in the case of post-common envelope step.

Since I was working on this code, I also implemented an automatic check detection of grid boundaries in step_MESA for all grids.

Here is an example of how an eccentric BH-stripped_He system is redirected to the detached step.
<img width="1352" alt="Screenshot 2023-08-07 at 15 45 09" src="https://github.com/POSYDON-code/POSYDON/assets/32518238/35be3827-ef9f-403b-9838-2b2514e46a8d">

Since I could not easily find a system that after the detached step would lead to CO-HeMS_RLO. I artificially crafted the initial conditions and show here that the changes to POSYDON indeed evolve such systems.
<img width="1291" alt="Screenshot 2023-08-07 at 15 45 51" src="https://github.com/POSYDON-code/POSYDON/assets/32518238/237a4293-e12a-42e1-b9c9-35993756bd07">

I tested that the code runs correctly on a 1K binary pop synth model at 8 metallicities. I found the following unexpected, but correct, way to hit the step_CO_HeMS_RLO. After the step_CE we map to a NS-He-star where the secondary star has mass below ou minimum He-star in the grids (this is ok as the star will become a WD, not supported in v2). The code correctly redirects to step_detach which correctly finds RLO as low mass He-star expands mapping to the step_CO-HeMS_RLO, in this case we map to initail RLO probably suggesting that the evolved He-satar is more compact than an evolved ZAHeMS RLO in the grid.
<img width="1252" alt="Screenshot 2023-08-08 at 10 39 15" src="https://github.com/POSYDON-code/POSYDON/assets/32518238/e9aeca51-6156-457a-ada6-8aeddc8f166c">


EXTRA:
- [x] fixed bug for `interpolation_method = 'nearest_neighbour'`. The interpolated/classified MODEL properties were not stored correctly in MESA step.

