### PR TITLE
Allow non-burning stars in MT

### DIFF
--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -1445,7 +1445,9 @@ def infer_mass_transfer_case(rl_relative_overflow,
                   rl_relative_overflow, lg_mtransfer_rate)
         return MT_CASE_NO_RLO
 
-    if "H-rich" in donor_state:
+    if "non_burning" in donor_state:
+        return MT_CASE_NONBURNING
+    elif "H-rich" in donor_state:
         if "Core_H_burning" in donor_state:
             return MT_CASE_A
         if ("Core_He_burning" in donor_state
@@ -1460,8 +1462,6 @@ def infer_mass_transfer_case(rl_relative_overflow,
         if ("Central_He_depleted" in donor_state
                 or "Central_C_depletion" in donor_state):
             return MT_CASE_BB
-    elif "non_burning" in donor_state:
-        return MT_CASE_NONBURNING
     return MT_CASE_UNDETERMINED
 
 

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -66,11 +66,13 @@ MT_CASE_C = 3
 MT_CASE_BA = 4
 MT_CASE_BB = 5
 MT_CASE_BC = 6
+MT_CASE_NONBURNING = 8
 MT_CASE_UNDETERMINED = 9
 
 # All cases meaning RLO is happening
 ALL_RLO_CASES = set([MT_CASE_A, MT_CASE_B, MT_CASE_C,
-                     MT_CASE_BA, MT_CASE_BB, MT_CASE_BC])
+                     MT_CASE_BA, MT_CASE_BB, MT_CASE_BC,
+                     MT_CASE_NONBURNING])
 
 # Conversion of integer mass-transfer flags to strings
 MT_CASE_TO_STR = {
@@ -81,6 +83,7 @@ MT_CASE_TO_STR = {
     MT_CASE_BA: "BA",
     MT_CASE_BB: "BB",
     MT_CASE_BC: "BC",
+    MT_CASE_NONBURNING: "nonburning",
     MT_CASE_UNDETERMINED: "undetermined_MT"
 }
 
@@ -486,7 +489,7 @@ def bondi_hoyle(binary, accretor, donor, idx=-1, wind_disk_criteria=True,
         default: True, see [5]_
     scheme : str
         There are different options:
-        
+
         - 'Hurley+2002' : following [3]_
         - 'Kudritzki+2000' : following [7]_
 
@@ -1457,6 +1460,8 @@ def infer_mass_transfer_case(rl_relative_overflow,
         if ("Central_He_depleted" in donor_state
                 or "Central_C_depletion" in donor_state):
             return MT_CASE_BB
+    elif "non_burning" in donor_state:
+        return MT_CASE_NONBURNING
     return MT_CASE_UNDETERMINED
 
 


### PR DESCRIPTION
We have added code that allows non burning stars to enter mass transfer without failing immediately. @celiotine will test this. Addresses Issue #205.