### PR TITLE
Change loc call to list to always return a pandas.DataFrame

### DIFF
--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -614,7 +614,7 @@ class PopulationManager:
         binary_holder = []
         for i in np.unique(hist.index):
             binary = BinaryStar.from_df(
-                hist.loc[i],
+                hist.loc[[i]],
                 extra_columns=self.kwargs.get('extra_columns', []))
 
             # if the binary has failed


### PR DESCRIPTION
This is a problem when the user is (re-)evolving a BinaryPopulation by reading the binary from an HDF5 file.

The change to an input list ensures that a `pandas.DataFrame` is returned instead of a `pandas.Series`. `BinaryStar.from_df` expects a `pandas.DataFrame` as an input.

Solves issue #215