### PR TITLE
Updates in installation instructions in the V1 documentation

### DIFF
--- a/docs/install/install.rst
+++ b/docs/install/install.rst
@@ -5,22 +5,19 @@ Installation
 ############
 
 The easiest way to start with POSYDON is to install it from Anaconda
-(Automatic Installation), and call an executable script that downloads the grid
-data automatically (Automatic Data Download).
+(Recommended way), and call an executable script that downloads the grid
+data automatically.
 
 Alternatively, if you are interested in modifying the code, you can install
-POSYDON manually through `github` (Manual Installation). You can still use the
-automatic script to download the data, however, if you are about to modify the
-grid data, you can get them using the `git-lfs` module (Manual Data Download).
+POSYDON manually through `github` (Manual Installation). Below we describe both
+ways.
 
-Below we describe both ways.
+=======================================================
+Installing POSYDON v1.0.0 from Anaconda (Recommend way)
+=======================================================
 
-==========================================================
-Recommended way (Automatic installation and Data Download)
-==========================================================
-
-Installing POSYDON v1.0.0 from Anaconda (Automatic Installation)
-----------------------------------------------------------------
+Installation
+------------
 
 We recommend to install the Python distribution Anaconda and to install POSYDON
 in a virtual environment. Specifically, we recommend using the installation we
@@ -52,8 +49,8 @@ Now, you can source the environment with
     conda activate posydon
 
 
-Getting the POSYDON data (Automatic Data Download)
---------------------------------------------------
+Getting the POSYDON data
+------------------------
 Export the path to where you want to clone the data, e.g. `/home/`, and
 download the data from ZENODO with the following commands
 
@@ -69,7 +66,6 @@ download the data from ZENODO with the following commands
 ==========================================================
 Installing POSYDON v.1.0 from GitHub (Manual Installation)
 ==========================================================
-
 
 Creating a conda environment
 ----------------------------
@@ -130,31 +126,17 @@ the `mpi4py` dependency
     conda install mpi4py
 
 
-Downloading POSYDON data (after Manual Installation via `github`)
------------------------------------------------------------------
-OPTION 1: Zenodo (latest official version)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Getting the POSYDON data
+------------------------
 Export the path to where you want to clone the data, e.g. `/home/`, and
-download the data with the following commands
+download the data from ZENODO with the following commands
 
 .. code-block::
 
     export PATH_TO_POSYDON_DATA=/home/
     get-posydon-data
 
-
-OPTION 2: git LFS submodule (latest development version)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Inside the cloned POSYDON repository run the following commands to
-install and initialise git LFS, and download the data.
-
-.. code-block::
-
-    export PATH_TO_POSYDON_DATA=$PATH_TO_POSYDON/data/
-    conda install git-lfs
-    git lfs install
-    git submodule init
-    git submodule update data/POSYDON_data
+(Note that you can add the export command to your .bashrc or .bash_profile.)
 
 
 Installing POSYDON documentations modules
@@ -176,8 +158,9 @@ To compile the documentation and open the html page do the following
     open _build/html/index.html
 
 
+======================
 Installation Notes/FAQ
-----------------------
+======================
 
 .. note::
 

--- a/docs/install/install.rst
+++ b/docs/install/install.rst
@@ -4,22 +4,36 @@
 Installation
 ############
 
-=======================================
-Installing POSYDON v1.0.0 from Anaconda
-=======================================
+The easiest way to start with POSYDON is to install it from Anaconda
+(Automatic Installation), and call an executable script that downloads the grid
+data automatically (Automatic Data Download).
 
-We recommend to install the Python distribution Anaconda and to install POSYDON 
-in a virtual environment. Specifically, we recommend using the installation we 
-have provided which can be accessed through conda-forge. On Linux, the new 
-conda environment can be created (we have named our environment posydon-example, 
-but you can choose any name), the conda-forge channel added, and the required 
+Alternatively, if you are interested in modifying the code, you can install
+POSYDON manually through `github` (Manual Installation). You can still use the
+automatic script to download the data, however, if you are about to modify the
+grid data, you can get them using the `git-lfs` module (Manual Data Download).
+
+Below we describe both ways.
+
+==========================================================
+Recommended way (Automatic installation and Data Download)
+==========================================================
+
+Installing POSYDON v1.0.0 from Anaconda (Automatic Installation)
+----------------------------------------------------------------
+
+We recommend to install the Python distribution Anaconda and to install POSYDON
+in a virtual environment. Specifically, we recommend using the installation we
+have provided which can be accessed through conda-forge. On Linux, the new
+conda environment can be created (we have named our environment posydon-example,
+but you can choose any name), the conda-forge channel added, and the required
 library installation can all be completed in one line:
 
 .. code-block::
 
     conda create --name posydon-example -c posydon -c conda-forge posydon
 
-On Mac (or if you have problems with the above command on Linux), these steps 
+On Mac (or if you have problems with the above command on Linux), these steps
 likely need to be separately run:
 
 .. code-block::
@@ -38,9 +52,23 @@ Now, you can source the environment with
     conda activate posydon
 
 
-=========================================
-Installing the latest release from GitHub
-=========================================
+Getting the POSYDON data (Automatic Data Download)
+--------------------------------------------------
+Export the path to where you want to clone the data, e.g. `/home/`, and
+download the data from ZENODO with the following commands
+
+.. code-block::
+
+    export PATH_TO_POSYDON_DATA=/home/
+    get-posydon-data
+
+(Note that you can add the export command to your .bashrc or .bash_profile.)
+
+
+
+==========================================================
+Installing POSYDON v.1.0 from GitHub (Manual Installation)
+==========================================================
 
 
 Creating a conda environment
@@ -97,12 +125,13 @@ the `mpi4py` dependency
 
 .. code-block::
 
+    git checkout main
     pip install -e .
     conda install mpi4py
 
 
-Downloading POSYDON data
-------------------------
+Downloading POSYDON data (after Manual Installation via `github`)
+-----------------------------------------------------------------
 OPTION 1: Zenodo (latest official version)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Export the path to where you want to clone the data, e.g. `/home/`, and
@@ -128,11 +157,11 @@ install and initialise git LFS, and download the data.
     git submodule update data/POSYDON_data
 
 
-=========================================
 Installing POSYDON documentations modules
-=========================================
+-----------------------------------------
 
-These modules are needed in order to compile the documentation
+In the case of manual installation you can also alter and build the
+documentation. These modules are needed in order to compile the documentation
 
 .. code-block::
 

--- a/docs/install/install.rst
+++ b/docs/install/install.rst
@@ -42,6 +42,17 @@ likely need to be separately run:
     conda config --set channel_priority false
     conda install posydon
 
+In case of OSX-ARM architectures, where many packages of Python 3.7 are not
+available, please use the following commands:
+
+.. code-block::
+
+    conda create --name posydon_conda
+    conda activate posydon_conda
+    conda config --env --set subdir osx-64
+    conda install python=3.7
+    conda install posydon
+
 Now, you can activate the environment with
 
 .. code-block::

--- a/docs/install/install.rst
+++ b/docs/install/install.rst
@@ -19,11 +19,11 @@ Installing POSYDON v1.0.0 from Anaconda (Recommended way)
 Installation
 ------------
 
-We recommend using Anaconda and to install POSYDON in a virtual environment. 
-We have created a package which can be accessed through conda-forge. On Linux, 
-the new conda environment can be created (we have named our environment 
-posydon-example, but you can choose any name), the conda-forge channel added, 
-and the required library installation can all be completed in one line using 
+We recommend using Anaconda and to install POSYDON in a virtual environment.
+We have created a package which can be accessed through conda-forge. On Linux,
+the new conda environment can be created (we have named our environment
+posydon-example, but you can choose any name), the conda-forge channel added,
+and the required library installation can all be completed in one line using
 the terminal or command line:
 
 .. code-block::
@@ -52,8 +52,8 @@ Now, you can activate the environment with
 Downloading the POSYDON data
 ----------------------------
 Because the data is large, ~10 GB, it must be downloaded
-with an explicit command. Export the path to where you want 
-to clone the data, e.g. `/home/`, and download the data from 
+with an explicit command. Export the path to where you want
+to clone the data, e.g. `/home/`, and download the data from
 ZENODO with the following commands
 
 .. code-block::
@@ -72,8 +72,8 @@ Installing POSYDON v.1.0 from GitHub (Manual Installation)
 Creating a conda environment
 ----------------------------
 
-As above, we recommend using Anaconda to install POSYDON in a virtual 
-environment. After creating the environment (you can choose any name, e.g., 
+As above, we recommend using Anaconda to install POSYDON in a virtual
+environment. After creating the environment (you can choose any name, e.g.,
 `posydon`, or `posydon_env`) like this:
 
 .. code-block::

--- a/docs/install/install.rst
+++ b/docs/install/install.rst
@@ -12,19 +12,19 @@ Alternatively, if you are interested in modifying the code, you can install
 POSYDON manually through `github` (Manual Installation). Below we describe both
 ways.
 
-=======================================================
-Installing POSYDON v1.0.0 from Anaconda (Recommend way)
-=======================================================
+=========================================================
+Installing POSYDON v1.0.0 from Anaconda (Recommended way)
+=========================================================
 
 Installation
 ------------
 
-We recommend to install the Python distribution Anaconda and to install POSYDON
-in a virtual environment. Specifically, we recommend using the installation we
-have provided which can be accessed through conda-forge. On Linux, the new
-conda environment can be created (we have named our environment posydon-example,
-but you can choose any name), the conda-forge channel added, and the required
-library installation can all be completed in one line:
+We recommend using Anaconda and to install POSYDON in a virtual environment. 
+We have created a package which can be accessed through conda-forge. On Linux, 
+the new conda environment can be created (we have named our environment 
+posydon-example, but you can choose any name), the conda-forge channel added, 
+and the required library installation can all be completed in one line using 
+the terminal or command line:
 
 .. code-block::
 
@@ -42,17 +42,19 @@ likely need to be separately run:
     conda config --set channel_priority false
     conda install posydon
 
-Now, you can source the environment with
+Now, you can activate the environment with
 
 .. code-block::
 
     conda activate posydon
 
 
-Getting the POSYDON data
-------------------------
-Export the path to where you want to clone the data, e.g. `/home/`, and
-download the data from ZENODO with the following commands
+Downloading the POSYDON data
+----------------------------
+Because the data is large, ~10 GB, it must be downloaded
+with an explicit command. Export the path to where you want 
+to clone the data, e.g. `/home/`, and download the data from 
+ZENODO with the following commands
 
 .. code-block::
 
@@ -70,16 +72,16 @@ Installing POSYDON v.1.0 from GitHub (Manual Installation)
 Creating a conda environment
 ----------------------------
 
-We recommend to install the Python distribution Anaconda and to install POSYDON
-in a virtual environment. After creating the environment (you can choose any
-name, e.g., `posydon`, or `posydon_env`) like this:
+As above, we recommend using Anaconda to install POSYDON in a virtual 
+environment. After creating the environment (you can choose any name, e.g., 
+`posydon`, or `posydon_env`) like this:
 
 .. code-block::
 
     conda create -n posydon python=3.7
 
 Make sure you agree to any questions about installing required libraries. To
-proceed with the installation, we will need to activate the environment:
+proceed with the installation, you will need to activate the environment:
 
 .. code-block::
 
@@ -117,7 +119,7 @@ Export the path to the cloned POSYDON code (you can add this line to your
 Installing the package
 ~~~~~~~~~~~~~~~~~~~~~~
 From the cloned POSYDON directory execute the commands to install POSYDON and
-the `mpi4py` dependency
+the `mpi4py` dependency (first make sure you are on the main branch!)
 
 .. code-block::
 
@@ -139,8 +141,8 @@ download the data from ZENODO with the following commands
 (Note that you can add the export command to your .bashrc or .bash_profile.)
 
 
-Installing POSYDON documentations modules
------------------------------------------
+Installing POSYDON documentation modules
+----------------------------------------
 
 In the case of manual installation you can also alter and build the
 documentation. These modules are needed in order to compile the documentation
@@ -149,7 +151,7 @@ documentation. These modules are needed in order to compile the documentation
 
     pip install -e .[doc]
 
-To compile the documentation and open the html page do the following
+To compile the documentation and open the html page use the following commands
 
 .. code-block::
 

--- a/docs/install/install.rst
+++ b/docs/install/install.rst
@@ -50,6 +50,8 @@ available, please use the following commands:
     conda create --name posydon_conda
     conda activate posydon_conda
     conda config --env --set subdir osx-64
+    conda config --add channels conda-forge
+    conda config --add channels posydon
     conda install python=3.7
     conda install posydon
 


### PR DESCRIPTION
- [x] Adding introduction in the installation instructions, explaining the two ways to install/download data, and why we care.
- [x] Restructuring the sections
- [x] Repeating the download-script instruction in the conda installation (and the `bashrc` trick)
- [x] Adding the `git checkout main` instruction before pip installing from github (V1)
- [x] Language check
- [x] Final move to the website (using the `github.io`