### PR TITLE
V1 python_utils fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ install_requires = [
     'pandas == 1.3.0',
     'scikit-learn == 0.21.3',
     'matplotlib ==  3.5.0',
+    'more-itertools == 9.1.0',
     'matplotlib-label-lines == 0.3.8',
     'PyQt5 == 5.15.3',
     'h5py == 3.7.0',

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ install_requires = [
     'psutil == 5.6.7',
     'tqdm == 4.48.2',
     'tables == 3.6.1',
+    'python_utils == 3.5.2',
     'progressbar2 == 4.0.0',
 ]
 


### PR DESCRIPTION
This PR sets the version of `python_utils` to v3.5.2, which is the last version which supports python v3.7. 
This way `progressbar2` which has a dependency on `python_utils>=3.0.0` does not import an unsupported version.

It fixes Issue #190.