### PR TITLE
Add error for returning to step_detached after leaving it.

### DIFF
--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -1392,6 +1392,11 @@ class CO_HMS_RLO_step(MesaGridStep):
             ecc == 0.)):
             super().__call__(self.binary)
         else:
+            if len(self.binary.state_history) > 2:
+                if self.binary.state_history[-2] == 'detached':
+                    self.state = "ERR"
+                    raise ValueError('CO_HMS_RLO binary outside grid and coming from detached')
+                
             self.binary.state = "detached"
             self.binary.event = "redirect_from_CO_HMS_RLO"
             return


### PR DESCRIPTION
This should stop systems from going into loops between the `detached` and `CO_HMS_RLO` grids, when the compact object is outside the range of the grid.

This fixes issue #194 