### PR TITLE
Tilt tracking

### DIFF
--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -1181,7 +1181,7 @@ class StepSN(object):
             The corresponding azimuthal angle such that phi=0 is on the Z axis.
 
         tilt :
-            The angle between pre- and post- supernova orbital angular momentum vectors.
+            The angle between pre- and post- supernova orbital angular momentum vectors
             
 
         Parameters
@@ -1523,6 +1523,9 @@ class StepSN(object):
             # For epre=0 (sin_psi=1), reduces to Eq 4, in Kalogera, V. 1996, ApJ, 471, 352
 
             tilt = np.arccos((Vky + Vr * sin_psi) / np.sqrt( Vkz ** 2 + (Vky + Vr * sin_psi) ** 2 ))
+
+            # Track direction of tilt
+            if Vkz < 0: tilt *= -1 
 
             def SNCheck(
                 M_he_star,

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -1424,7 +1424,10 @@ class StepSN(object):
             # Eq 15, Wong, T.-W., Valsecchi, F., Fragos, T., & Kalogera, V. 2012, ApJ, 747, 111
             # orbital separation at the time of the exlosion
             rpre = Apre * (1.0 - epre * np.cos(E_ma))
-
+            
+            true_anomaly = 2 * np.arctan(
+                np.sqrt((1 + epre) / (1 - epre)) * np.tan(E_ma / 2)
+            )
             # load constants in CGS
             G = const.standard_cgrav
 
@@ -1624,18 +1627,43 @@ class StepSN(object):
             # update the binary object which was bound at least before the SN
             if flag_binary:
                 # update the tilt
-                if binary.event == "CC1":
-                    binary.star_1.spin_orbit_tilt = tilt
-                elif binary.event == "CC2":
-                    binary.star_2.spin_orbit_tilt = tilt
-                else:
-                    raise ValueError("This should never happen!")
-
-                # compute new orbital period before reseting the binary properties
+                #Check if this is the first SN
+                first_SN = binary.true_anomaly_first_SN is None
 
                 for key in BINARYPROPERTIES:
-                    if key != 'nearest_neighbour_distance':
+                    if key != 'nearest_neighbour_distance' and key != 'true_anomaly_first_SN':
                         setattr(binary, key, None)
+
+                if first_SN:
+                    # update the tilt
+                    binary.star_1.spin_orbit_tilt_first_SN = tilt
+                    binary.star_2.spin_orbit_tilt_first_SN = tilt
+                    binary.true_anomaly_first_SN = true_anomaly
+                else:
+                    if binary.event == 'CC2':
+                        # Assume progenitor has aligned with the preSN orbital angular momentum
+                        binary.star_2.spin_orbit_tilt_second_SN = tilt
+                        binary.star_1.spin_orbit_tilt_second_SN = get_combined_tilt(
+                            tilt_1 = binary.star_1.spin_orbit_tilt_first_SN, 
+                            tilt_2 = tilt, 
+                            true_anomaly_1 = binary.true_anomaly_first_SN, 
+                            true_anomaly_2 = true_anomaly
+                            )
+                        binary.true_anomaly_SN2 = true_anomaly
+                    elif binary.event == 'CC1':
+                        # Assume progenitor has aligned with the preSN orbital angular momentum
+                        binary.star_1.spin_orbit_tilt_second_SN = tilt
+                        binary.star_2.spin_orbit_tilt_second_SN = get_combined_tilt(
+                            tilt_1 = binary.star_1.spin_orbit_tilt_first_SN, 
+                            tilt_2 = tilt, 
+                            true_anomaly_1 = binary.true_anomaly_first_SN, 
+                            true_anomaly_2 = true_anomaly
+                            )
+                        binary.true_anomaly_second_SN = true_anomaly
+                    else:
+                        raise ValueError("This should never happen!")
+
+                # compute new orbital period before reseting the binary properties
 
                 binary.state = "detached"
                 binary.event = None
@@ -1649,18 +1677,20 @@ class StepSN(object):
                     binary.separation, binary.star_1.mass, binary.star_2.mass)
                 binary.orbital_period = new_orbital_period
                 binary.mass_transfer_case = 'None'
-            else:
-                # update the tilt
-                if binary.event == "CC1":
-                    binary.star_1.spin_orbit_tilt = np.nan
-                elif binary.event == "CC2":
-                    binary.star_2.spin_orbit_tilt = np.nan
-                else:
-                    raise ValueError("This should never happen!")
 
+            else:
                 for key in BINARYPROPERTIES:
                     if key != 'nearest_neighbour_distance':
                         setattr(binary, key, None)
+                # update the tilt
+                if first_SN:
+                    binary.star_1.spin_orbit_tilt_SN1 = np.nan
+                    binary.star_2.spin_orbit_tilt_SN1 = np.nan
+                else:
+                    binary.star_1.spin_orbit_tilt_SN2 = np.nan
+                    binary.star_2.spin_orbit_tilt_SN2 = np.nan
+
+             
                 binary.state = "disrupted"
                 binary.event = None
                 binary.separation = np.nan
@@ -1725,7 +1755,82 @@ class StepSN(object):
             Vkick = 0.0
 
         return Vkick
+    def rotate(axis, angle):
 
+        """Generate rotation matrix to rotate a vector about an arbitrary axis 
+            by a given angle
+
+        Parameters
+        ----------
+        axis : array of length 3
+            Axis to rotate about
+        angle : float
+            Angle, in radians, through which to rotate about axis
+
+        Returns
+        -------
+        rotation_matrix : 3x3 array
+            Array such that rotation_matrix.dot(vector) rotates vector
+            about the given axis by the given angle
+
+        """
+
+        # normalize the axis vector
+        axis = axis / np.linalg.norm(axis)
+        
+
+        # calculate the cosine and sine of the angle
+        cos_theta = np.cos(angle)
+        sin_theta = np.sin(angle)
+        
+        # construct the rotation matrix
+        rotation_matrix = np.array([
+            [cos_theta + axis[0]**2 * (1 - cos_theta),
+            axis[0] * axis[1] * (1 - cos_theta) - axis[2] * sin_theta,
+            axis[0] * axis[2] * (1 - cos_theta) + axis[1] * sin_theta],
+            [axis[1] * axis[0] * (1 - cos_theta) + axis[2] * sin_theta,
+            cos_theta + axis[1]**2 * (1 - cos_theta),
+            axis[1] * axis[2] * (1 - cos_theta) - axis[0] * sin_theta],
+            [axis[2] * axis[0] * (1 - cos_theta) - axis[1] * sin_theta,
+            axis[2] * axis[1] * (1 - cos_theta) + axis[0] * sin_theta,
+            cos_theta + axis[2]**2 * (1 - cos_theta)]
+        ])
+        
+        
+        return rotation_matrix
+        
+    def get_combined_tilt(tilt_1, tilt_2, true_anomaly_1, true_anomaly_2):
+        """Get the combined spin-orbit-tilt after two supernovae, assuming
+        the spin as not realigned with the orbital angular momentum after
+        SN1
+
+            Parameters
+            ----------
+            tilt_1: float
+                Angle, in radians, through which the orbital plane was tilted 
+                by SN1
+            tilt_2: float
+                Angle, in radians, through which the orbital plane was tilted 
+                by SN2
+            true_anomaly_1: float
+                Angle, in radians, of the true anomaly at the moment of SN1
+            true_anomaly_2: float
+                Angle, in radians, of the true anomaly at the moment of SN2
+
+
+            Returns
+            -------
+            combined_tilt: float
+                Angle, in radians, between the spin and orbital angular momentum
+                after SN2
+        """
+        z_prime = rotate((1,0,0), tilt_1).dot((0,0,1))
+        x_prime = rotate(z_prime, true_anomaly_2-true_anomaly_1).dot((1,0,0))
+
+        cos_tilt = np.dot((0,0,1),rotate(x_prime, tilt_2).dot(z_prime))
+        combined_tilt = np.arccos(cos_tilt)
+        return combined_tilt
+    
     def C_abundance_for_H_stars(self, CO_core_mass):
         """Get the C abundance for a H-star given it's CO core mass."""
         return 0.20/CO_core_mass + 0.15

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -1625,13 +1625,13 @@ class StepSN(object):
                                   verbose=self.verbose)
 
             # update the binary object which was bound at least before the SN
+            #Check if this is the first SN
+            first_SN = binary.true_anomaly_first_SN is None
             if flag_binary:
                 # update the tilt
-                #Check if this is the first SN
-                first_SN = binary.true_anomaly_first_SN is None
 
                 for key in BINARYPROPERTIES:
-                    if key != 'nearest_neighbour_distance' and key != 'true_anomaly_first_SN':
+                    if key != 'nearest_neighbour_distance':
                         setattr(binary, key, None)
 
                 if first_SN:
@@ -1649,7 +1649,7 @@ class StepSN(object):
                             true_anomaly_1 = binary.true_anomaly_first_SN, 
                             true_anomaly_2 = true_anomaly
                             )
-                        binary.true_anomaly_SN2 = true_anomaly
+                        binary.true_anomaly_second_SN = true_anomaly
                     elif binary.event == 'CC1':
                         # Assume progenitor has aligned with the preSN orbital angular momentum
                         binary.star_1.spin_orbit_tilt_second_SN = tilt
@@ -1684,11 +1684,11 @@ class StepSN(object):
                         setattr(binary, key, None)
                 # update the tilt
                 if first_SN:
-                    binary.star_1.spin_orbit_tilt_SN1 = np.nan
-                    binary.star_2.spin_orbit_tilt_SN1 = np.nan
+                    binary.star_1.spin_orbit_tilt_first_SN = np.nan
+                    binary.star_2.spin_orbit_tilt_first_SN = np.nan
                 else:
-                    binary.star_1.spin_orbit_tilt_SN2 = np.nan
-                    binary.star_2.spin_orbit_tilt_SN2 = np.nan
+                    binary.star_1.spin_orbit_tilt_first_SN = np.nan
+                    binary.star_2.spin_orbit_tilt_first_SN = np.nan
 
              
                 binary.state = "disrupted"

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -1626,13 +1626,13 @@ class StepSN(object):
                                   verbose=self.verbose)
 
             # update the binary object which was bound at least before the SN
+            #Check if this is the first SN
+            first_SN = binary.true_anomaly_first_SN is None
             if flag_binary:
                 # update the tilt
-                #Check if this is the first SN
-                first_SN = binary.true_anomaly_first_SN is None
 
                 for key in BINARYPROPERTIES:
-                    if key != 'nearest_neighbour_distance' and key != 'true_anomaly_first_SN':
+                    if key != 'nearest_neighbour_distance':
                         setattr(binary, key, None)
 
                 if first_SN:
@@ -1650,7 +1650,7 @@ class StepSN(object):
                             true_anomaly_1 = binary.true_anomaly_first_SN, 
                             true_anomaly_2 = true_anomaly
                             )
-                        binary.true_anomaly_SN2 = true_anomaly
+                        binary.true_anomaly_second_SN = true_anomaly
                     elif binary.event == 'CC1':
                         # Assume progenitor has aligned with the preSN orbital angular momentum
                         binary.star_1.spin_orbit_tilt_second_SN = tilt
@@ -1685,11 +1685,11 @@ class StepSN(object):
                         setattr(binary, key, None)
                 # update the tilt
                 if first_SN:
-                    binary.star_1.spin_orbit_tilt_SN1 = np.nan
-                    binary.star_2.spin_orbit_tilt_SN1 = np.nan
+                    binary.star_1.spin_orbit_tilt_first_SN = np.nan
+                    binary.star_2.spin_orbit_tilt_first_SN = np.nan
                 else:
-                    binary.star_1.spin_orbit_tilt_SN2 = np.nan
-                    binary.star_2.spin_orbit_tilt_SN2 = np.nan
+                    binary.star_1.spin_orbit_tilt_first_SN = np.nan
+                    binary.star_2.spin_orbit_tilt_first_SN = np.nan
 
              
                 binary.state = "disrupted"

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -167,6 +167,8 @@ class BinaryStar:
             self.true_anomaly_SN1 = None
         if not hasattr(self, 'true_anomaly_second_SN'):
             self.true_anomaly_SN2 = None
+        if not hasattr(self, 'first_SN_already_occurred'):
+            self.first_SN_already_occurred = False
         # if not hasattr(self, 'V_sys'):
         #     self.V_sys = [0, 0, 0]
         

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -162,6 +162,11 @@ class BinaryStar:
             self.inspiral_time = None
         if not hasattr(self, 'mass_transfer_case'):
             self.mass_transfer_case = 'None'
+
+        if not hasattr(self, 'true_anomaly_first_SN'):
+            self.true_anomaly_SN1 = None
+        if not hasattr(self, 'true_anomaly_second_SN'):
+            self.true_anomaly_SN2 = None
         # if not hasattr(self, 'V_sys'):
         #     self.V_sys = [0, 0, 0]
         

--- a/posydon/binary_evol/singlestar.py
+++ b/posydon/binary_evol/singlestar.py
@@ -137,8 +137,10 @@ class SingleStar:
         # these quantities are updated in step_SN.py
         if not hasattr(self, 'natal_kick_array'):
             self.natal_kick_array = [None] * 4
-        if not hasattr(self, 'spin_orbit_tilt'):
-            self.spin_orbit_tilt = None
+        if not hasattr(self, 'spin_orbit_tilt_first_SN'):
+            self.spin_orbit_tilt_SN1 = None
+        if not hasattr(self, 'spin_orbit_tilt_second_SN'):
+            self.spin_orbit_tilt_SN2 = None
         if not hasattr(self, 'f_fb'):
             self.f_fb = None
         if not hasattr(self, 'SN_type'):

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -2668,3 +2668,47 @@ def convert_metallicity_to_string(Z):
     if not Z in valid_Z:
         raise ValueError(f'Metallicity {Z} not supported! Available metallicities in POSYDON v2 are {valid_Z}.')
     return f'{Z:1.1e}'.replace('.0','')
+
+def rotate(axis, angle):
+
+        """Generate rotation matrix to rotate a vector about an arbitrary axis 
+            by a given angle
+
+        Parameters
+        ----------
+        axis : array of length 3
+            Axis to rotate about
+        angle : float
+            Angle, in radians, through which to rotate about axis
+
+        Returns
+        -------
+        rotation_matrix : 3x3 array
+            Array such that rotation_matrix.dot(vector) rotates vector
+            about the given axis by the given angle
+
+        """
+
+        # normalize the axis vector
+        axis = axis / np.linalg.norm(axis)
+        
+
+        # calculate the cosine and sine of the angle
+        cos_theta = np.cos(angle)
+        sin_theta = np.sin(angle)
+        
+        # construct the rotation matrix
+        rotation_matrix = np.array([
+            [cos_theta + axis[0]**2 * (1 - cos_theta),
+            axis[0] * axis[1] * (1 - cos_theta) - axis[2] * sin_theta,
+            axis[0] * axis[2] * (1 - cos_theta) + axis[1] * sin_theta],
+            [axis[1] * axis[0] * (1 - cos_theta) + axis[2] * sin_theta,
+            cos_theta + axis[1]**2 * (1 - cos_theta),
+            axis[1] * axis[2] * (1 - cos_theta) - axis[0] * sin_theta],
+            [axis[2] * axis[0] * (1 - cos_theta) - axis[1] * sin_theta,
+            axis[2] * axis[1] * (1 - cos_theta) + axis[0] * sin_theta,
+            cos_theta + axis[2]**2 * (1 - cos_theta)]
+        ])
+        
+        
+        return rotation_matrix


### PR DESCRIPTION
This pull request adds combined tilt tracking to step_SN, as well as the required angles to binarystar and singlestar. 
After the first SN1, the spin-orbit misalignment for both objects is just the tilt from SN1. At SN2, we assume the remaining non-compact object realigns with the orbital angular momentum. After SN2, it's spin-orbit misalignment is the tilt from SN1, but the compact object formed in SN2 has a combined misalignment from both SN:

Taking $\hat{x}$ and $\hat{z}$ to be the X and Z unit vectors of the SN1 coordinate system, and $\hat{L}=\hat{z}$ and $\hat{L}'$ to be the unit vectors in the direction of the orbital angular momentum pre-SN1 and post-SN2 respectively, we can write:

$\hat{L}' =  R_{\hat{x}' }(\theta_{SN2})R_{\hat{x} }(\theta_{SN1})\hat{L}$

where 

$\hat{x}' = R_{\hat{z}'} (f_{SN2} - f_{SN1})\hat{x}$
and

$\hat{z}' = R_{\hat{x}}(\theta_{SN1})\hat{z}$

are the transformed unit vectors in the SN2 coordinate frame, 
$R_{\vec{u}}(t)$ denotes rotation about the vector $\vec{u}$ by an angle $t$, and $f_{SN1}$ and $f_{SN2}$ are the true anomalies of the binary just before the first and second SN, respectively. Then the angle between the first compact object's spin and the binary orbital angular momentum is given by
$\cos(\Omega_{1,SN2}) = \hat{z} \cdot \hat{L}' $
