### PR TITLE
Concatenate fix for casting current scalar_names

### DIFF
--- a/posydon/binary_evol/singlestar.py
+++ b/posydon/binary_evol/singlestar.py
@@ -314,16 +314,13 @@ class SingleStar:
         for name in scalar_names:
             if hasattr(self, name):
                 if name == 'natal_kick_array':
-                    natal_kick_array = np.array(getattr(self, name), dtype=np.float64)
+                    natal_kick_array = getattr(self, name)
                     for i in range(4):
                         col_name = prefix+name+'_{}'.format(int(i))
                         oneline_df[col_name] = [natal_kick_array[i]]
-                elif (name == 'spin_orbit_tilt') | (name == 'f_fb'):
-                    oneline_df[prefix+name] = [np.float64(getattr(self, name))]
                 else:
                     oneline_df[prefix+name] = [getattr(self, name)]
         return oneline_df
-
 
     def __repr__(self):
         """Return the object representation when print is called."""

--- a/posydon/binary_evol/singlestar.py
+++ b/posydon/binary_evol/singlestar.py
@@ -314,13 +314,16 @@ class SingleStar:
         for name in scalar_names:
             if hasattr(self, name):
                 if name == 'natal_kick_array':
-                    natal_kick_array = getattr(self, name)
+                    natal_kick_array = np.array(getattr(self, name), dtype=np.float64)
                     for i in range(4):
                         col_name = prefix+name+'_{}'.format(int(i))
                         oneline_df[col_name] = [natal_kick_array[i]]
+                elif (name == 'spin_orbit_tilt') | (name == 'f_fb'):
+                    oneline_df[prefix+name] = [np.float64(getattr(self, name))]
                 else:
                     oneline_df[prefix+name] = [getattr(self, name)]
         return oneline_df
+
 
     def __repr__(self):
         """Return the object representation when print is called."""

--- a/posydon/popsyn/io.py
+++ b/posydon/popsyn/io.py
@@ -304,7 +304,7 @@ def clean_binary_oneline_df(oneline_df, extra_binary_dtypes_user=None,
         if key in scalar_keys:
             common_dtype_dict[key] = SCALAR_NAMES_DTYPES.get(
                                         key.replace('S1_', '').replace('S2_', '') )
-        if key in binary_keys:
+        elif key in binary_keys:
             common_dtype_dict[key] = BP_comb_extras_dict.get( strip_prefix_and_suffix(key) )
         elif key in S1_keys:
             common_dtype_dict[key] = SP_comb_S1_dict.get( strip_prefix_and_suffix(key) )

--- a/posydon/popsyn/io.py
+++ b/posydon/popsyn/io.py
@@ -141,7 +141,7 @@ SCALAR_NAMES_DTYPES = {
     'natal_kick_array_3': 'float64',
     'SN_type':'string',
     'f_fb': 'float64',
-    'sping_orbit_tilt': 'float64',
+    'spin_orbit_tilt': 'float64',
 }
 
 
@@ -277,6 +277,7 @@ def clean_binary_oneline_df(oneline_df, extra_binary_dtypes_user=None,
     SP_comb_S2_dict = {**STARPROPERTIES_DTYPES, **EXTRA_STAR_COLUMNS_DTYPES, 
                        **SCALAR_NAMES_DTYPES, **extra_S2_dtypes_user}
     
+
     # All default & user passed keys which we have mappings for
     binary_keys = set( [key + '_i' for key in BP_comb_extras_dict.keys()] 
                      + [key + '_f' for key in BP_comb_extras_dict.keys()] )
@@ -284,16 +285,25 @@ def clean_binary_oneline_df(oneline_df, extra_binary_dtypes_user=None,
                  + ['S1_' + key + '_f' for key in SP_comb_S1_dict.keys()] )
     S2_keys = set( ['S2_' + key + '_i' for key in SP_comb_S2_dict.keys()]
                  + ['S2_' + key + '_f' for key in SP_comb_S2_dict.keys()] )
-    
+    scalar_keys = set( ['S1_' + key for key in SCALAR_NAMES_DTYPES.keys()]
+                     + ['S2_' + key for key in SCALAR_NAMES_DTYPES.keys()] )
+                        
     # Find common keys between the binary_df and our column-dtype mapping
-    common_keys =  oneline_columns & ( binary_keys | S1_keys | S2_keys )
+    common_keys =  oneline_columns & ( binary_keys 
+                                     | S1_keys
+                                     | S2_keys 
+                                     | scalar_keys)
     
 
     # Create a dict with column-dtype mapping only for columns in binary_df
     common_dtype_dict = {}
     # helper function to remove the '_i' and '_f' 
-    strip_prefix_and_suffix = lambda key : key.strip('_i').strip('_f').strip('S1_').strip('S2_')
+    strip_prefix_and_suffix = lambda key : key.replace('_i', '').replace('_f', '') \
+                                             .replace('S1_', '').replace('S2_', '')
     for key in common_keys:
+        if key in scalar_keys:
+            common_dtype_dict[key] = SCALAR_NAMES_DTYPES.get(
+                                        key.replace('S1_', '').replace('S2_', '') )
         if key in binary_keys:
             common_dtype_dict[key] = BP_comb_extras_dict.get( strip_prefix_and_suffix(key) )
         elif key in S1_keys:

--- a/posydon/popsyn/io.py
+++ b/posydon/popsyn/io.py
@@ -134,6 +134,15 @@ EXTRA_BINARY_COLUMNS_DTYPES = {
 # no default extras for history attributes
 EXTRA_STAR_COLUMNS_DTYPES = {}
 
+SCALAR_NAMES_DTYPES = {
+    'natal_kick_array_0': 'float64',
+    'natal_kick_array_1': 'float64',
+    'natal_kick_array_2': 'float64',
+    'natal_kick_array_3': 'float64',
+    'SN_type':'string',
+    'f_fb': 'float64',
+    'sping_orbit_tilt': 'float64',
+}
 
 
 def clean_binary_history_df(binary_df, extra_binary_dtypes_user=None, 
@@ -264,9 +273,9 @@ def clean_binary_oneline_df(oneline_df, extra_binary_dtypes_user=None,
                            **extra_binary_dtypes_user}
     # combine columns for star 1 and star 2 history with extras
     SP_comb_S1_dict = {**STARPROPERTIES_DTYPES, **EXTRA_STAR_COLUMNS_DTYPES, 
-                       **extra_S1_dtypes_user}
+                       **SCALAR_NAMES_DTYPES, **extra_S1_dtypes_user}
     SP_comb_S2_dict = {**STARPROPERTIES_DTYPES, **EXTRA_STAR_COLUMNS_DTYPES, 
-                       **extra_S2_dtypes_user}
+                       **SCALAR_NAMES_DTYPES, **extra_S2_dtypes_user}
     
     # All default & user passed keys which we have mappings for
     binary_keys = set( [key + '_i' for key in BP_comb_extras_dict.keys()] 


### PR DESCRIPTION
This fixes issue https://github.com/POSYDON-code/POSYDON/issues/161, where the files would not concatenate after a run due to the types of several scalar_name columns between different oneline_df's being different.

However, a better solution needs to be found for these scalar_name variables such that they're always cast to the same type as they're used in the code.
See issue https://github.com/POSYDON-code/POSYDON/issues/155 for mention of storage consistency of some of these variables as well.