### PR TITLE
Option for losing mass during cee that leads to merging

### DIFF
--- a/posydon/binary_evol/CE/step_CEE.py
+++ b/posydon/binary_evol/CE/step_CEE.py
@@ -828,7 +828,7 @@ class StepCEE(object):
                 # GMMej/(lambda * R)  = a_CE * [ - GM1M2/(2a_i) +  G(M1-Mej)*M2/(2a_f) ]
                 # with a_f = separation_postCEE
                 # and solving it for Mejected
-                Mejected_donor = alpha_CE * (m1_i * const.Msun * m2_i * const.Msun)/2. * (1./separation_i - 1./separation_postCEE) \
+                Mejected_donor = alpha_CE * (m1_i * const.Msun * m2_i * const.Msun)/2. * (1./separation_postCEE - 1./separation_i) \
                           / ( (m1_i * const.Msun/(lambda1_CE*radius1 * const.Rsun)) + ((alpha_CE*m2_i * const.Msun)/(2.*separation_postCEE))  )
 
                 Mejected_donor = Mejected / const.Msun # to go from cgs to solar masses again

--- a/posydon/binary_evol/CE/step_CEE.py
+++ b/posydon/binary_evol/CE/step_CEE.py
@@ -827,7 +827,7 @@ class StepCEE(object):
                 # Ebind(Mejected) = a_CE*D_orb =>
                 # GMMej/(lambda * R)  = a_CE * [ - GM1M2/(2a_i) +  G(M1-Mej)*M2/(2a_f) ]
                 # with a_f = separation_postCEE
-                # and solvind it for Mejected
+                # and solving it for Mejected
                 Mejected_donor = alpha_CE * (m1_i * const.Msun * m2_i * const.Msun)/2. * (1./separation_i - 1./separation_postCEE) \
                           / ( (m1_i * const.Msun/(lambda1_CE*radius1 * const.Rsun)) + ((alpha_CE*m2_i * const.Msun)/(2.*separation_postCEE))  )
 

--- a/posydon/binary_evol/CE/step_CEE.py
+++ b/posydon/binary_evol/CE/step_CEE.py
@@ -42,7 +42,7 @@ from posydon.binary_evol.binarystar import BINARYPROPERTIES
 from posydon.binary_evol.singlestar import STARPROPERTIES
 from posydon.utils.common_functions import PATH_TO_POSYDON
 from posydon.utils.common_functions import check_state_of_star
-from posydon.utils.common_functions import calculate_lambda_from_profile
+from posydon.utils.common_functions import calculate_lambda_from_profile, calculate_Mejected_for_integrated_binding_energy
 
 
 warnings.simplefilter('always', UserWarning)
@@ -783,7 +783,7 @@ class StepCEE(object):
                                             'co_core_mass',
                                             'co_core_radius'
 
-                        ]) 
+                        ])
                 elif star_type == "not_giant_companion":
                     continue
                 else:
@@ -826,88 +826,79 @@ class StepCEE(object):
                 print("Rdonor core vs RLdonor core = ", rc1_i, RL1)
                 print("Rcompanion vs RLcompanion= ", rc2_i, RL2)
 
+            Mejected_donor = 0.0
+            Mejected_comp = 0.0
+
             if mass_loss_during_CEE_merged:
                 # we calculate the ejected mass from part of the commone envelope, using
                 # a_f = separation_postCEE so that one of the cores (or MS star) is filling its inner Roche lobe,
                 # and assuming that lambda(Menvelope) ~ lamda(Mejected) although
                 # Mejected < Menvelope (e.g. see Fig1 of Dewi+Tauris2000)
 
-                separation_for_inner_RLO1 = rc1_i / cf.roche_lobe_radius(mc1_i/mc2_i, a_orb=1)
-                separation_for_inner_RLO2 = rc2_i / cf.roche_lobe_radius(mc2_i/mc1_i, a_orb=1)
-
-                separation_postCEE = max( separation_for_inner_RLO1, separation_for_inner_RLO2 ) * const.Rsun
-
-                if verbose:
-                    print("separation_postCEE (for the calculation of Mejected for the merger): ",separation_postCEE/ const.Rsun , "in Rsun")
-                    print("which is the max of RLO1 or RLO2 of the inner cores: ", separation_for_inner_RLO1 ,  separation_for_inner_RLO2, "in Rsun")
-
-                if not double_CE:
-                    # Ebind(Mejected) = a_CE*D_orb =>
-                    # GMMej/(lambda * R)  = a_CE * [ - GM1M2/(2a_i) +  G(M1-Mej)*M2/(2a_f) ]
-                    # with a_f = separation_postCEE
-                    # and solving it for Mejected
-                    Mejected_donor = alpha_CE * (m1_i * const.Msun * m2_i * const.Msun)/2. * (1./separation_postCEE - 1./separation_i) \
-                              / ( (m1_i * const.Msun/(lambda1_CE*radius1 * const.Rsun)) + ((alpha_CE*m2_i * const.Msun)/(2.*separation_postCEE))  )
-
-                    Mejected_donor = Mejected_donor / const.Msun # to go from cgs to solar masses again
+                if not double_CE and donor.profile is None:
+                    Mejected_donor = 0.0
                     Mejected_comp = 0.0
+                    warnings.warn("mass_loss_during_CEE_merged == True, but no profile found for the donor star. Proceeding with no partial mass ejection.")
+                elif double_CE and (donor.profile is None or comp_star.profile is None):
+                    Mejected_comp = 0.0
+                    Mejected_comp = 0.0
+                    warnings.warn("mass_loss_during_CEE_merged == True, but not profile found the donor or companion star in double_CE. Proceeding with no partial mass ejection.")
 
-                    if Mejected_donor > m1_i  - mc1_i:
-                        Mejected_donor = (m1_i  - mc1_i) -0.01 # at least this value of envelope is left.
-                        warnings.warn("Mejected_donor in normal CEE is found to be more that the initial envelope. Reduced to initial_envelope - 0.01 Msun")
+                else:
 
-                else: # in double_CE
+                    separation_for_inner_RLO1 = rc1_i / cf.roche_lobe_radius(mc1_i/mc2_i, a_orb=1)
+                    separation_for_inner_RLO2 = rc2_i / cf.roche_lobe_radius(mc2_i/mc1_i, a_orb=1)
 
-                    # Assuming that the ratio of ejected mass of each (common) envelope
-                    # is the same as the ratio of the initial envelope masses:
-                    # the root of the mass lost for each is the solution of a quadratic algebraic equation
-
-                    WF = (m1_i  - mc1_i)/ (m2_i - mc2_i) # weight factor:
-                                                        # = Mdonor,envelope / Mcomp,envelope == Mejected_donor / Mejected_comp
-
-                    # Mejected_comp = Mejected_donor / WF
-                    # A*Mejected_donor^2 + B*Mejected_donor + C = 0
-
-                    A = alpha_CE / (WF*2.*separation_postCEE)
-                    B = ( ( - alpha_CE*m1_i * const.Msun/ (WF*2.*separation_postCEE)) - (alpha_CE*m2_i * const.Msun/ (2.*separation_postCEE)) \
-                        - (m1_i * const.Msun/ (lambda1_CE*radius1 * const.Rsun)) - (m2_i * const.Msun/ (WF*lambda2_CE*radius2 * const.Rsun)))
-                    C = alpha_CE * (m1_i * const.Msun * m2_i * const.Msun)/2. * (1./separation_postCEE - 1./separation_i)
-                    roots = np.roots([A,B,C])
-                    if min( np.real(roots[0]), np.real(roots[1]) ) < 0.:
-                        root = max( np.real(roots[0]), np.real(roots[1]) ) # if one root is negative, the other is considered the physical solution
-                    elif max( np.real(roots[0]), np.real(roots[1]) ) > m1_i  - mc1_i: # if one root is more positive than the Menvelope that we allow to ejected
-                                                                                     # then the other is considered the physical solution
-                        root = min( np.real(roots[0]), np.real(roots[1]) )
-
-                    Mejected_donor = root  / const.Msun # to go from cgs to solar masses again
-                    Mejected_comp = Mejected_donor / WF
+                    separation_before_merger = max( separation_for_inner_RLO1, separation_for_inner_RLO2 ) * const.Rsun
 
                     if verbose:
-                        print("The roots are: ", roots / const.Msun, "in Msun")
-                        print("so Mejecta_donor = ", Mejected_donor, "in Msun compared to its initial envelope =",  m1_i  - mc1_i)
-                        print("so Mejecta_comp = ", Mejected_comp, "in Msun compared to its initial envelope =",  m2_i  - mc2_i)
+                        print("separation_before_merger (for the calculation of Mejected for the merger): ",separation_before_merger/ const.Rsun , "in Rsun")
+                        print("which is the max of RLO1 or RLO2 of the inner cores: ", separation_for_inner_RLO1 ,  separation_for_inner_RLO2, "in Rsun")
 
-                    if not ( (Mejected_donor <= m1_i  - mc1_i) and (Mejected_comp <= m2_i  - mc2_i) ):
-                        raise Exception("Mejected_donor in double CEE with mass_loss_during_CEE_merged is found more than Menvelope")
-                    if not (Mejected_donor >= 0.):
-                        raise Exception("The root of the equation in double CEE with mass_loss_during_CEE_merged is found negative")
+                    E_orb_used_up_to_inner_RLOF = alpha_CE * ( - const.standard_cgrav * m1_i * const.Msun * m2_i * const.Msun/(2. * separation_i) + \
+                             const.standard_cgrav * mc1_i  * const.Msun * mc2_i  * const.Msun/(2. * separation_before_merger) )
 
+                    # We assume "lambda_from_profile_gravitational_plus_internal_minus_recombination"
+                    if not double_CE:
+                        Mejected_donor = calculate_Mejected_for_integrated_binding_energy(donor.profile, E_orb_used_up_to_inner_RLOF, mc1_i, rc1_i, m1_i, radius1)
 
-                    if (Mejected_donor > m1_i  - mc1_i) or (Mejected_comp > m2_i  - mc2_i):
-                        print("MANOS", Mejected_donor > m1_i  - mc1_i, Mejected_comp > m2_i  - mc2_i)
-                        Mejected_donor = (m1_i  - mc1_i) -0.01 # at least this value of envelope is left.
-                        Mejected_comp = (m2_i  - mc2_i) -0.01
-                        warnings.warn("Mejected of at least one star in double CEE is found to be more that the initial envelope. Reduced both to their initial_envelope - 0.01 Msun")
+                    else: # in double_CE
 
-                donor.mass = m1_i - Mejected_donor
-                donor.log_R = np.nan
-                comp_star.mass = m2_i - Mejected_comp
-                comp_star.log_R = np.nan
-                if donor_type == 'CO_core':
-                    donor.he_core_mass = m1_i - Mejected_donor
-                    donor.he_core_radius = np.nan
-                    comp_star.he_core_mass = m2_i - Mejected_comp
-                    comp_star.he_core_radius = np.nan
+                        # Assuming that the ratio of orbital energy used for the partial ejection of each (common) envelope
+                        # is the same as the ratio of the initial envelope masses:
+
+                        WF = (m1_i  - mc1_i)/ (m2_i - mc2_i  +  m1_i  - mc1_i) # weight factor for 1:
+                                                            # = Mdonor,envelope / Mcomp,envelope
+                        Eorb_for_partial_ej_1 = E_orb_used_up_to_inner_RLOF * WF
+                        Mejected_donor = calculate_Mejected_for_integrated_binding_energy(donor.profile, Eorb_for_partial_ej_1, mc1_i, rc1_i, m1_i, radius1)
+
+                        Eorb_for_partial_ej_2 = E_orb_used_up_to_inner_RLOF * (1. - WF)
+                        Mejected_comp = calculate_Mejected_for_integrated_binding_energy(comp_star.profile, Eorb_for_partial_ej_2, mc2_i, rc2_i, m2_i, radius2)
+
+                if verbose:
+                    print("Mejecta_donor = ", Mejected_donor, "in Msun compared to its initial envelope =",  m1_i  - mc1_i)
+                    print("Mejecta_comp = ", Mejected_comp, "in Msun compared to its initial envelope =",  m2_i  - mc2_i)
+                '''
+                if not ( (Mejected_donor <= m1_i  - mc1_i) and (Mejected_comp <= m2_i  - mc2_i) ):
+                    raise Exception("Mejected_donor in double CEE with mass_loss_during_CEE_merged is found more than Menvelope")
+                if not (Mejected_donor >= 0.):
+                    raise Exception("The root of the equation in double CEE with mass_loss_during_CEE_merged is found negative")
+                '''
+
+                if (Mejected_donor > m1_i  - mc1_i) or (Mejected_comp > m2_i  - mc2_i):
+                    Mejected_donor = (m1_i  - mc1_i) -0.01 # at least this value of envelope is left.
+                    Mejected_comp = (m2_i  - mc2_i) -0.01
+                    warnings.warn("Mejected of at least one star in double CEE is found to be more that the initial envelope. Reduced both to their initial_envelope - 0.01 Msun")
+
+            donor.mass = m1_i - Mejected_donor
+            donor.log_R = np.nan
+            comp_star.mass = m2_i - Mejected_comp
+            comp_star.log_R = np.nan
+            if donor_type == 'CO_core':
+                donor.he_core_mass = m1_i - Mejected_donor
+                donor.he_core_radius = np.nan
+                comp_star.he_core_mass = m2_i - Mejected_comp
+                comp_star.he_core_radius = np.nan
 
             if verbose:
                 print("The mass loss during merging_CEE is: ", mass_loss_during_CEE_merged)

--- a/posydon/binary_evol/CE/step_CEE.py
+++ b/posydon/binary_evol/CE/step_CEE.py
@@ -783,7 +783,7 @@ class StepCEE(object):
                                             'co_core_mass',
                                             'co_core_radius'
 
-                        ])
+                        ]) 
                 elif star_type == "not_giant_companion":
                     continue
                 else:

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -2629,7 +2629,7 @@ def calculate_Mejected_for_integrated_binding_energy(profile, Ebind_threshold,
         U_energy = U_energy + specific_internal_energy[i]*donor_dm[i]*const.Msun
         Ebind_so_far = Grav_energy + factor_internal_energy * U_energy
         i=i+1
-    ind_threshold = i
+    ind_threshold = i-1
 
     if donor_mass[ind_threshold]< mc1_i or  donor_radius[ind_threshold]<rc1_i:
         warnings.warn("partial mass ejected found more than the envelope mass")

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -486,7 +486,7 @@ def bondi_hoyle(binary, accretor, donor, idx=-1, wind_disk_criteria=True,
         default: True, see [5]_
     scheme : str
         There are different options:
-        
+
         - 'Hurley+2002' : following [3]_
         - 'Kudritzki+2000' : following [7]_
 

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -2620,7 +2620,7 @@ def calculate_Mejected_for_integrated_binding_energy(profile, Ebind_threshold,
     i = 0
     Ebind_so_far = 0.0 # the integration from surface going inwards of the binding energy (negative in principle)
 
-    while abs(Ebind_so_far) < Ebind_threshold:
+    while (abs(Ebind_so_far) < Ebind_threshold) and (i<len(donor_mass)):
         Grav_energy_of_cell = (-const.standard_cgrav * donor_mass[i]
                                * const.Msun * donor_dm[i]*const.Msun
                                / (donor_radius[i]*const.Rsun))
@@ -2628,10 +2628,10 @@ def calculate_Mejected_for_integrated_binding_energy(profile, Ebind_threshold,
         Grav_energy = Grav_energy + Grav_energy_of_cell
         U_energy = U_energy + specific_internal_energy[i]*donor_dm[i]*const.Msun
         Ebind_so_far = Grav_energy + factor_internal_energy * U_energy
-        ind_threshold = i
         i=i+1
+    ind_threshold = i
 
-    if donor_mass[ind_threshold]< mc1_i or  donor_radius[i]<rc1_i:
+    if donor_mass[ind_threshold]< mc1_i or  donor_radius[ind_threshold]<rc1_i:
         warnings.warn("partial mass ejected found more than the envelope mass")
         print("M_ejected, M_envelope = ", donor_mass[0] - donor_mass[ind_threshold], donor_mass[0] - mc1_i)
         donor_mass[ind_threshold] = mc1_i


### PR DESCRIPTION
We allow for the possiblity of mass loss during step_CEE, even in the case it leads to oMerging1/2. So we reduce the envelope mass before going to step_CEE, assuming that some of the envelope was indeed ejected during CEE, although in the end the binary did not avoid merging (due to inner RLOF of the core(s))

"mass_loss_during_CEE_merged": False # If False, then no mass loss from this step for a merged star
                                              # If True, then we remove mass according to the alpha-lambda prescription
                                              # assuming a final separation where the inner core RLOF starts.


# we calculate the ejected mass from part of the commone envelope, using
                # a_f = separation_postCEE so that one of the cores (or MS star) is filling its inner Roche lobe,
                # and assuming that lambda(Menvelope) ~ lamda(Mejected) although
                # Mejected < Menvelope (e.g. see Fig1 of Dewi+Tauris2000)

# in double_CE
                    # Assuming that the ratio of ejected mass of each (common) envelope
                    # is the same as the ratio of the initial envelope masses:
                    # the root of the mass lost for each is the solution of a quadratic algebraic equation

We also assume the radius of the surface of the pre-merging stars is np.nan