### PR TITLE
fixing issues for mismatched CC/RLO/S1/S2 output and S2 initially more massive

### DIFF
--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -543,6 +543,9 @@ class MergedStep(IsolatedStep):
                 merged_star = comp
                 # TODO: potentially flag a Thorne-Zytkov object
                 massless_remnant = convert_star_to_massless_remnant(star_base)
+
+                ## in this case, want CO companion object to stay the same, and base star to be assigned massless remnant
+                return massless_remnant, merged_star
         else:
             print("Combination of merging star states not expected: ", s1, s2)
 


### PR DESCRIPTION
This PR fixes bugs detailed in issues #203 and #214, so see these issues for more information of the problems.
In `step_merged.py`, the returned `massless_remnant` and `merged_star` objects need to be flipped in the case where a stellar object is engulfing a BH or NS. 