### PR TITLE
Correcting the boolean logic in deciding single/binary evolution in the detached step

### DIFF
--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -923,13 +923,21 @@ class detached_step:
         KEYS = self.KEYS
         KEYS_POSITIVE = self.KEYS_POSITIVE
 
-        if binary.star_1 is None or binary.star_1.state == "massless_remnant":
-            self.non_existent_companion = 1
-        if binary.star_2 is None or binary.star_2.state == "massless_remnant":
-            self.non_existent_companion = 2
+        companion_1_exists = (binary.star_1 is not None
+                              and binary.star_1.state != "massless_remnant")
+        companion_2_exists = (binary.star_2 is not None
+                              and binary.star_2.state != "massless_remnant")
+
+        if companion_1_exists:
+            if companion_2_exists:                  # to evolve a binary star
+                self.non_existent_companion = 0
+            else:                                   # star1 is a single star
+                self.non_existent_companion = 2
         else:
-            # detached step of an actual binary
-            self.non_existent_companion = 0
+            if companion_2_exists:                  # star2 is a single star
+                self.non_existent_companion = 1
+            else:                                   # no star in the system
+                raise Exception("There is no star to evolve. Who summoned me?")
 
         if self.non_existent_companion == 0: #no isolated evolution, detached step of an actual binary
             # the primary in a real binary is potential compact object, or the more evolved star


### PR DESCRIPTION
This PR solves the issue identified by @celiotine : the detached step is not handling well cases of isolated evolution after mergers.