### PR TITLE
Konst removing init imports

### DIFF
--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -24,7 +24,7 @@ from scipy.optimize import root
 from posydon.utils.data_download import PATH_TO_POSYDON_DATA
 from posydon.binary_evol.binarystar import BINARYPROPERTIES
 from posydon.binary_evol.singlestar import STARPROPERTIES
-from posydon.interpolation import GRIDInterpolator
+from posydon.interpolation.interpolation import GRIDInterpolator
 from posydon.interpolation.data_scaling import DataScaler
 from posydon.utils.common_functions import (
     bondi_hoyle,
@@ -1038,7 +1038,7 @@ class detached_step:
                 raise Exception("State not recognized!")
         else:
             raise Exception("Non existent companion has not a recognized value!")
-        
+
         def get_star_data(binary, star1, star2, htrack,
                           co, copy_prev_m0=None, copy_prev_t0=None):
             """Get and interpolate the properties of stars.
@@ -1149,10 +1149,10 @@ class detached_step:
         # get the matched data of two stars, respectively
         interp1d_sec, m0, t0 = get_star_data(
             binary, secondary, primary, secondary.htrack, co=False)
-        
+
         primary_not_normal = (primary.co) or (self.non_existent_companion in [1,2])
-        primary_normal = (not primary.co) and self.non_existent_companion == 0 
-        
+        primary_normal = (not primary.co) and self.non_existent_companion == 0
+
         if primary_not_normal:
             # copy the secondary star except mass which is of the primary,
             # and radius, mdot, Idot = 0
@@ -1164,8 +1164,8 @@ class detached_step:
                 binary, primary, secondary, primary.htrack, False)[0]
         else:
             raise Exception("During matching primary is either should be either normal or not normal. `non_existent_companion` should be zero.")
-        
-        
+
+
         if interp1d_sec is None or interp1d_pri is None:
             # binary.event = "END"
             binary.state += " (GridMatchingFailed)"
@@ -1829,7 +1829,7 @@ class detached_step:
 
             if primary.state == "massless_remnant":
                 pass
-            
+
             elif primary.co:
                 mdot_acc = np.atleast_1d(bondi_hoyle(
                     binary, primary, secondary, slice(-len(t), None),

--- a/posydon/binary_evol/DT/step_disrupted.py
+++ b/posydon/binary_evol/DT/step_disrupted.py
@@ -8,40 +8,11 @@ __authors__ = [
 ]
 
 
-import os
-import numpy as np
-from scipy.integrate import solve_ivp
-from scipy.interpolate import PchipInterpolator
-from scipy.optimize import minimize
-from scipy.optimize import root
-
 from posydon.utils.data_download import PATH_TO_POSYDON_DATA
-from posydon.binary_evol.binarystar import BINARYPROPERTIES
-from posydon.binary_evol.singlestar import STARPROPERTIES
-from posydon.interpolation import GRIDInterpolator
-from posydon.interpolation.data_scaling import DataScaler
-from posydon.utils.common_functions import (
-    bondi_hoyle,
-    orbital_period_from_separation,
-    orbital_separation_from_period,
-    roche_lobe_radius,
-    check_state_of_star,
-    PchipInterpolator2
-)
-from posydon.binary_evol.flow_chart import (STAR_STATES_CC)
-import posydon.utils.constants as const
-from posydon.binary_evol.DT.step_detached import detached_step
 from posydon.binary_evol.DT.step_isolated import IsolatedStep
 
-import warnings
-
-from posydon.binary_evol.flow_chart import (STAR_STATES_ALL,
-    STAR_STATES_CO,
-    STAR_STATES_H_RICH,
-    STAR_STATES_HE_RICH,
-    STAR_STATES_NOT_CO
-    )
-
+from posydon.binary_evol.flow_chart import (
+    STAR_STATES_H_RICH, STAR_STATES_HE_RICH)
 
 
 LIST_ACCEPTABLE_STATES_FOR_HMS = ["H-rich_Core_H_burning"]

--- a/posydon/binary_evol/DT/step_initially_single.py
+++ b/posydon/binary_evol/DT/step_initially_single.py
@@ -8,40 +8,11 @@ __authors__ = [
 ]
 
 
-import os
-import numpy as np
-from scipy.integrate import solve_ivp
-from scipy.interpolate import PchipInterpolator
-from scipy.optimize import minimize
-from scipy.optimize import root
-
 from posydon.utils.data_download import PATH_TO_POSYDON_DATA
-from posydon.binary_evol.binarystar import BINARYPROPERTIES
-from posydon.binary_evol.singlestar import STARPROPERTIES
-from posydon.interpolation import GRIDInterpolator
-from posydon.interpolation.data_scaling import DataScaler
-from posydon.utils.common_functions import (
-    bondi_hoyle,
-    orbital_period_from_separation,
-    orbital_separation_from_period,
-    roche_lobe_radius,
-    check_state_of_star,
-    PchipInterpolator2
-)
-from posydon.binary_evol.flow_chart import (STAR_STATES_CC)
-import posydon.utils.constants as const
-from posydon.binary_evol.DT.step_detached import detached_step
 from posydon.binary_evol.DT.step_isolated import IsolatedStep
 
-import warnings
-
-from posydon.binary_evol.flow_chart import (STAR_STATES_ALL,
-    STAR_STATES_CO,
-    STAR_STATES_H_RICH,
-    STAR_STATES_HE_RICH,
-    STAR_STATES_NOT_CO
-    )
-
+from posydon.binary_evol.flow_chart import (
+    STAR_STATES_H_RICH, STAR_STATES_HE_RICH)
 
 
 LIST_ACCEPTABLE_STATES_FOR_HMS = ["H-rich_Core_H_burning"]
@@ -63,7 +34,7 @@ class InitiallySingleStep(IsolatedStep):
         grid_name_strippedHe=None,
         path=PATH_TO_POSYDON_DATA,
         *args, **kwargs):
-        
+
         super().__init__(
         grid_name_Hrich=grid_name_Hrich,
         grid_name_strippedHe=grid_name_strippedHe,

--- a/posydon/binary_evol/DT/step_isolated.py
+++ b/posydon/binary_evol/DT/step_isolated.py
@@ -18,7 +18,6 @@ from scipy.optimize import root
 from posydon.utils.data_download import PATH_TO_POSYDON_DATA
 from posydon.binary_evol.binarystar import BINARYPROPERTIES
 from posydon.binary_evol.singlestar import STARPROPERTIES
-from posydon.interpolation import GRIDInterpolator
 from posydon.interpolation.data_scaling import DataScaler
 from posydon.utils.common_functions import (
     bondi_hoyle,

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -8,36 +8,17 @@ __authors__ = [
 ]
 
 
-import os
 import numpy as np
-from scipy.integrate import solve_ivp
-from scipy.interpolate import PchipInterpolator
-from scipy.optimize import minimize
-from scipy.optimize import root
 
 from posydon.utils.data_download import PATH_TO_POSYDON_DATA
-from posydon.binary_evol.binarystar import BINARYPROPERTIES
 from posydon.binary_evol.singlestar import STARPROPERTIES
 from posydon.binary_evol.singlestar import properties_massless_remnant
-from posydon.interpolation import GRIDInterpolator
-from posydon.interpolation.data_scaling import DataScaler
-from posydon.utils.common_functions import (
-    bondi_hoyle,
-    orbital_period_from_separation,
-    orbital_separation_from_period,
-    roche_lobe_radius,
-    check_state_of_star,
-    PchipInterpolator2
-)
-from posydon.binary_evol.flow_chart import (STAR_STATES_CC)
-import posydon.utils.constants as const
-from posydon.binary_evol.DT.step_detached import detached_step
+from posydon.utils.common_functions import check_state_of_star
 from posydon.binary_evol.DT.step_isolated import IsolatedStep
 
 import warnings
 
-from posydon.binary_evol.flow_chart import (STAR_STATES_ALL,
-    STAR_STATES_CO,
+from posydon.binary_evol.flow_chart import (
     STAR_STATES_H_RICH,
     STAR_STATES_HE_RICH,
     STAR_STATES_NOT_CO

--- a/posydon/binary_evol/__init__.py
+++ b/posydon/binary_evol/__init__.py
@@ -1,5 +1,0 @@
-from .binarystar import BinaryStar
-from .singlestar import SingleStar
-from .simulationproperties import SimulationProperties
-from .DT.step_detached import detached_step
-from .MESA.step_mesa import MesaGridStep

--- a/posydon/interpolation/__init__.py
+++ b/posydon/interpolation/__init__.py
@@ -1,2 +1,0 @@
-from .interpolation import GRIDInterpolator, fscale
-from .IF_interpolation import IFInterpolator

--- a/posydon/popsyn/__init__.py
+++ b/posydon/popsyn/__init__.py
@@ -1,1 +1,0 @@
-from .binarypopulation import BinaryPopulation

--- a/posydon/popsyn/independent_sample.py
+++ b/posydon/popsyn/independent_sample.py
@@ -14,7 +14,7 @@ __authors__ = [
 
 import numpy as np
 from scipy.stats import truncnorm
-from posydon.utils import rejection_sampler
+from posydon.utils.common_functions import rejection_sampler
 
 
 def generate_independent_samples(orbital_scheme, **kwargs):

--- a/posydon/popsyn/star_formation_history.py
+++ b/posydon/popsyn/star_formation_history.py
@@ -14,8 +14,8 @@ import scipy as sp
 from scipy import stats
 from posydon.utils.data_download import PATH_TO_POSYDON_DATA
 from posydon.utils.constants import age_of_universe
-from posydon.utils import (rejection_sampler, histogram_sampler,
-                           read_histogram_from_file)
+from posydon.utils.common_functions import (
+    rejection_sampler, histogram_sampler, read_histogram_from_file)
 from posydon.utils.constants import Zsun
 from scipy.interpolate import interp1d
 from astropy.cosmology import Planck15 as cosmology

--- a/posydon/tests/binary_evol/CE/test_CEE.py
+++ b/posydon/tests/binary_evol/CE/test_CEE.py
@@ -1,13 +1,10 @@
 import unittest
-import warnings
 import os
 import numpy as np
 from posydon.utils.common_functions import PATH_TO_POSYDON
-from posydon.utils import constants as const
 from posydon.utils import common_functions as cf
 from posydon.binary_evol.binarystar import BinaryStar
 from posydon.binary_evol.singlestar import SingleStar
-from posydon.binary_evol.simulationproperties import SimulationProperties
 from posydon.binary_evol.CE.step_CEE import StepCEE
 
 # spaces are read '\\ ' instead of ' '

--- a/posydon/tests/binary_evol/SN/test_step_SN.py
+++ b/posydon/tests/binary_evol/SN/test_step_SN.py
@@ -4,7 +4,6 @@ from posydon.utils.common_functions import PATH_TO_POSYDON
 from posydon.binary_evol.SN.step_SN import StepSN
 from posydon.binary_evol.binarystar import BinaryStar
 from posydon.binary_evol.singlestar import SingleStar
-from posydon.binary_evol import SimulationProperties
 
 import numpy as np
 import os

--- a/posydon/tests/popsyn/test_binarypopulation.py
+++ b/posydon/tests/popsyn/test_binarypopulation.py
@@ -4,7 +4,7 @@ import numpy as np
 import os
 
 from posydon.popsyn.binarypopulation import BinaryPopulation
-from posydon.binary_evol import SimulationProperties
+from posydon.binary_evol.simulationproperties import SimulationProperties
 from posydon.binary_evol.flow_chart import flow_chart
 from posydon.binary_evol.step_end import step_end
 

--- a/posydon/tests/utils/test_configfile.py
+++ b/posydon/tests/utils/test_configfile.py
@@ -57,7 +57,7 @@ class TestConfigFile(unittest.TestCase):
 
         # check `print` and `str` methods
         print(str(self))
-        print(len(str(self).split("\m")))
+        print(len(str(self).split("\m")))   # TODO: Should this be r"\m"?
 
     def test_getters(self):
         """Test the two ways to get entries."""

--- a/posydon/utils/__init__.py
+++ b/posydon/utils/__init__.py
@@ -1,1 +1,0 @@
-from .common_functions import *


### PR DESCRIPTION
This PR
- removes imports from all `__init__.py` files, in hope of resolving future cyclic imports
- corrects import statements where aliases were used (e.g., `from posydon.binary_evol import SimulationProperties` is not valid anymore, since `SimulationProperties` is in `posydon.binary_evol.simulationproperties`)
- removes a significant fraction of unused imports in all POSYDON scripts
- adds a TODO note to a possible mistake