### PR TITLE
Adding an option to create a VH diagram w/ BinaryStar objects

### DIFF
--- a/posydon/visualization/VH_diagram/Presenter.py
+++ b/posydon/visualization/VH_diagram/Presenter.py
@@ -328,9 +328,9 @@ class Presenter:
         "S2_profile": "",
     }
 
-    def __init__(self, filename, path="./"):
+    def __init__(self, filename, path="./", binary=False):
         """Initialize a Presenter instance."""
-        self._model = SimulationModel(filename=filename, path=path)
+        self._model = SimulationModel(filename=filename, path=path, binary=binary)
         self._model.load_csv()
 
         self._main_window = MainWindow()

--- a/posydon/visualization/VH_diagram/SimulationModel.py
+++ b/posydon/visualization/VH_diagram/SimulationModel.py
@@ -14,11 +14,12 @@ import os
 class SimulationModel:
     """Model containing the dataset of simulations."""
 
-    def __init__(self, filename, path="./"):
+    def __init__(self, filename, path="./", binary=False):
         """Initialize a SimulationModel instance."""
         self._df = None
         self.path = path
         self.filename = filename
+        self.binary = binary
 
     def load_csv(self):
         """Load dataframe as CSV with .gz compression."""
@@ -41,4 +42,8 @@ class SimulationModel:
             Copy of a sub-dataframe with binary_index == index
 
         """
-        return self._df.loc[index].copy()
+
+        if self.binary:
+            return self._df.copy()
+        else:
+            return self._df.loc[index].copy()

--- a/posydon/visualization/VHdiagram.py
+++ b/posydon/visualization/VHdiagram.py
@@ -48,7 +48,7 @@ class VHdiagram:
         )  # Check if there is instance of QApplication
         if not self._app:  # if not, create it
             self._app = QApplication([])
-        
+
         self._presenter = Presenter(filename=filename, path=path, binary=binary)
 
         self._presenter.present(index, presentMode)

--- a/posydon/visualization/VHdiagram.py
+++ b/posydon/visualization/VHdiagram.py
@@ -49,7 +49,6 @@ class VHdiagram:
         if not self._app:  # if not, create it
             self._app = QApplication([])
         
-        print(binary)
         self._presenter = Presenter(filename=filename, path=path, binary=binary)
 
         self._presenter.present(index, presentMode)

--- a/posydon/visualization/VHdiagram.py
+++ b/posydon/visualization/VHdiagram.py
@@ -39,6 +39,7 @@ class VHdiagram:
         *,
         presentMode=PresenterMode.DETAILED,
         displayMode=DisplayMode.WINDOW,
+        binary = False,
         figsize=(10, 8)
     ):
         """Initialize a VHdiagram instance."""
@@ -47,8 +48,9 @@ class VHdiagram:
         )  # Check if there is instance of QApplication
         if not self._app:  # if not, create it
             self._app = QApplication([])
-
-        self._presenter = Presenter(filename=filename, path=path)
+        
+        print(binary)
+        self._presenter = Presenter(filename=filename, path=path, binary=binary)
 
         self._presenter.present(index, presentMode)
 


### PR DESCRIPTION
The Van den Heuvel diagram (VHD) code currently lacks the capability to plot a VHD for a `BinaryStar` object.

This PR introduces slight modifications to that code to enable it to work with `BinaryStar` objects.

When calling `VHdiagram("file.h5")`, `VHdiagram` creates a `Presenter`, which in turn creates a `SimulationModel`. The latter object retrieves data from a `.h5` file by a `binary_index` and copies it into memory. This is meant to work with a population `.h5` file (with multiple binary systems), but does not work for a binary star `.h5` file that contains a single binary system.

This PR introduces a keyword argument to `VHdiagram`: a boolean called `binary`, that ultimately is passed to `SimulationModel`. If `binary = True`, the code will instead simply copy data from the `.h5` file without extracting it by `binary_index`. Passing `binary = False` leads to the default behavior for population files.

This has been tested and is functional.

This issue was initially raised by a user.