### PR TITLE
Fixing minor bugs that were coming up in population runs.

### DIFF
--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -12,9 +12,9 @@ __authors__ = [
     "Jeffrey Andrews <jeffrey.andrews@northwestern.edu>",
 ]
 
-
 import os
 import numpy as np
+import pandas as pd
 import time
 from scipy.integrate import solve_ivp
 from scipy.interpolate import PchipInterpolator
@@ -122,7 +122,6 @@ DEFAULT_TRANSLATION = {
     "profile": None,
     "metallicity": None,
     "spin": "spin_parameter",
-    "log_total_angular_momentum": "log_total_angular_momentum",
     "conv_env_top_mass": "conv_env_top_mass",
     "conv_env_bot_mass": "conv_env_bot_mass",
     "conv_env_top_radius": "conv_env_top_radius",
@@ -834,7 +833,7 @@ class detached_step:
                             colscalers=colscalers, scales=scales)
 
                     x0 = get_root0(
-                        MESA_label, posydon_attribute, htrack, rs=rs)
+                        MESA_labels, posydon_attributes, htrack, rs=rs)
 
                     # bnds = ([m_min_H, m_max_H], [0, None])
                     sol = minimize(sq_diff_function, x0,
@@ -1083,19 +1082,19 @@ class detached_step:
                         print("Matching duration: "
                               f"{t_after_matching-t_before_matching:.6g}")
 
+            if pd.isna(m0) or pd.isna(t0):
+                    #    binary.event = "END"
+                    #    binary.state += " (GridMatchingFailed)"
+                    #    if self.verbose:
+                    #        print("Failed matching")
+                return None, None, None
+            
             if htrack:
                 self.grid = self.grid_Hrich
-            elif not htrack:
+            else:
                 self.grid = self.grid_strippedHe
 
             get_track = self.grid.get
-
-            if np.isnan(m0) or np.isnan(t0):
-                #    binary.event = "END"
-                #    binary.state += " (GridMatchingFailed)"
-                #    if self.verbose:
-                #        print("Failed matching")
-                return None, None, None
 
             max_time = binary.properties.max_simulation_time
             assert max_time > 0.0, "max_time is non-positive"
@@ -1351,7 +1350,7 @@ class detached_step:
                         # EDIT: We assume POSYDON surf_avg_omega is provided in
                         # rad/yr already.
                     else:
-                        if is_secondary == True:
+                        if is_secondary:
                             radius_to_be_used = interp1d_sec["R"](interp1d_sec["t0"])
                             mass_to_be_used = interp1d_sec["mass"](interp1d_sec["t0"])
                         else:

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -109,8 +109,6 @@ POSYDON_TO_MESA = {
         'lambda_CE_1cent': 'lambda_CE_1cent',
         'lambda_CE_10cent': 'lambda_CE_10cent',
         'lambda_CE_30cent': 'lambda_CE_30cent',
-        'co_core_mass': 'co_core_mass',
-        'co_core_radius': 'co_core_radius',
         'lambda_CE_pure_He_star_10cent': 'lambda_CE_pure_He_star_10cent',
         'profile': True
     }

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -35,7 +35,6 @@ import atexit
 import os
 from tqdm import tqdm
 import psutil
-import random
 import sys
 
 if 'posydon.binary_evol.binarystar' not in sys.modules.keys():

--- a/posydon/popsyn/independent_sample.py
+++ b/posydon/popsyn/independent_sample.py
@@ -347,7 +347,7 @@ def generate_secondary_masses(primary_masses,
 
     # Generate secondary masses
     if secondary_mass_scheme == 'flat_mass_ratio':
-        mass_ratio_min = secondary_mass_min / primary_masses
+        mass_ratio_min = np.max([secondary_mass_min / primary_masses,np.ones(len(primary_masses))*0.05], axis=0)
         mass_ratio_max = np.min([secondary_mass_max / primary_masses,
                                  np.ones(len(primary_masses))], axis=0)
         secondary_masses = (


### PR DESCRIPTION
This PR is introducing some small changes that will fix errors that resulted in binaries failing in 3 seperate cases.

1. The first change is trying to address an ValueError that was triggered in the MESA step from binaries that had a mass ratio q < 0.05 . 
 ````
Traceback (most recent call last):
  File "/blue/jeffrey.andrews/kasdaglie/POSYDON/posydon/popsyn/binarypopulation.py", line 259, in _safe_evolve
    binary.evolve()
  File "/blue/jeffrey.andrews/kasdaglie/POSYDON/posydon/binary_evol/binarystar.py", line 199, in evolve
    self.run_step()
  File "/blue/jeffrey.andrews/kasdaglie/POSYDON/posydon/binary_evol/binarystar.py", line 229, in run_step
    next_step(self)
  File "/blue/jeffrey.andrews/kasdaglie/POSYDON/posydon/binary_evol/MESA/step_mesa.py", line 1305, in __call__
    raise ValueError('The star_1.state = %s, star_2.state = %s, '
ValueError: The star_1.state = H-rich_Core_H_burning, star_2.state = H-rich_Core_H_burning, binary.event = ZAMS and not H-rich_Core_H_burning - H-rich_Core_H_burning - * - ZAMS`
```

2. The second bug was rare and only occurred during the third matching attemp in the detached step. Wrong attributes were passed in the root0 function. 
 
Traceback (most recent call last):
  ```
File "/blue/jeffrey.andrews/kasdaglie/POSYDON/posydon/popsyn/binarypopulation.py", line 259, in _safe_evolve
    binary.evolve()
  File "/blue/jeffrey.andrews/kasdaglie/POSYDON/posydon/binary_evol/binarystar.py", line 199, in evolve
    self.run_step()
  File "/blue/jeffrey.andrews/kasdaglie/POSYDON/posydon/binary_evol/binarystar.py", line 229, in run_step
    next_step(self)
  File "/blue/jeffrey.andrews/kasdaglie/POSYDON/posydon/binary_evol/DT/step_detached.py", line 1155, in __call__
    interp1d_sec, m0, t0 = get_star_data(
                           ^^^^^^^^^^^^^^
  File "/blue/jeffrey.andrews/kasdaglie/POSYDON/posydon/binary_evol/DT/step_detached.py", line 1080, in get_star_data
    m0, t0, htrack = self.match_to_single_star(star1, htrack)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/blue/jeffrey.andrews/kasdaglie/POSYDON/posydon/binary_evol/DT/step_detached.py", line 836, in match_to_single_star
    x0 = get_root0(
         ^^^^^^^^^^
  File "/blue/jeffrey.andrews/kasdaglie/POSYDON/posydon/binary_evol/DT/step_detached.py", line 609, in get_root0
    idx = np.argmax(np.asanyarray(keys)[:, None] == self.root_keys, axis=1)
                    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^
IndexError: too many indices for array: array is 0-dimensional, but 1 were indexed

```
3. The third error occured when m0,t0 the outputs of the matching were None instead of np.nan. The pandas pd.isna works for both of those cases. 

> Traceback (most recent call last):
>   File "/blue/jeffrey.andrews/kasdaglie/POSYDON/posydon/popsyn/binarypopulation.py", line 259, in _safe_evolve
>     binary.evolve()
>   File "/blue/jeffrey.andrews/kasdaglie/POSYDON/posydon/binary_evol/binarystar.py", line 199, in evolve
>     self.run_step()
>   File "/blue/jeffrey.andrews/kasdaglie/POSYDON/posydon/binary_evol/binarystar.py", line 229, in run_step
>     next_step(self)
>   File "/blue/jeffrey.andrews/kasdaglie/POSYDON/posydon/binary_evol/DT/step_merged.py", line 117, in __call__
>     super().__call__(binary)
>   File "/blue/jeffrey.andrews/kasdaglie/POSYDON/posydon/binary_evol/DT/step_isolated.py", line 93, in __call__
>     super().__call__(binary)
>   File "/blue/jeffrey.andrews/kasdaglie/POSYDON/posydon/binary_evol/DT/step_detached.py", line 1164, in __call__
>     interp1d_pri = get_star_data(
>                    ^^^^^^^^^^^^^^
>   File "/blue/jeffrey.andrews/kasdaglie/POSYDON/posydon/binary_evol/DT/step_detached.py", line 1093, in get_star_data
>     if np.isnan(m0) or np.isnan(t0):
>        ^^^^^^^^^^^^
> TypeError: ufunc 'isnan' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''

