### PR TITLE
Hotfix for multi-metallicity runs

### DIFF
--- a/posydon/popsyn/synthetic_population.py
+++ b/posydon/popsyn/synthetic_population.py
@@ -15,6 +15,8 @@ import numpy as np
 import pandas as pd
 from tqdm import tqdm
 import os
+import copy
+import multiprocessing as mp
 from posydon.utils.constants import Zsun
 from posydon.popsyn.io import binarypop_kwargs_from_ini
 from posydon.popsyn.binarypopulation import BinaryPopulation
@@ -77,8 +79,8 @@ class SyntheticPopulation:
     def create_binary_populations(self):
         """Create a list of BinaryPopulation objects."""
         self.binary_populations = []
-        ini_kw = self.synthetic_pop_params.copy()
         for met in self.metallicities[::-1]:
+            ini_kw = copy.deepcopy(self.synthetic_pop_params)
             ini_kw['metallicity'] = met
             ini_kw['temp_directory'] = self.create_met_prefix(met) + self.synthetic_pop_params['temp_directory']
             self.binary_populations.append(BinaryPopulation(**ini_kw))
@@ -92,9 +94,15 @@ class SyntheticPopulation:
             self.create_binary_populations()
         while self.binary_populations:
             pop =  self.binary_populations.pop()
+            
             if self.verbose:
                 print(f'Z={pop.kwargs["metallicity"]:.2e} Z_sun')
-            pop.evolve()
+                            
+            process = mp.Process(target=pop.evolve)
+            process.start()
+            process.join()
+            
+            pop.close()
             del pop
 
 


### PR DESCRIPTION
**Issue:**
After finishing with a metallicity in a `SyntheticPopulation` run, the memory and objects associated with the metallicity are not released. As a resulting, the memory usage jumps to more than 4Gb after loading in the data for 3 metallicities, since with the fix in PR #233 the new metallicity information (grids) is correctly loaded in.

There might be a cyclical reference to the `BinaryPopulation` somewhere, but it's unclear to me where exactly this occurs (for more details, see Issue #224).

This PR introduces a quick solution for the multi-metallicity runs by running the `BinaryPopulation.evolve()` into a subprocess. The main process waits for one metallicity to finish and then kills it. This forces all memory associated with the subprocess to be released to the OS. This will not solve any issues with potential memory leakage in a very long single metallicity run.

This figure shows the memory usage of two runs: the old version (including PR #233) in black and this PR in blue. The black process is killed due to out-of-memory, while the blue one hits wall time on the debug-cpu (900s). There runs were only 100 binaries with a dump rate of 10.
<img width="1385" alt="memory usage runs" src="https://github.com/POSYDON-code/POSYDON/assets/14039563/151aacdf-654e-4396-aa88-3d8e4990409f">
The maximum memory usage of the blue run fluctuations might fluctuate due to what parts of single star grids are loaded in based on the binaries at that metallicity, but does not explain why it suddenly peaks at ~300s.

This PR also includes PR #233.