### PR TITLE
HDF5 read fix

### DIFF
--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -464,7 +464,7 @@ class BinaryPopulation:
     def close(self):
         """Close loaded h5 files from SimulationProperties."""
         self.population_properties.close()
-        self.manager.close()
+
 
     def __getstate__(self):
         """Prepare the BinaryPopulation to be 'pickled'."""
@@ -514,13 +514,8 @@ class PopulationManager:
         self.entropy = self.binary_generator.entropy
 
         if file_name:
-            self.store = pd.HDFStore(file_name, mode='r',)
-            atexit.register(lambda: PopulationManager.close(self))
+            self.store_file = file_name
 
-    def close(self):
-        """Close the HDF5 file."""
-        if hasattr(self, 'store'):
-            self.store.close()
 
     def append(self, binary):
         """Add a binary instance internaly."""
@@ -641,8 +636,9 @@ class PopulationManager:
         else:
             query_str = str(where)
 
-        hist = self.store.select(key='history', where=query_str)
-        oneline = self.store.select(key='oneline', where=query_str)
+        with pd.HDFStore(self.store_file, mode='r') as store:
+            hist = store.select(key='history', where=query_str)
+            oneline = store.select(key='oneline', where=query_str)
 
         binary_holder = []
         for i in np.unique(hist.index):

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -465,7 +465,6 @@ class BinaryPopulation:
         """Close loaded h5 files from SimulationProperties."""
         self.population_properties.close()
 
-
     def __getstate__(self):
         """Prepare the BinaryPopulation to be 'pickled'."""
         # In order to be generally picklable, we need to discard the
@@ -515,7 +514,6 @@ class PopulationManager:
 
         if file_name:
             self.store_file = file_name
-
 
     def append(self, binary):
         """Add a binary instance internaly."""


### PR DESCRIPTION
When (re-)evolving a BinaryPopulation from an HDF5 file, the file was kept open while items were being read.
Because the binaries are stored in a table format, pandas leeks memory (See Pandas [Issue](https://github.com/pandas-dev/pandas/issues/22082)). In our Issue #224, the problem is described in more detail.

The below plot shows 3 runs in a row each with all 8 metallicities and 100 binaries per metallicity. 
The first run is with random generated binaries. 
The second with the constant open pd.HDFStore in PopulationManager. 
The third with this fix.

There's still a small increase present in the random and fix run, but it's unclear if this is actually a continuous increase or just an increase due to metallicity switches. For now, this fix should solve evolving binaries from an HDF5 file.

The generated run and third run differ a bit in memory usage. This is likely due to the type of binaries being ran. If more grids have to be loaded in the `detached_step` then more memory will be used.

<img width="856" alt="Screenshot 2023-12-21 at 16 33 51" src="https://github.com/POSYDON-code/POSYDON/assets/14039563/fc8251f1-32d7-4eda-87f5-5c4541493f5f">
