### PR TITLE
Add loop checks for other CO grids

### DIFF
--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -1072,7 +1072,7 @@ class detached_step:
                     # ZAMS stars in wide (non-mass exchaging binaries) that are
                     # directed to detached step at birth
                     m0, t0 = star1.mass, 0
-                elif co: 
+                elif co:
                     m0, t0 = copy_prev_m0, copy_prev_t0
                 else:
                     t_before_matching = time.time()
@@ -1094,7 +1094,7 @@ class detached_step:
             else:
                 self.grid = self.grid_strippedHe
             
-            # cehck if m0 is in the grid
+            # check if m0 is in the grid
             if m0 < self.grid.grid_mass.min() or m0 > self.grid.grid_mass.max():
                 binary.state = "ERR"
                 binary.event = "FAILED"

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -32,7 +32,8 @@ from posydon.utils.common_functions import (
     roche_lobe_radius,
     check_state_of_star,
     PchipInterpolator2,
-    convert_metallicity_to_string
+    convert_metallicity_to_string,
+    set_binary_to_failed,
 )
 from posydon.binary_evol.flow_chart import (STAR_STATES_CC, STAR_STATES_CO)
 import posydon.utils.constants as const
@@ -1096,8 +1097,7 @@ class detached_step:
             
             # check if m0 is in the grid
             if m0 < self.grid.grid_mass.min() or m0 > self.grid.grid_mass.max():
-                binary.state = "ERR"
-                binary.event = "FAILED"
+                set_binary_to_failed(binary)
                 raise ValueError(f"The mass {m0} is out of the single star grid range and cannot be matched to a track.")
 
             get_track = self.grid.get

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -1072,7 +1072,7 @@ class detached_step:
                     # ZAMS stars in wide (non-mass exchaging binaries) that are
                     # directed to detached step at birth
                     m0, t0 = star1.mass, 0
-                elif co:
+                elif co: 
                     m0, t0 = copy_prev_m0, copy_prev_t0
                 else:
                     t_before_matching = time.time()
@@ -1081,7 +1081,7 @@ class detached_step:
                     if self.verbose or self.verbose == 1:
                         print("Matching duration: "
                               f"{t_after_matching-t_before_matching:.6g}")
-
+            
             if pd.isna(m0) or pd.isna(t0):
                     #    binary.event = "END"
                     #    binary.state += " (GridMatchingFailed)"
@@ -1093,6 +1093,12 @@ class detached_step:
                 self.grid = self.grid_Hrich
             else:
                 self.grid = self.grid_strippedHe
+            
+            # cehck if m0 is in the grid
+            if m0 < self.grid.grid_mass.min() or m0 > self.grid.grid_mass.max():
+                binary.state = "ERR"
+                binary.event = "FAILED"
+                raise ValueError(f"The mass {m0} is out of the single star grid range and cannot be matched to a track.")
 
             get_track = self.grid.get
 

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -1298,7 +1298,7 @@ class MS_MS_step(MesaGridStep):
         elif (state_1 == 'H-rich_Core_H_burning' and
               state_2 == 'H-rich_Core_H_burning' and
               event == 'ZAMS' and
-              p <= self.p_max and
+              self.p_min <= p <= self.p_max and
               (m1 < self.m1_min or m1 > self.m1_max)):
             set_binary_to_failed(self.binary)
             raise ValueError(f'The mass of m1 ({m1}) is outside the grid,'
@@ -1307,7 +1307,7 @@ class MS_MS_step(MesaGridStep):
         elif (state_1 == 'H-rich_Core_H_burning' and
               state_2 == 'H-rich_Core_H_burning' and
               event == 'ZAMS' and
-              p <= self.p_max and
+              self.p_min <= p <= self.p_max and
               (m2 < self.m2_min or m2 > self.m2_max)):
             set_binary_to_failed(self.binary)
             raise ValueError(f'The mass of m2 ({m2}) is outside the grid,'
@@ -1411,6 +1411,25 @@ class CO_HMS_RLO_step(MesaGridStep):
             self.p_min <= p <= self.p_max and
             ecc == 0.)):
             super().__call__(self.binary)
+        
+        # period inside the grid, but m1 outside the grid
+        elif ((not self.flip_stars_before_step and
+               self.p_min <= p <= self.p_max and
+               (m1 < self.m1_min or m1 > self.m1_max)
+               )):
+            set_binary_to_failed(self.binary)
+            raise ValueError(f'The mass of m1 ({m1}) is outside the grid,'
+                                'while the period is inside the grid.')
+            
+        # period inside the grid, but m2 outside the grid
+        elif ((not self.flip_stars_before_step and
+               self.p_min <= p <= self.p_max and
+               (m2 < self.m2_min or m2 > self.m2_max)
+               )):
+            set_binary_to_failed(self.binary)
+            raise ValueError(f'The mass of m2 ({m2}) is outside the grid,'
+                                'while the period is inside the grid.')
+            
         else:
             if len(self.binary.state_history) > 2:
                 if self.binary.state_history[-2] == 'detached':
@@ -1506,11 +1525,27 @@ class CO_HeMS_RLO_step(MesaGridStep):
             self.p_min <= p <= self.p_max and
             ecc == 0.)):
             super().__call__(self.binary)
+        # period inside the grid, but m1 outside the grid
+        elif ((not self.flip_stars_before_step and
+               self.p_min <= p <= self.p_max and
+                (m1 < self.m1_min or m1 > self.m1_max)
+                )):
+            set_binary_to_failed(self.binary)
+            raise ValueError(f'The mass of m1 ({m1}) is outside the grid,'
+                                'while the period is inside the grid.')
+        # period inside the grid, but m2 outside the grid
+        elif ((not self.flip_stars_before_step and
+               self.p_min <= p <= self.p_max and
+               (m2 < self.m2_min or m2 > self.m2_max)
+               )):
+            set_binary_to_failed(self.binary)
+            raise ValueError(f'The mass of m2 ({m2}) is outside the grid,'
+                                'while the period is inside the grid.')
+        
         else:
             if len(self.binary.state_history) > 2:
                 if self.binary.state_history[-2] == 'detached':
-                    self.binary.event = 'FAILED'
-                    self.binary.state = 'ERR'
+                    set_binary_to_failed(self.binary)
                     raise ValueError('CO_HeMS_RLO binary outside grid and coming from detached')
                 
             self.binary.state = "detached"
@@ -1610,8 +1645,7 @@ class CO_HeMS_step(MesaGridStep):
         else:
             if len(self.binary.state_history) > 2:
                 if self.binary.state_history[-2] == 'detached':
-                    self.binary.event = 'FAILED'
-                    self.binary.state = 'ERR'
+                    set_binary_to_failed(self.binary)
                     raise ValueError('CO_HeMS binary outside grid and coming from detached')
             self.binary.event = 'redirect_from_CO_HeMS'
             return

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -26,7 +26,8 @@ from posydon.binary_evol.binarystar import BinaryStar
 from posydon.interpolation.IF_interpolation import IFInterpolator
 from posydon.utils.common_functions import (flip_stars,
                                             convert_metallicity_to_string,
-                                            CO_radius, infer_star_state)
+                                            CO_radius, infer_star_state,
+                                            set_binary_to_failed,)
 from posydon.utils.data_download import data_download, PATH_TO_POSYDON_DATA
 from posydon.grids.MODELS import MODELS
 
@@ -1297,8 +1298,7 @@ class MS_MS_step(MesaGridStep):
               event == 'ZAMS' and
               p <= self.p_max and
               (m1 < self.m1_min or m1 > self.m1_max)):
-            self.binary.event = 'FAILED'
-            self.binary.state = 'ERR'
+            set_binary_to_failed(self.binary)
             raise ValueError(f'The mass of m1 ({m1}) is outside the grid,'
                              'while the period is inside the grid.')
         # outside the mass grid for m2
@@ -1307,8 +1307,7 @@ class MS_MS_step(MesaGridStep):
               event == 'ZAMS' and
               p <= self.p_max and
               (mass_ratio < self.q_min or mass_ratio > self.q_max)):
-            self.binary.event = 'FAILED'
-            self.binary.state = 'ERR'
+            set_binary_to_failed(self.binary)
             raise ValueError(f'The mass of m2 ({m2}) is outside the grid,'
                              'while the period is inside the grid.')
         # redirect if CC1
@@ -1320,8 +1319,7 @@ class MS_MS_step(MesaGridStep):
             self.binary.event = 'CC2'
             return
         else:
-            self.binary.event = 'FAILED'
-            self.binary.state = 'ERR'
+            set_binary_to_failed(self.binary)
             raise ValueError('The star_1.state = %s, star_2.state = %s, '
                              'binary.event = %s and not H-rich_Core_H_burning '
                              '- H-rich_Core_H_burning - * - ZAMS'
@@ -1414,8 +1412,7 @@ class CO_HMS_RLO_step(MesaGridStep):
         else:
             if len(self.binary.state_history) > 2:
                 if self.binary.state_history[-2] == 'detached':
-                    self.binary.state = "ERR"
-                    self.binary.event = "FAILED"
+                    set_binary_to_failed(self.binary)
                     raise ValueError('CO_HMS_RLO binary outside grid and coming from detached')
                 
             self.binary.state = "detached"

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -1392,7 +1392,7 @@ class CO_HMS_RLO_step(MesaGridStep):
         else:
             if len(self.binary.state_history) > 2:
                 if self.binary.state_history[-2] == 'detached':
-                    self.state = "ERR"
+                    self.state = "FAILED"
                     raise ValueError('CO_HMS_RLO binary outside grid and coming from detached')
                 
             self.binary.state = "detached"
@@ -1485,6 +1485,11 @@ class CO_HeMS_RLO_step(MesaGridStep):
             ecc == 0.)):
             super().__call__(self.binary)
         else:
+            if len(self.binary.state_history) > 2:
+                if self.binary.state_history[-2] == 'detached':
+                    self.state = "FAILED"
+                    raise ValueError('CO_HeMS_RLO binary outside grid and coming from detached')
+                
             self.binary.state = "detached"
             self.binary.event = "redirect_from_CO_HeMS_RLO"
             return
@@ -1580,5 +1585,10 @@ class CO_HeMS_step(MesaGridStep):
             ecc == 0.)):
             super().__call__(binary)
         else:
+            if len(self.binary.state_history) > 2:
+                if self.binary.state_history[-2] == 'detached':
+                    self.state = "FAILED"
+                    raise ValueError('CO_HeMS binary outside grid and coming from detached')
+                
             self.binary.event = 'redirect_from_CO_HeMS'
             return

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -1297,8 +1297,8 @@ class MS_MS_step(MesaGridStep):
               event == 'ZAMS' and
               p <= self.p_max and
               (m1 < self.m1_min or m1 > self.m1_max)):
-            self.binary.event = 'ERR'
-            self.binary.state = 'FAILED'
+            self.binary.event = 'FAILED'
+            self.binary.state = 'ERR'
             raise ValueError(f'The mass of m1 ({m1}) is outside the grid,'
                              'while the period is inside the grid.')
         # outside the mass grid for m2

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -1294,6 +1294,14 @@ class MS_MS_step(MesaGridStep):
               p > self.p_max):
             self.binary.event = 'redirect_from_ZAMS'
             return
+        # redirect if period smaller than the minimum period
+        elif (state_1 == 'H-rich_Core_H_burning' and
+              state_2 == 'H-rich_Core_H_burning' and
+              event == 'ZAMS' and
+              p < self.p_min):
+            self.binary.event = 'redirect_from_ZAMS'
+            return
+        
         # outside the mass grid for m1
         elif (state_1 == 'H-rich_Core_H_burning' and
               state_2 == 'H-rich_Core_H_burning' and
@@ -1303,12 +1311,13 @@ class MS_MS_step(MesaGridStep):
             set_binary_to_failed(self.binary)
             raise ValueError(f'The mass of m1 ({m1}) is outside the grid,'
                              'while the period is inside the grid.')
+        
         # outside the mass grid for m2
         elif (state_1 == 'H-rich_Core_H_burning' and
               state_2 == 'H-rich_Core_H_burning' and
               event == 'ZAMS' and
               self.p_min <= p <= self.p_max and
-              (m2 < self.m2_min or m2 > self.m2_max)):
+              (m2 < np.max(self.m2_min, 0.5) or m2 > self.m2_max)):
             set_binary_to_failed(self.binary)
             raise ValueError(f'The mass of m2 ({m2}) is outside the grid,'
                              'while the period is inside the grid.')

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -1250,6 +1250,8 @@ class MS_MS_step(MesaGridStep):
         # load grid boundaries
         self.m1_min = min(self._psyTrackInterp.grid.initial_values['star_1_mass'])
         self.m1_max = max(self._psyTrackInterp.grid.initial_values['star_1_mass'])
+        self.m2_min = min(self._psyTrackInterp.grid.initial_values['star_2_mass'])
+        self.m2_max = max(self._psyTrackInterp.grid.initial_values['star_2_mass'])
         self.q_min = 0.05 # can be computed m2_min/m1_min
         self.q_max = 1. # note that for MESA stability we actually run q_max = 0.99
         self.p_min = min(self._psyTrackInterp.grid.initial_values['period_days'])
@@ -1306,7 +1308,7 @@ class MS_MS_step(MesaGridStep):
               state_2 == 'H-rich_Core_H_burning' and
               event == 'ZAMS' and
               p <= self.p_max and
-              (mass_ratio < self.q_min or mass_ratio > self.q_max)):
+              (m2 < self.m2_min or m2 > self.m2_max)):
             set_binary_to_failed(self.binary)
             raise ValueError(f'The mass of m2 ({m2}) is outside the grid,'
                              'while the period is inside the grid.')

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -1276,7 +1276,7 @@ class MS_MS_step(MesaGridStep):
             state_2 == 'H-rich_Core_H_burning' and
             event == 'ZAMS' and
             self.m1_min <= m1 <= self.m1_max and
-            self.q_min <= mass_ratio <= self.q_max and
+            np.max(self.q_min, 0.5/m1) <= mass_ratio <= self.q_max and
             self.p_min <= p <= self.p_max):
             self.flip_stars_before_step = False
             super().__call__(self.binary)  
@@ -1285,7 +1285,7 @@ class MS_MS_step(MesaGridStep):
               state_2 == 'H-rich_Core_H_burning' and
               event == 'ZAMS' and
               self.m1_min <= m2 <= self.m1_max and
-              self.q_min <= 1./mass_ratio <= self.q_max and
+              np.max(self.q_min, 0.5/m1) <= 1./mass_ratio <= self.q_max and
               self.p_min <= p <= self.p_max):
             self.flip_stars_before_step = True
             super().__call__(self.binary)
@@ -1378,6 +1378,7 @@ class CO_HMS_RLO_step(MesaGridStep):
         m2 = self.binary.star_2.mass
         p = self.binary.orbital_period
         ecc = self.binary.eccentricity
+        mass_ratio = m2/m1
 
         # TODO: import states from flow_chart.py
         FOR_RLO_STATES = ["H-rich_Core_H_burning",

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -1271,6 +1271,7 @@ class MS_MS_step(MesaGridStep):
         m2 = self.binary.star_2.mass
         mass_ratio = m2/m1
         p = self.binary.orbital_period
+        # check if the binary is in the grid
         if (state_1 == 'H-rich_Core_H_burning' and
             state_2 == 'H-rich_Core_H_burning' and
             event == 'ZAMS' and
@@ -1278,7 +1279,8 @@ class MS_MS_step(MesaGridStep):
             self.q_min <= mass_ratio <= self.q_max and
             self.p_min <= p <= self.p_max):
             self.flip_stars_before_step = False
-            super().__call__(self.binary)
+            super().__call__(self.binary)  
+        # binary in grid but masses flipped
         elif (state_1 == 'H-rich_Core_H_burning' and
               state_2 == 'H-rich_Core_H_burning' and
               event == 'ZAMS' and
@@ -1287,7 +1289,7 @@ class MS_MS_step(MesaGridStep):
               self.p_min <= p <= self.p_max):
             self.flip_stars_before_step = True
             super().__call__(self.binary)
-        # redirect if outside grid
+        # redirect if outside grid for period
         elif (state_1 == 'H-rich_Core_H_burning' and
               state_2 == 'H-rich_Core_H_burning' and
               event == 'ZAMS' and
@@ -1300,8 +1302,7 @@ class MS_MS_step(MesaGridStep):
               event == 'ZAMS' and
               p < self.p_min):
             self.binary.event = 'redirect_from_ZAMS'
-            return
-        
+            return 
         # outside the mass grid for m1
         elif (state_1 == 'H-rich_Core_H_burning' and
               state_2 == 'H-rich_Core_H_burning' and
@@ -1311,13 +1312,14 @@ class MS_MS_step(MesaGridStep):
             set_binary_to_failed(self.binary)
             raise ValueError(f'The mass of m1 ({m1}) is outside the grid,'
                              'while the period is inside the grid.')
-        
         # outside the mass grid for m2
+        # because m2_min is 0.5 Msun or from q_min, the minimum mass ratio is either
+        # q_min or 0.5/m1.
         elif (state_1 == 'H-rich_Core_H_burning' and
               state_2 == 'H-rich_Core_H_burning' and
               event == 'ZAMS' and
               self.p_min <= p <= self.p_max and
-              (m2 < np.max(self.m2_min, 0.5) or m2 > self.m2_max)):
+              (mass_ratio < np.max(self.q_min, 0.5/m1) or mass_ratio > self.q_max)):
             set_binary_to_failed(self.binary)
             raise ValueError(f'The mass of m2 ({m2}) is outside the grid,'
                              'while the period is inside the grid.')

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -1378,7 +1378,6 @@ class CO_HMS_RLO_step(MesaGridStep):
         m2 = self.binary.star_2.mass
         p = self.binary.orbital_period
         ecc = self.binary.eccentricity
-        mass_ratio = m2/m1
 
         # TODO: import states from flow_chart.py
         FOR_RLO_STATES = ["H-rich_Core_H_burning",

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -1374,6 +1374,18 @@ def flip_stars(binary):
         setattr(binary, i+'2_history', value1_history)
 
 
+def set_binary_to_failed(binary):
+    '''Set the properties of the binary to indicate that it has failed.
+    
+    Parameters
+    ----------
+    binary : BinaryStar
+        The binary to set to failed.
+    '''
+    binary.state = "ERR"
+    binary.event = "FAILED"
+    
+
 def infer_star_state(star_mass=None, surface_h1=None,
                      center_h1=None, center_he4=None, center_c12=None,
                      log_LH=None, log_LHe=None, log_Lnuc=None, star_CO=False):


### PR DESCRIPTION
This adds checks for other CO grids and sets the binary state to `"FAILED"` instead of `"ERR"`, which seems to be used in `BinaryPopulation` as well when an error is thrown. Issue  #194