### PR TITLE
Numerical precision fix failed

### DIFF
--- a/posydon/grids/scrubbing.py
+++ b/posydon/grids/scrubbing.py
@@ -139,7 +139,7 @@ def keep_after_RLO(bh, h1, h2):
         min_dt = min(np.diff(new_bh["age"]))
         new_age_to_remove = (age_to_remove // min_dt) * min_dt
         if new_age_to_remove==age_to_remove:
-            new_age_to_remove = (age_to_remove // min_dt - 1.0) * min_dt
+            new_age_to_remove -= min_dt
         relative_error = abs(new_age_to_remove - age_to_remove) / age_to_remove
         if relative_error > 0.01:
             raise Exception("Numerical precision fix too aggressive.")

--- a/posydon/grids/scrubbing.py
+++ b/posydon/grids/scrubbing.py
@@ -138,6 +138,8 @@ def keep_after_RLO(bh, h1, h2):
     if len(new_ages) > 1 and min(np.diff(new_ages)) == 0.0:
         min_dt = min(np.diff(new_bh["age"]))
         new_age_to_remove = (age_to_remove // min_dt) * min_dt
+        if new_age_to_remove==age_to_remove:
+            new_age_to_remove = (age_to_remove // min_dt - 1.0) * min_dt
         relative_error = abs(new_age_to_remove - age_to_remove) / age_to_remove
         if relative_error > 0.01:
             raise Exception("Numerical precision fix too aggressive.")


### PR DESCRIPTION
- [x] Adding a rule if the new and old age_to_remove would be the same.

In such a case, the numerical precision fix would fail, because there won't be a change to fix anything.
To explain, when this happens: it occurs in the rare case, the normal division would be an integer already. Thus the floor division will give the same result, which cancels with the multiplication. The solution is simply enforcing in such a case to go down by 1 before the multiplication. Mathematically it simply changes `new_age_to_remove<=age_to_remove` to `new_age_to_remove<age_to_remove`.