### PR TITLE
added a new rerun type: hemb_mltp_mesh

### DIFF
--- a/bin/run-pipeline
+++ b/bin/run-pipeline
@@ -451,6 +451,8 @@ def copy_ini_file(grid_path, rerun_type, destination, cluster):
         replace_text = "development-22c1bb9e730343558c3e70984a99b3fc1f3c346e"
     elif rerun_type == 'thermohaline_mixing':
         replace_text = "development-22c1bb9e730343558c3e70984a99b3fc1f3c346e"
+    elif rerun_type == 'hemb_mltp_mesh':
+        replace_text = "development-22c1bb9e730343558c3e70984a99b3fc1f3c346e"
     elif rerun_type == 'other': # e.g. 'envelope_mass_limit', 'fe_core_infall_limit'
         # this rerun uses the default inlist commit
         return
@@ -547,6 +549,15 @@ def logic_rerun(grid, rerun_type):
     elif rerun_type == 'thermohaline_mixing':
         termination_flags = TF1_POOL_ERROR
         new_mesa_flag = {'thermohaline_coeff' : 17.5}
+    elif rerun_type == 'hemb_mltp_mesh':
+        new_mesa_flag = {'gradT_excess_f2' : 0.1,
+                         'max_logT_for_k_below_const_q' : 100,
+                         'max_q_for_k_below_const_q' : 0.995,
+                         'min_q_for_k_below_const_q' : 0.995,
+                         'max_logT_for_k_const_mass' : 100,
+                         'max_q_for_k_const_mass' : 0.99,
+                         'min_q_for_k_const_mass' : 0.99}
+
     elif rerun_type == 'envelope_mass_limit': # maybe 'fe_core_infall_limit' as well?
         runs_to_rerun = None # implement logic
     else:


### PR DESCRIPTION
This adds a new rerun type `hemb_mltp_mesh` which will introduce several changes to the MESA inlists found to help convergence.

1. **Issue: HeMB is not implemented, but magnetic braking is suspected of causing convergence issues on the CO-HeMS grid. So, during reruns, magnetic braking would be turned off for that grid. This will need to be disabled in the `run_binary_extras.f` file.**
2. MLT+ (mltp) is implemented, and changes the parameter `gradT_excess_f2` to 0.1 (from a value of 0.001). A larger value of this parameter makes the superadiabaticity reduction of MLT++ weaker (with 1 meaning no reduction).
3. "mesh" is implemented and refers to changes in MESA's mesh algoorithm, adopted from MIST, which were found to help convergence. These are:

```
      max_logT_for_k_below_const_q = 100
      max_q_for_k_below_const_q = 0.995
      min_q_for_k_below_const_q = 0.995
      max_logT_for_k_const_mass = 100
      max_q_for_k_const_mass = 0.99
      min_q_for_k_const_mass = 0.99

```