### PR TITLE
CO and SN_type consistency checks

### DIFF
--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -1016,10 +1016,13 @@ class detached_step:
             elif (binary.star_2.state in LIST_ACCEPTABLE_STATES_FOR_HeStar):
                 secondary.htrack = False
             elif (binary.star_2.state in STAR_STATES_CO):
-                binary.state += " Thorne-Zytkow object"
-                if self.verbose or self.verbose == 1:
-                    print("Formation of Thorne-Zytkow object, nothing to do further")
+                # only a compact object left
                 return
+            #elif (binary.star_2.state in STAR_STATES_CO):
+                #binary.state += " Thorne-Zytkow object"
+                #if self.verbose or self.verbose == 1:
+                #    print("Formation of Thorne-Zytkow object, nothing to do further")
+                #return
             else:
                 raise Exception("State not recognized!")
 

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -1019,11 +1019,6 @@ class detached_step:
             elif (binary.star_2.state in STAR_STATES_CO):
                 # only a compact object left
                 return
-            #elif (binary.star_2.state in STAR_STATES_CO):
-                #binary.state += " Thorne-Zytkow object"
-                #if self.verbose or self.verbose == 1:
-                #    print("Formation of Thorne-Zytkow object, nothing to do further")
-                #return
             else:
                 raise Exception("State not recognized!")
 
@@ -1038,9 +1033,6 @@ class detached_step:
             elif (binary.star_1.state in LIST_ACCEPTABLE_STATES_FOR_HeStar):
                 secondary.htrack = False
             elif (binary.star_1.state in STAR_STATES_CO):
-                binary.state += " Thorne-Zytkow object"
-                if self.verbose or self.verbose == 1:
-                    print("Formation of Thorne-Zytkow object, nothing to do further")
                 return
             else:
                 raise Exception("State not recognized!")

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -12,8 +12,7 @@ import numpy as np
 
 from posydon.utils.data_download import PATH_TO_POSYDON_DATA
 from posydon.binary_evol.singlestar import STARPROPERTIES
-from posydon.binary_evol.singlestar import properties_massless_remnant
-from posydon.utils.common_functions import check_state_of_star
+from posydon.utils.common_functions import check_state_of_star, convert_star_to_massless_remnant
 from posydon.binary_evol.DT.step_isolated import IsolatedStep
 
 import warnings
@@ -32,14 +31,6 @@ LIST_ACCEPTABLE_STATES_FOR_POSTMS = STAR_STATES_H_RICH.copy()
 
 LIST_ACCEPTABLE_STATES_FOR_POSTHeMS = STAR_STATES_HE_RICH.copy()
 [LIST_ACCEPTABLE_STATES_FOR_POSTHeMS.remove(x) for x in LIST_ACCEPTABLE_STATES_FOR_HeMS]
-
-
-def convert_star_to_massless_remnant(star):
-    for key in STARPROPERTIES:
-        setattr(star, key, properties_massless_remnant()[key])
-    return star
-
-
 
 
 class MergedStep(IsolatedStep):

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -11,8 +11,8 @@ __authors__ = [
 import numpy as np
 
 from posydon.utils.data_download import PATH_TO_POSYDON_DATA
-from posydon.binary_evol.singlestar import STARPROPERTIES
-from posydon.utils.common_functions import check_state_of_star, convert_star_to_massless_remnant
+from posydon.binary_evol.singlestar import STARPROPERTIES, convert_star_to_massless_remnant
+from posydon.utils.common_functions import check_state_of_star
 from posydon.binary_evol.DT.step_isolated import IsolatedStep
 
 import warnings

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -532,21 +532,7 @@ class StepSN(object):
                     # check if SN_type matches the predicted CO
                     # and force the SN_type to match the predicted CO.
                     # ie WD is no SN
-                    # 1. Check if SN_type and star state match
-                    def check_SN_CO_match(star):
-                        correct_SN_type = True
-                        if star.state == 'WD' and star.SN_type != "WD":
-                            correct_SN_type = False
-                        elif (star.state == "NS" or star.state == "BH") and \
-                                (star.SN_type != 'ECSN' and
-                                star.SN_type != "CCSN" and
-                                star.SN_type != 'PPISN'):
-                            correct_SN_type = False
-                        elif (star.state == "PISN" and star.SN_type != 'PISN'):
-                            correct_SN_type = False     
-                        return correct_SN_type
-                   
-                    
+                    # 1. Check if SN_type and star state match                    
                     # Non-matching SN_type and star state
                     if not check_SN_CO_match(star):
                         # raise a warning
@@ -2377,3 +2363,30 @@ class Couch20_corecollapse(object):
             raise Exception("Need a NS or BH to apply `Sukhbold16_corecollapse`.")
 
         return float(m_rem), f_fb, state
+
+
+
+def check_SN_CO_match(star):
+    '''Check if the SN type matches the stellar state of the given star.
+    
+    Parameters
+    ----------
+    star : SingleStar object
+        Star object containing the star properties.
+        
+    Returns
+    -------
+    correct_SN_type : bool
+        True if the SN type matches the stellar state of the star.
+    '''
+    correct_SN_type = True
+    if star.state == 'WD' and star.SN_type != "WD":
+        correct_SN_type = False
+    elif (star.state == "NS" or star.state == "BH") and \
+            (star.SN_type != 'ECSN' and
+            star.SN_type != "CCSN" and
+            star.SN_type != 'PPISN'):
+        correct_SN_type = False
+    elif (star.state == "PISN" and star.SN_type != 'PISN'):
+        correct_SN_type = False     
+    return correct_SN_type

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -503,7 +503,7 @@ class StepSN(object):
                 elif getattr(star, MODEL_NAME_SEL) is None:
                     # NOTE: this option is needed to do the collapse
                     # for stars evolved with the step_detached or 
-                    # steo_disrupted.
+                    # step_disrupted.
                     # allow to continue with the collapse with profile
                     # or core masses
                     warnings.warn(f'{MODEL_NAME_SEL}: The collapsed star '
@@ -511,14 +511,48 @@ class StepSN(object):
                                      'or use_core_masses is set to True, '
                                      'continue with the collapse.')                 
                 else:
+                    # store some properties of the star object
+                    # to be used for collapse verification
+                    pre_SN_c_core_mass = star.c_core_mass
+                    pre_SN_he_core_mass = star.he_core_mass
+                    pre_SN_mass = star.mass
+                    
                     MODEL_properties = getattr(star, MODEL_NAME_SEL)
                     for key, value in MODEL_properties.items():
                         setattr(star, key, value)
-                
+                    
+
                     for key in STARPROPERTIES:
                         if key not in ["state", "mass", "spin",
                                         "m_disk_accreted ", "m_disk_radiated"]:
                             setattr(star, key, None)
+                            
+                    # check if SN_type is not None
+                    print('state:',star.state)
+                    print('type:',star.SN_type)  
+                    # check if SN_type matches the predicted CO
+                    # ie WD is no SN
+                    if star.state == 'WD' and star.SN_type != "WD":
+                        star.SN_type = 'WD'
+                    elif (star.state == "NS" or star.state == "BH") and \
+                         (star.SN_type != 'ECSN' or star.SN_type != 'CCSN'):
+                        star.SN_type = self.check_SN_type(pre_SN_c_core_mass,
+                                                pre_SN_he_core_mass,
+                                                pre_SN_mass)[-1]
+                    #elif star.state == 'ERR':
+                    
+
+                    #print('state:',star.state)
+                    #print('type:',star.SN_type)   
+                    #print(MODEL_properties.keys())
+                    #print(star.c_core_mass, star.he_core_mass, star.mass)
+                   # print('calculated SN_type', self.check_SN_type(pre_SN_c_core_mass,
+                                                              #     pre_SN_he_core_mass,
+                                                               #    pre_SN_mass))
+                    # if NS/BH then ECSN or CCSN
+                    # if None then PISN?
+                    print('state:',star.state)
+                    print('type:',star.SN_type)  
                     
                     if getattr(star, 'SN_type') != 'PISN':
                         star.log_R = np.log10(CO_radius(star.mass, star.state))

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -529,7 +529,6 @@ class StepSN(object):
                                         "m_disk_accreted ", "m_disk_radiated"]:
                             setattr(star, key, None)
                         
-                    print(star.SN_type)
                     # check if SN_type matches the predicted CO
                     # and force the SN_type to match the predicted CO.
                     # ie WD is no SN

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -517,9 +517,6 @@ class StepSN(object):
                     # store some properties of the star object
                     # to be used for collapse verification
                     pre_SN_star = copy.deepcopy(star)
-                    pre_SN_c_core_mass = star.c_core_mass
-                    pre_SN_he_core_mass = star.he_core_mass
-                    pre_SN_mass = star.mass
 
                     MODEL_properties = getattr(star, MODEL_NAME_SEL)
                     for key, value in MODEL_properties.items():
@@ -549,9 +546,9 @@ class StepSN(object):
                             star.state = 'PISN'
                         else:
                             _, _, star.state = self.compute_m_rembar(pre_SN_star, m_PISN)
-                            star.SN_type = self.check_SN_type(pre_SN_c_core_mass,
-                                                            pre_SN_he_core_mass,
-                                                            pre_SN_mass)[-1]
+                            star.SN_type = self.check_SN_type(pre_SN_star.c_core_mass,
+                                                            pre_SN_star.he_core_mass,
+                                                            pre_SN_star.mass)[-1]
 
                         # check if the new SN_type matches new SN_type
                         if not check_SN_CO_match(star):

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -526,7 +526,7 @@ class StepSN(object):
                         if key not in ["state", "mass", "spin",
                                         "m_disk_accreted ", "m_disk_radiated"]:
                             setattr(star, key, None)
-                        
+                    
                     # check if SN_type matches the predicted CO
                     # and force the SN_type to match the predicted CO.
                     # ie WD is no SN
@@ -2383,6 +2383,9 @@ def check_SN_CO_match(star):
     correct_SN_type : bool
         True if the SN type matches the stellar state of the star.
     '''
+    # TODO: remove star.state == PISN, because PISN shouldn't be a stellar state
+    if star.state == 'PISN':
+        star.state = 'massless_remnant'
     correct_SN_type = True
     if star.state == 'WD' and star.SN_type != "WD":
         correct_SN_type = False

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -2386,9 +2386,12 @@ def check_SN_CO_match(star):
     correct_SN_type = True
     if star.state == 'WD' and star.SN_type != "WD":
         correct_SN_type = False
-    elif (star.state == "NS" or star.state == "BH") and \
+    elif (star.state == "NS") and \
             (star.SN_type != 'ECSN' and
-            star.SN_type != "CCSN" and
+            star.SN_type != "CCSN"):
+        correct_SN_type = False
+    elif (star.state =="BH") and \
+            (star.SN_type != "CCSN" and
             star.SN_type != 'PPISN'):
         correct_SN_type = False
     elif (star.state == "PISN" and star.SN_type != 'PISN'):

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -44,11 +44,11 @@ from posydon.utils.common_functions import (
 )
 
 from posydon.binary_evol.binarystar import BINARYPROPERTIES
-from posydon.binary_evol.singlestar import STARPROPERTIES
+from posydon.binary_evol.singlestar import STARPROPERTIES, convert_star_to_massless_remnant
 from posydon.binary_evol.SN.profile_collapse import do_core_collapse_BH
 from posydon.binary_evol.flow_chart import (STAR_STATES_CO, STAR_STATES_CC,
                                             STAR_STATES_C_DEPLETION)
-from posydon.binary_evol.DT.step_merged import convert_star_to_massless_remnant
+
 from posydon.grids.MODELS import MODELS
 
 from pandas import read_csv

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -472,7 +472,7 @@ class StepSN(object):
 
         """
         state = star.state
-
+        
         # Verifies if the star is in state state where it can
         # explode
         if state in STAR_STATES_CC:
@@ -496,6 +496,8 @@ class StepSN(object):
                         if self.verbose:
                             print('matched to model:', tmp)
                         MODEL_NAME_SEL = tmp
+                
+                
                 
                 # check if selected MODEL is supported
                 if MODEL_NAME_SEL is None:
@@ -526,7 +528,8 @@ class StepSN(object):
                         if key not in ["state", "mass", "spin",
                                         "m_disk_accreted ", "m_disk_radiated"]:
                             setattr(star, key, None)
-                            
+                        
+                    print(star.SN_type)
                     # check if SN_type matches the predicted CO
                     # and force the SN_type to match the predicted CO.
                     # ie WD is no SN
@@ -593,15 +596,7 @@ class StepSN(object):
 
                 # check if the star was disrupted by the PISN
                 if np.isnan(m_rembar):
-                    star.mass = np.nan
-                    star.state = "PISN"
-                    star.spin = np.nan
-                    star.m_disk_accreted = np.nan
-                    star.m_disk_radiated = np.nan
-                    for key in STARPROPERTIES:
-                        if key not in ["state", "mass", "spin",
-                                       "m_disk_accreted ", "m_disk_radiated"]:
-                            setattr(star, key, None)
+                    convert_star_to_massless_remnant(star=star)
                     return
 
                 # Computing the gravitational mass of the remnant
@@ -700,15 +695,7 @@ class StepSN(object):
 
                 # check if the star was disrupted by the PISN
                 if np.isnan(m_rembar):
-                    star.mass = np.nan
-                    star.state = "PISN"
-                    star.spin = np.nan
-                    star.m_disk_accreted = np.nan
-                    star.m_disk_radiated = np.nan
-                    for key in STARPROPERTIES:
-                        if key not in ["state", "mass", "spin",
-                                       "m_disk_accreted ", "m_disk_radiated"]:
-                            setattr(star, key, None)
+                    convert_star_to_massless_remnant(star=star)
                     return
 
                 # Computing the gravitational mass of the remnant

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -561,7 +561,7 @@ class StepSN(object):
                                 star.SN_type = 'WD'
                             elif star.state == 'NS' or star.state == 'BH':
                                 star.SN_type = 'CCSN'
-                            elif star.state == 'PISN':
+                            elif star.state == 'massless_remnant':
                                 star.SN_type = 'PISN'
                             else:
                                 raise ValueError('Star state not recognized.')

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -543,7 +543,7 @@ class StepSN(object):
                         # no remnant if a PISN happens
                         if pd.isna(m_PISN):
                             star.SN_type = 'PISN'
-                            star.state = 'PISN'
+                            star.state = 'massless_remnant'
                         else:
                             _, _, star.state = self.compute_m_rembar(pre_SN_star, m_PISN)
                             star.SN_type = self.check_SN_type(pre_SN_star.c_core_mass,
@@ -2394,6 +2394,6 @@ def check_SN_CO_match(star):
             (star.SN_type != "CCSN" and
             star.SN_type != 'PPISN'):
         correct_SN_type = False
-    elif (star.state == "massless_remnant" and star.SN_type != 'PISN'):
+    elif (star.state == "PISN" and star.SN_type != 'PISN'):
         correct_SN_type = False     
     return correct_SN_type

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -2394,6 +2394,6 @@ def check_SN_CO_match(star):
             (star.SN_type != "CCSN" and
             star.SN_type != 'PPISN'):
         correct_SN_type = False
-    elif (star.state == "PISN" and star.SN_type != 'PISN'):
+    elif (star.state == "massless_remnant" and star.SN_type != 'PISN'):
         correct_SN_type = False     
     return correct_SN_type

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -286,10 +286,12 @@ class BinaryStar:
 
     def update_star_states(self):
         """Update the states of the two stars in the binary."""
-        self.star_1.state = check_state_of_star(
-            self.star_1, star_CO=self.star_1.state in ["WD", "BH", "NS"])
-        self.star_2.state = check_state_of_star(
-            self.star_2, star_CO=self.star_2.state in ["WD", "BH", "NS"])
+        if self.star_1.state != 'massless_remnant':
+            self.star_1.state = check_state_of_star(
+                self.star_1, star_CO=self.star_1.state in ["WD", "BH", "NS"])
+        if self.star_2.state != 'massless_remnant':
+            self.star_2.state = check_state_of_star(
+                self.star_2, star_CO=self.star_2.state in ["WD", "BH", "NS"])
 
     def to_df(self, **kwargs):
         """Return history parameters from the binary in a DataFrame.

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -288,10 +288,10 @@ class BinaryStar:
         """Update the states of the two stars in the binary."""
         if self.star_1.state != 'massless_remnant':
             self.star_1.state = check_state_of_star(
-                self.star_1, star_CO=self.star_1.state in ["WD", "BH", "NS"])
+                self.star_1, star_CO=self.star_1.state in ["WD", "NS", "BH"])
         if self.star_2.state != 'massless_remnant':
             self.star_2.state = check_state_of_star(
-                self.star_2, star_CO=self.star_2.state in ["WD", "BH", "NS"])
+                self.star_2, star_CO=self.star_2.state in ["WD", "NS", "BH"])
 
     def to_df(self, **kwargs):
         """Return history parameters from the binary in a DataFrame.

--- a/posydon/binary_evol/flow_chart.py
+++ b/posydon/binary_evol/flow_chart.py
@@ -246,13 +246,6 @@ for b in ['initially_single_star']:
                 POSYDON_FLOW_CHART[(s1, s2, b, e)] = 'step_initially_single'
                 POSYDON_FLOW_CHART[(s2, s1, b, e)] = 'step_initially_single'
 
-for s1 in STAR_STATES_CO:
-    for s2 in ['massless_remnant']:
-        for e in BINARY_EVENTS_ALL:
-            POSYDON_FLOW_CHART[(s1, s2, b, e)] = 'step_end'
-            POSYDON_FLOW_CHART[(s2, s1, b, e)] = 'step_end'
-
-
 
 BINARY_EVENTS_OF_SN_OR_AFTER_DETACHED = BINARY_EVENTS_ALL.copy()
 [BINARY_EVENTS_OF_SN_OR_AFTER_DETACHED.remove(x) for x in ['CC1','CC2','MaxTime_exceeded','maxtime']]
@@ -291,6 +284,15 @@ for b in BINARY_STATES_ALL:
         for s2 in STAR_STATES_ALL:
             for e in ['maxtime', 'MaxTime_exceeded', 'CO_contact']:
                 POSYDON_FLOW_CHART[(s1, s2, b, e)] = 'step_end'
+
+# catch all massless remnants with compact objects
+for b in BINARY_STATES_ALL:
+    for s1 in STAR_STATES_CO:
+        for s2 in ['massless_remnant']:
+            for e in BINARY_EVENTS_ALL:
+                POSYDON_FLOW_CHART[(s1, s2, b, e)] = 'step_end'
+                POSYDON_FLOW_CHART[(s2, s1, b, e)] = 'step_end'
+
 
 
 def flow_chart(FLOW_CHART=POSYDON_FLOW_CHART, CHANGE_FLOW_CHART=None):

--- a/posydon/binary_evol/flow_chart.py
+++ b/posydon/binary_evol/flow_chart.py
@@ -293,6 +293,11 @@ for b in BINARY_STATES_ALL:
                 POSYDON_FLOW_CHART[(s1, s2, b, e)] = 'step_end'
                 POSYDON_FLOW_CHART[(s2, s1, b, e)] = 'step_end'
 
+for b in BINARY_STATES_ALL:
+    for s in ['massless_remnant']:
+        for e in BINARY_EVENTS_ALL:
+            POSYDON_FLOW_CHART[(s, s, b, e)] = 'step_end'
+
 
 
 def flow_chart(FLOW_CHART=POSYDON_FLOW_CHART, CHANGE_FLOW_CHART=None):

--- a/posydon/binary_evol/flow_chart.py
+++ b/posydon/binary_evol/flow_chart.py
@@ -293,6 +293,8 @@ for b in BINARY_STATES_ALL:
                 POSYDON_FLOW_CHART[(s1, s2, b, e)] = 'step_end'
                 POSYDON_FLOW_CHART[(s2, s1, b, e)] = 'step_end'
 
+# catch two massless remnants
+# separate for readability
 for b in BINARY_STATES_ALL:
     for s in ['massless_remnant']:
         for e in BINARY_EVENTS_ALL:

--- a/posydon/binary_evol/singlestar.py
+++ b/posydon/binary_evol/singlestar.py
@@ -113,6 +113,10 @@ def properties_massless_remnant():
     PROPERTIES_MASSLESS["mass"] = 0.0
     return PROPERTIES_MASSLESS
 
+def convert_star_to_massless_remnant(star):
+    for key in STARPROPERTIES:
+        setattr(star, key, properties_massless_remnant()[key])
+    return star
 
 class SingleStar:
     """Class describing a single star."""

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -24,8 +24,6 @@ from posydon.utils import constants as const
 import copy
 import warnings
 from scipy.interpolate import PchipInterpolator
-from posydon.binary_evol.singlestar import properties_massless_remnant, STARPROPERTIES
-
 
 PATH_TO_POSYDON = os.environ.get("PATH_TO_POSYDON")
 
@@ -1375,10 +1373,6 @@ def flip_stars(binary):
         setattr(binary, i+'2_history', value1_history)
 
 
-def convert_star_to_massless_remnant(star):
-    for key in STARPROPERTIES:
-        setattr(star, key, properties_massless_remnant()[key])
-    return star
 
 def infer_star_state(star_mass=None, surface_h1=None,
                      center_h1=None, center_he4=None, center_c12=None,

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -24,6 +24,7 @@ from posydon.utils import constants as const
 import copy
 import warnings
 from scipy.interpolate import PchipInterpolator
+from posydon.binary_evol.singlestar import properties_massless_remnant, STARPROPERTIES
 
 
 PATH_TO_POSYDON = os.environ.get("PATH_TO_POSYDON")
@@ -1373,6 +1374,11 @@ def flip_stars(binary):
         setattr(binary, i+'1_history', value2_history)
         setattr(binary, i+'2_history', value1_history)
 
+
+def convert_star_to_massless_remnant(star):
+    for key in STARPROPERTIES:
+        setattr(star, key, properties_massless_remnant()[key])
+    return star
 
 def infer_star_state(star_mass=None, surface_h1=None,
                      center_h1=None, center_he4=None, center_c12=None,


### PR DESCRIPTION
The SN_type and compact object state are independently classified. As a result, the `SN_type` can mismatch the compact object type predicted by the interpolator (See Issues #79, #195, #220).

While this overwrites some `SN_type=None` predictions from the interpolator when a BH or NS is formed, I'm not sure how to handle all cases.

This PR is to address these issues by implementing a consistency check for the case where the `SN_type` does not match the predicted CO.

I provide an example binary for each case and a few 'good' binaries.



## Error binaries:
<details>
<summary>CO=NS with SN_type=WD (Issue #79)</summary>

----
**This should return CO=NS with SN_type=ECSN.**

```
STAR1 = SingleStar(**{'mass': 6.782576, 
                      'state': 'H-rich_Core_H_burning'})
STAR2 = SingleStar(**{'mass':3.273864,
                      'state': 'H-rich_Core_H_burning'})

BINARY = BinaryStar(STAR1, STAR2,  
                    **{'time': 0.0, 'state': 'detached', 'event': 'ZAMS', 'orbital_period':4513.150157, 'eccentricity': 0.0},
                    properties = sim_pop)
```
preSN properties: 
- ECSN prescription: 'Podsiadlowksi+04'
- C core mass: 1.328124743188463
- He core mass: 2.0052920504094196
- star mass: 6.688762345425637
---
</details>

<details><summary>CO=BH, SN_type=None (Issue #220)</summary>

---
**This should return CO=BH with SN_type=CCSN.**

```
STAR1 = SingleStar(**{'mass': 17.782576, 
                      'state': 'H-rich_Core_H_burning'})
STAR2 = SingleStar(**{'mass':3.273864,
                      'state': 'H-rich_Core_H_burning'})

BINARY = BinaryStar(STAR1, STAR2,  
                    **{'time': 0.0, 'state': 'detached', 'event': 'ZAMS', 'orbital_period':4513.150157, 'eccentricity': 0.0},
                    properties = sim_pop)
```

PreSN properties:
- C core mass: 6.0967014022685015
- He core mass: 7.948455463697542
- star mass: 8.945633604962683

---
</details> 

<details><summary>state=PISN and SN_type=CCSN (Issue #195)</summary>
<p>

---
**Should be state=PISN, SN_type=PISN**

I am not sure if this is the correct evolution now, since it does not evolve the `distrupted` binary.
I feel like it should switch to a `massless_remnant` and the `state` in the `step_SN` should not be `PISN`.
However, changing it to `massless_remnant` creates different issues.
**EDIT: 15/10/2023: Based on discussion in Issue #195, we have chosen to go with `massless_remnant` and adjust the code accordingly to properly evolve the disrupted binary.**


```
STAR1 = SingleStar(**{'mass': 	170.638207, 
                      'state': 'H-rich_Core_H_burning',
                      'natal_kick_array': [4.921294, 4.31745, 1.777768, 3.509656]})
STAR2 = SingleStar(**{'mass':37.917852,
                      'state': 'H-rich_Core_H_burning'})

BINARY = BinaryStar(STAR1, STAR2,  
                    **{'time': 0.0, 'state': 'detached', 'event': 'ZAMS', 'orbital_period':113.352736, 'eccentricity': 0.0},
                    properties = sim_pop)
```
**EDIT: New Evolution**


state | event | time | S1_mass | S2_mass | orbital_period | S1_state | S2_state | step_names
 -- | -- | -- | -- | -- | -- | -- | -- | --
detached | ZAMS | 0.000000e+00 | 170.638207 | 37.917852 | 113.352736 | H-rich_Core_H_burning | H-rich_Core_H_burning | initial_cond
detached | CC1 | 2.827616e+06 | 155.652108 | 38.967189 | 71.996420 | H-rich_Central_He_depleted | H-rich_Core_H_burning | step_HMS_HMS
disrupted | <NA> | 2.827616e+06 | 0.000000 | 38.967189 | NaN | massless_remnant | H-rich_Core_H_burning | step_SN
disrupted | CC2 | 5.799377e+06 | 0.000000 | 29.299084 | NaN | massless_remnant | H-rich_Central_C_depletion | step_disrupted
disrupted | <NA> | 5.799377e+06 | 0.000000 | 19.314849 | NaN | massless_remnant | BH | step_SN
disrupted | END | 5.799377e+06 | 0.000000 | 19.314849 | NaN | massless_remnant | BH | step_end


**Previous Evolution**

 state | event | time | S1_mass | S2_mass | orbital_period | S1_state | S2_state | step_names
 -- | -- | -- | -- | -- | -- | -- | -- | --
detached | ZAMS | 0.000000e+00 | 170.638207 | 37.917852 | 113.352736 | H-rich_Core_H_burning | H-rich_Core_H_burning | initial_cond
detached | CC1 | 2.827616e+06 | 155.652108 | 38.967189 | 71.996420 | H-rich_Central_He_depleted | H-rich_Core_H_burning | step_HMS_HMS
disrupted | <NA> | 2.827616e+06 | NaN | 38.967189 | NaN | PISN | H-rich_Core_H_burning | step_SN
disrupted | END | 2.827616e+06 | NaN | 38.967189 | NaN | PISN | H-rich_Core_H_burning | nan


---
</p>

</details> 

<details><summary>merger + PISN</summary>
<p>

----

This binary merges during a CE and S2 becomes a massless remnant.
The primary then undergoes a PISN after depleting carbon.

The S1_state should not be PISN, but massless_remnant too.
Then the binary should be send to `step_end`.

state | event | time | S1_mass | S2_mass | orbital_period | S1_state | S2_state | step_names
-- | -- | -- | -- | -- | -- | -- | -- | --
detached | ZAMS | 0.000000e+00 | 100.638207 | 37.917852 | 113.352736 | H-rich_Core_H_burning | H-rich_Core_H_burning | initial_cond
RLO1 | oCE1 | 3.389395e+06 | 78.375401 | 39.168541 | 59.701795 | H-rich_Central_He_depleted | H-rich_Core_H_burning | step_HMS_HMS
merged | oMerging1 | 3.389395e+06 | 78.375401 | 39.168541 | 59.701795 | H-rich_Central_He_depleted | H-rich_Core_H_burning | step_CE
merged | CC1 | 3.680443e+06 | 120.404497 | 0.000000 | NaN | H-rich_Central_C_depletion | massless_remnant | step_merged
merged |   | 3.680443e+06 | NaN | 0.000000 | NaN | PISN | massless_remnant | step_SN
merged | END | 3.680443e+06 | NaN | 0.000000 | NaN | PISN | massless_remnant | nan

**Cleaned up evolution **

 state | event | time | S1_mass | S2_mass | orbital_period | S1_state | S2_state | step_names
 -- | -- | -- | -- | -- | -- | -- | -- | --

detached | ZAMS | 0.000000e+00 | 100.638207 | 37.917852 | 113.352736 | H-rich_Core_H_burning | H-rich_Core_H_burning | initial_cond
RLO1 | oCE1 | 3.389395e+06 | 78.375401 | 39.168541 | 59.701795 | H-rich_Central_He_depleted | H-rich_Core_H_burning | step_HMS_HMS
merged | oMerging1 | 3.389395e+06 | 78.375401 | 39.168541 | 59.701795 | H-rich_Central_He_depleted | H-rich_Core_H_burning | step_CE
merged | CC1 | 3.680443e+06 | 120.404497 | 0.000000 | NaN | H-rich_Central_C_depletion | massless_remnant | step_merged
merged | <NA> | 3.680443e+06 | 0.000000 | 0.000000 | NaN | massless_remnant | massless_remnant | step_SN
merged | END | 3.680443e+06 | 0.000000 | 0.000000 | NaN | massless_remnant | massless_remnant | step_end

----

</p>
</details> 


## Good binaries:
<details>
<summary>CO=NS with SN_type=CCSN </summary>

---

```
STAR1 = SingleStar(**{'mass': 8.782576, 
                      'state': 'H-rich_Core_H_burning'})
STAR2 = SingleStar(**{'mass':3.273864,
                      'state': 'H-rich_Core_H_burning'})

BINARY = BinaryStar(STAR1, STAR2,  
                    **{'time': 0.0, 'state': 'detached', 'event': 'ZAMS', 'orbital_period':4513.150157, 'eccentricity': 0.0},
                    properties = sim_pop)
```
---

</details>

<details><summary>BH + BH (disrupted)</summary>
<p>

----

This binary looks as expected.

 state | event | time | S1_mass | S2_mass | orbital_period | S1_state | S2_state | step_names
 -- | -- | -- | -- | -- | -- | -- | -- | --

detached | ZAMS | 0.000000e+00 | 40.638207 | 37.917852 | 2113.352736 | H-rich_Core_H_burning | H-rich_Core_H_burning | initial_cond
detached | CC1 | 5.552096e+06 | 27.678909 | 29.162179 | 3379.031935 | H-rich_Central_C_depletion | H-rich_Shell_H_burning | step_HMS_HMS
detached | <NA> | 5.552096e+06 | 20.679255 | 29.162179 | 5459.060963 | BH | H-rich_Shell_H_burning | step_SN
detached | CC2 | 5.832642e+06 | 20.679255 | 26.597324 | 5048.384078 | BH | H-rich_Central_C_depletion | step_detached
disrupted | <NA> | 5.832642e+06 | 20.679255 | 17.654297 | NaN | BH | BH | step_SN
disrupted | END | 5.832642e+06 | 20.679255 | 17.654297 | NaN | BH | BH | step_end


```
STAR1 = SingleStar(**{'mass': 	40.638207, 
                      'state': 'H-rich_Core_H_burning',
                      'natal_kick_array': [30.921294, 4.31745, 1.777768, 3.509656]})
STAR2 = SingleStar(**{'mass':37.917852,
                      'state': 'H-rich_Core_H_burning'})

BINARY = BinaryStar(STAR1, STAR2,  
                    **{'time': 0.0, 'state': 'detached', 'event': 'ZAMS', 'orbital_period':2113.352736, 'eccentricity': 0.0},
                    properties = sim_pop)
```

---

</p>
</details> 