### PR TITLE
Using a child process to copy data from work to storage directory

### DIFF
--- a/bin/posydon-run-grid
+++ b/bin/posydon-run-grid
@@ -11,6 +11,7 @@ import random
 import string
 import itertools
 import stat
+import time
 
 import numpy as np
 import pandas
@@ -123,10 +124,16 @@ def parse_commandline():
     parser.add_argument("--keep_photos", action="store_true", default=False,
                         help="Do not delete photos at run completion")
 
+    parser.add_argument("--job_start", type=int, default=0,
+                        help="Start time of the job (in seconds)")
+
+    parser.add_argument("--job_end", type=int, default=600,
+                        help="End time of the job (in seconds)")
+
     args = parser.parse_args()
 
     if args.grid_type not in ['fixed', 'dynamic']:
-        raise parser.error("--run-type must be either grid or sample")
+        raise parser.error("--run-type must be either fixed or dynamic")
 
     # if we are running a dynamic grid then these arguments are required otherwise
     # they are not
@@ -397,6 +404,31 @@ def create_star_formation(mass, work_dir, star_inlist_project, initial_z=None, n
 
     return
 
+def move_mesa_output(work_dir, final_dir, copyinstead=False):
+    """Moves the data from the working directory to the final directory.
+    Parameters:
+        work_dir:
+            Working directory (i.e. where the mesa exectuable should run)
+        final_dir:
+            When completed where would you like the output to go
+        copyinstead:
+            Indicates that the files should be copied instead of moved
+    """
+    if not work_dir == final_dir:
+        if os.path.isdir(final_dir):
+            print ("folder "+ final_dir +" exists, replacing with new data")
+            sys.stdout.flush()
+            shutil.rmtree(final_dir)
+        if copyinstead:
+            print ("copy data from " + work_dir+ " to "+ final_dir)
+            shutil.copy2(work_dir, final_dir)
+        else:
+            print ("move data from " + work_dir+ " to "+ final_dir)
+            shutil.move(work_dir, final_dir)
+        sys.stdout.flush()
+
+    return
+
 def run_mesa(mesa_executable, work_dir, final_dir, **kwargs):
     """Provides minor utility for actually spawning the mesa job for each grid
 
@@ -411,32 +443,47 @@ def run_mesa(mesa_executable, work_dir, final_dir, **kwargs):
     outfile_name = kwargs.pop('outfile_name', 'out.txt')
     keep_profiles = kwargs.pop('keep_profiles', False)
     keep_photos = kwargs.pop('keep_photos', False)
+    job_time = kwargs.pop('job_end', 600) - kwargs.pop('job_start', 0)
 
     os.chdir(work_dir)
-    os.system("{0} &> {1}".format(mesa_executable, os.path.join(work_dir, outfile_name)))
-
-    if not keep_profiles:
-        if os.path.exists(os.path.join(work_dir, 'LOGS')):
-            os.chmod(os.path.join(work_dir, 'LOGS'), stat.S_IRWXU  | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH )
-            os.system("rm LOGS/profile*")
-        if os.path.exists(os.path.join(work_dir, 'LOGS1')):
-            os.chmod(os.path.join(work_dir, 'LOGS1'), stat.S_IRWXU  | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH )
-            os.system("rm LOGS1/profile*")
-        if os.path.exists(os.path.join(work_dir, 'LOGS2')):
-            os.chmod(os.path.join(work_dir, 'LOGS2'), stat.S_IRWXU  | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH )
-            os.system("rm LOGS2/profile*")
-    if os.path.exists(os.path.join(work_dir, '.mesa_temp_cache')): os.system("rm -rf .mesa_temp_cache")
-
-    if not keep_photos:
-        os.system("rm -rf photos*")
-
     if not work_dir == final_dir:
-        if os.path.isdir(final_dir):
-            print ("folder "+ final_dir +" exists, replacing with new data")
-            sys.stdout.flush()
-            shutil.rmtree(final_dir)
+        child_ID = os.fork()
+    else:
+        child_ID = 0.1
+    if child_ID>0:
+        #parent process: run MESA and do the clean up in the working directory
+        os.system("{0} &> {1}".format(mesa_executable, os.path.join(work_dir, outfile_name)))
 
-        shutil.move(work_dir, final_dir)
+        if not keep_profiles:
+            if os.path.exists(os.path.join(work_dir, 'LOGS')):
+                os.chmod(os.path.join(work_dir, 'LOGS'), stat.S_IRWXU  | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH )
+                os.system("rm LOGS/profile*")
+            if os.path.exists(os.path.join(work_dir, 'LOGS1')):
+                os.chmod(os.path.join(work_dir, 'LOGS1'), stat.S_IRWXU  | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH )
+                os.system("rm LOGS1/profile*")
+            if os.path.exists(os.path.join(work_dir, 'LOGS2')):
+                os.chmod(os.path.join(work_dir, 'LOGS2'), stat.S_IRWXU  | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH )
+                os.system("rm LOGS2/profile*")
+        if os.path.exists(os.path.join(work_dir, '.mesa_temp_cache')): os.system("rm -rf .mesa_temp_cache")
+
+        if not keep_photos:
+            os.system("rm -rf photos*")
+
+        if child_ID>=1:
+            #kill child process, because it is no longer needed
+            os.kill(child_ID, 9)
+        move_mesa_output(work_dir, final_dir)
+    elif child_ID==0:
+        #child process: waits till short before the job will get killed by slurm to copy the data beforehand and exit this process after the copy finished
+        if job_time>300:
+            #if job last longer than 5 minutes (300 seconds) get remaining time till 5 minutes before its end
+            wait_time = job_time-300
+        else:
+            #otherwise wait 1 minute
+            wait_time = 60
+        time.sleep(wait_time)
+        move_mesa_output(work_dir, final_dir, copyinstead=True)
+        sys.exit(0)
 
     os.chdir(final_dir)
     print("Done")

--- a/bin/posydon-run-grid
+++ b/bin/posydon-run-grid
@@ -421,7 +421,7 @@ def move_mesa_output(work_dir, final_dir, copyinstead=False):
             shutil.rmtree(final_dir)
         if copyinstead:
             print ("copy data from " + work_dir+ " to "+ final_dir)
-            shutil.copy2(work_dir, final_dir)
+            shutil.copytree(work_dir, final_dir)
         else:
             print ("move data from " + work_dir+ " to "+ final_dir)
             shutil.move(work_dir, final_dir)
@@ -735,8 +735,8 @@ def run_grid_point(grid, star1_formation, star2_formation,
 
     # run the binary exectuable
     run_mesa(args.mesa_binary_executable, work_dir, final_dir,
-             keep_profiles=args.keep_profiles,
-             keep_photos=args.keep_photos)
+             keep_profiles=args.keep_profiles, keep_photos=args.keep_photos,
+             job_start=args.job_start, job_end=args.job_end)
 
     # find out what happened
     mesa_result = extract_mesa_results(final_dir)
@@ -872,8 +872,8 @@ if __name__ == '__main__':
                 create_star_formation(grid_param_dict['initial_mass'], work_dir, inlist_step)
             run_mesa(args.mesa_star1_executable, work_dir, final_dir,
                      outfile_name='out_star1_formation_step{0}.txt'.format(index),
-                     keep_profiles=args.keep_profiles,
-                     keep_photos=args.keep_photos)
+                     keep_profiles=args.keep_profiles, keep_photos=args.keep_photos,
+                     job_start=args.job_start, job_end=args.job_end)
 
         sys.exit(0)
 

--- a/bin/posydon-setup-grid
+++ b/bin/posydon-setup-grid
@@ -1025,6 +1025,8 @@ if __name__ == '__main__':
                                               psycris_inifile = run_parameters["psycris_inifile"],
                                               keep_profiles=run_parameters['keep_profiles'],
                                               keep_photos=run_parameters['keep_photos'])
+    if 'work_dir' in slurm.keys() and not(slurm['work_dir'] == ''):
+        command_line += ' --temporary-directory '+slurm['work_dir']
 
     # now we need to know how this person plans to run the above created
     # command. As a shell script? As a SLURM submission? In some other way?

--- a/bin/posydon-setup-grid
+++ b/bin/posydon-setup-grid
@@ -1025,6 +1025,8 @@ if __name__ == '__main__':
                                               psycris_inifile = run_parameters["psycris_inifile"],
                                               keep_profiles=run_parameters['keep_profiles'],
                                               keep_photos=run_parameters['keep_photos'])
+    if args.submission_type == 'slurm':
+        command_line += ' --job_start $SLURM_JOB_START_TIME --job_end $SLURM_JOB_END_TIME'
     if 'work_dir' in slurm.keys() and not(slurm['work_dir'] == ''):
         command_line += ' --temporary-directory '+slurm['work_dir']
 

--- a/grid_params/grid_params.ini
+++ b/grid_params/grid_params.ini
@@ -26,6 +26,9 @@ account={ACCOUNT}
 ; wall-time
 walltime='2-00:00:00'
 
+; work-directory: place, where MESA writes during runtime
+work_dir={WORK_DIRECTORY}
+
 ;email
 email={YOUR_EMAIL_ADDRESS}
 


### PR DESCRIPTION
This PR replaces [PR#143](https://github.com/POSYDON-code/POSYDON/pull/143)

All started with hard drive issues on the cluster in Geneva. I got asked, whether we can use a different drive during the run and copy/move our stuff we need after the simulation finished at the end to the final storage place. The data at the storage during the run will get deleted (or at least offered to the OS to be deleted) after the run finished automatically.

It turned out, that we already have a functionality for this in the `posydon-run-grid`, there we can set a working directory with the argument `--temporary-directory`.
But the current implementation would leave all the data only in the working directory in case the simulation fails. As long as the python process keeps intact on the failure the data will get moved. Hence, all cases issued at the lowest level, where only MESA crashes, are fine. For all cases, where the issue emerges from a higher level, the python process will fail before the MESA one. Currently, there is only one case this happens: if slurm is killing the job because of running into the wall time. Hence, we need to capture those cases and still move our data before it gets deleted by clean up jobs.

Usually it would be better to capture this cases on the signal level. Unfortunately this conflicts with MPI and the python version of a system call, which we us for running MESA. Therefore, I now implemented a way to capture only the wall time cancellation. To do so, I create a child process of our python process before it runs MESA. This child process only has the information of the python process at the moment it forks out. Hence, all information, e.g. when the simulation will get terminated, has to be available at this moment. For getting the information about the wall time cancellation, I simply take the data from the slurm handler when it will try to kill the job because of the wall time. With this information I send the child process into sleep until short before the wall time is reached to copy the data in case the simulation is still running at this point (I don't move the data, because it might cause conflicts of still open files).

- [x] Put file movement into its own function. [`posydon-run-grid`]
- [x] Introduce new argument `work_dir` in slurm section of the ini file and add its value to be the `--temporary-directory` on run. [`grid_params.ini`, `posydon-setup-grid`]
- [x] Give the SLURM start and end time of the job as arguments to our python-run script. [`posydon-setup-grid`, `posydon-run-grid`]
- [x] Fork out a child process which sleeps for most of the time and copies the data if needed. [`posydon-run-grid`]
- [x] Removing the child process in case the parent process ended to ensure that there won't be a ghost process remaining. [`posydon-run-grid`]
- [x] Provide new ini files in the MESA-INLISTS submodule, see [PR#27](https://github.com/POSYDON-code/POSYDON-MESA-INLISTS/pull/23)
- [x] The 4 test cases (Normal run, run ended by abort or segmentation fault, killed by slurms wall time handler) worked.