### PR TITLE
Deepcopy `SimulationProperties`

### DIFF
--- a/posydon/popsyn/synthetic_population.py
+++ b/posydon/popsyn/synthetic_population.py
@@ -15,6 +15,7 @@ import numpy as np
 import pandas as pd
 from tqdm import tqdm
 import os
+import copy
 from posydon.utils.constants import Zsun
 from posydon.popsyn.io import binarypop_kwargs_from_ini
 from posydon.popsyn.binarypopulation import BinaryPopulation
@@ -77,8 +78,8 @@ class SyntheticPopulation:
     def create_binary_populations(self):
         """Create a list of BinaryPopulation objects."""
         self.binary_populations = []
-        ini_kw = self.synthetic_pop_params.copy()
         for met in self.metallicities[::-1]:
+            ini_kw = copy.deepcopy(self.synthetic_pop_params)
             ini_kw['metallicity'] = met
             ini_kw['temp_directory'] = self.create_met_prefix(met) + self.synthetic_pop_params['temp_directory']
             self.binary_populations.append(BinaryPopulation(**ini_kw))


### PR DESCRIPTION
This deepcopy per metallicity creates a unique copy of the `SimulationProperties`, such that each metallicity has it's own and loads in the correct metallicity grids.

This should fix Issue #232.