### PR TITLE
pipeline updates for reruns

### DIFF
--- a/bin/run-pipeline
+++ b/bin/run-pipeline
@@ -452,7 +452,7 @@ def copy_ini_file(grid_path, rerun_type, destination, cluster):
     elif rerun_type == 'thermohaline_mixing':
         replace_text = "development-22c1bb9e730343558c3e70984a99b3fc1f3c346e"
     elif rerun_type == 'HeMB_MTLp_mesh':
-        replace_text = "development-72d61123df1a669cebbf5811d6f1398221b1f081" #TODO:update
+        replace_text = "development-435d16c9158e4608530f21b8169ce6f31160e23e"
     elif rerun_type == 'more_mesh':
         replace_text = "development-72d61123df1a669cebbf5811d6f1398221b1f081" #TODO:update
     elif rerun_type == 'conv_bdy_weight':

--- a/bin/run-pipeline
+++ b/bin/run-pipeline
@@ -451,12 +451,12 @@ def copy_ini_file(grid_path, rerun_type, destination, cluster):
         replace_text = "development-22c1bb9e730343558c3e70984a99b3fc1f3c346e"
     elif rerun_type == 'thermohaline_mixing':
         replace_text = "development-22c1bb9e730343558c3e70984a99b3fc1f3c346e"
-    elif rerun_type == 'HeMB_MTLp_mesh':
+    elif rerun_type == 'HeMB_MLTp_mesh':
         replace_text = "development-435d16c9158e4608530f21b8169ce6f31160e23e"
     elif rerun_type == 'more_mesh':
-        replace_text = "development-72d61123df1a669cebbf5811d6f1398221b1f081" #TODO:update
+        replace_text = "development-435d16c9158e4608530f21b8169ce6f31160e23e"
     elif rerun_type == 'conv_bdy_weight':
-        replace_text = "development-72d61123df1a669cebbf5811d6f1398221b1f081" #TODO:update
+        replace_text = "development-435d16c9158e4608530f21b8169ce6f31160e23e"
     elif rerun_type == 'other': # e.g. 'envelope_mass_limit', 'fe_core_infall_limit'
         # this rerun uses the default inlist commit
         return
@@ -553,7 +553,7 @@ def logic_rerun(grid, rerun_type):
     elif rerun_type == 'thermohaline_mixing':
         termination_flags = TF1_POOL_ERROR
         new_mesa_flag = {'thermohaline_coeff' : 17.5}
-    elif rerun_type == 'HeMB_MTLp_mesh':
+    elif rerun_type == 'HeMB_MLTp_mesh':
         termination_flags = TF1_POOL_ERROR
     elif rerun_type == 'more_mesh':
         termination_flags = TF1_POOL_ERROR

--- a/bin/run-pipeline
+++ b/bin/run-pipeline
@@ -451,8 +451,12 @@ def copy_ini_file(grid_path, rerun_type, destination, cluster):
         replace_text = "development-22c1bb9e730343558c3e70984a99b3fc1f3c346e"
     elif rerun_type == 'thermohaline_mixing':
         replace_text = "development-22c1bb9e730343558c3e70984a99b3fc1f3c346e"
-    elif rerun_type == 'no_magnetic_braking':
-        replace_text = "development-22c1bb9e730343558c3e70984a99b3fc1f3c346e" #TODO:update
+    elif rerun_type == 'HeMB_MTLp_mesh':
+        replace_text = "development-72d61123df1a669cebbf5811d6f1398221b1f081" #TODO:update
+    elif rerun_type == 'more_mesh':
+        replace_text = "development-72d61123df1a669cebbf5811d6f1398221b1f081" #TODO:update
+    elif rerun_type == 'conv_bdy_weight':
+        replace_text = "development-72d61123df1a669cebbf5811d6f1398221b1f081" #TODO:update
     elif rerun_type == 'other': # e.g. 'envelope_mass_limit', 'fe_core_infall_limit'
         # this rerun uses the default inlist commit
         return
@@ -549,7 +553,12 @@ def logic_rerun(grid, rerun_type):
     elif rerun_type == 'thermohaline_mixing':
         termination_flags = TF1_POOL_ERROR
         new_mesa_flag = {'thermohaline_coeff' : 17.5}
-    elif rerun_type == 'no_magnetic_braking':
+    elif rerun_type == 'HeMB_MTLp_mesh':
+        termination_flags = TF1_POOL_ERROR
+    elif rerun_type == 'more_mesh':
+        termination_flags = TF1_POOL_ERROR
+        new_mesa_flag = {'mesh_Pgas_div_P_exponent' : 2, 'max_allowed_nz' : 50000} # may put this in a MESA-inlist PR
+    elif rerun_type == 'conv_bdy_weight':
         N_runs = len(grid)
         runs_to_rerun = []
         for i in range(N_runs):
@@ -569,9 +578,11 @@ def logic_rerun(grid, rerun_type):
                 with open(out_txt_path, "r") as log_file:
                     log_lines = log_file.readlines()
                 for line in log_lines:
-                    if "turn on magnetic braking" in line:
+                    if (("STOP prepare_for_new_try: bad num omega" in line) or
+                        ("Segmentation fault" in line)):
                         runs_to_rerun += [i]
         runs_to_rerun = np.array(runs_to_rerun)
+        new_mesa_flag = {'convective_bdy_weight' : 0}
     elif rerun_type == 'envelope_mass_limit': # maybe 'fe_core_infall_limit' as well?
         runs_to_rerun = None # implement logic
     else:

--- a/bin/run-pipeline
+++ b/bin/run-pipeline
@@ -451,6 +451,8 @@ def copy_ini_file(grid_path, rerun_type, destination, cluster):
         replace_text = "development-22c1bb9e730343558c3e70984a99b3fc1f3c346e"
     elif rerun_type == 'thermohaline_mixing':
         replace_text = "development-22c1bb9e730343558c3e70984a99b3fc1f3c346e"
+    elif rerun_type == 'no_magnetic_braking':
+        replace_text = "development-22c1bb9e730343558c3e70984a99b3fc1f3c346e" #TODO:update
     elif rerun_type == 'other': # e.g. 'envelope_mass_limit', 'fe_core_infall_limit'
         # this rerun uses the default inlist commit
         return
@@ -547,6 +549,29 @@ def logic_rerun(grid, rerun_type):
     elif rerun_type == 'thermohaline_mixing':
         termination_flags = TF1_POOL_ERROR
         new_mesa_flag = {'thermohaline_coeff' : 17.5}
+    elif rerun_type == 'no_magnetic_braking':
+        N_runs = len(grid)
+        runs_to_rerun = []
+        for i in range(N_runs):
+            dirname = grid.MESA_dirs[i].decode('utf-8')
+            if not os.path.isdir(dirname):
+                # TODO: handle the case when grids were moved location
+                raise ValueError(f'Grid directory not found at {dirname}')
+            if "single_HMS" in dirname:
+                out_txt_path = os.path.join(dirname,
+                                            "out_star1_formation_step0.txt")
+            elif "single_HeMS" in dirname:
+                out_txt_path = os.path.join(dirname,
+                                            "out_star1_formation_step2.txt")
+            else:
+                out_txt_path = os.path.join(dirname, "out.txt")
+            if (out_txt_path is not None) and os.path.isfile(out_txt_path):
+                with open(out_txt_path, "r") as log_file:
+                    log_lines = log_file.readlines()
+                for line in log_lines:
+                    if "turn on magnetic braking" in line:
+                        runs_to_rerun += [i]
+        runs_to_rerun = np.array(runs_to_rerun)
     elif rerun_type == 'envelope_mass_limit': # maybe 'fe_core_infall_limit' as well?
         runs_to_rerun = None # implement logic
     else:


### PR DESCRIPTION
- add logic to identify runs
  - [x] **HeMB_MTLp_mesh**
  - [x] **more_mesh**
  - [x] **conv_bdy_weight**
- replace MESA-INLISTS commits
  - [x] **HeMB_MTLp_mesh** after [PR#27](https://github.com/POSYDON-code/POSYDON-MESA-INLISTS/pull/27) and [PR#28](https://github.com/POSYDON-code/POSYDON-MESA-INLISTS/pull/28) got merged
  - [x] **more_mesh** after a PR on [MESA-INLISTS](https://github.com/POSYDON-code/POSYDON-MESA-INLISTS) is done
  - [x] **conv_bdy_weight** use same as for **more_mesh**