### PR TITLE
We can't use different criteria in MESA and POSYDON to detect the beginning of RLO

### DIFF
--- a/posydon/grids/scrubbing.py
+++ b/posydon/grids/scrubbing.py
@@ -98,14 +98,22 @@ def keep_after_RLO(bh, h1, h2):
     bh_colnames = bh.dtype.names
 
     if "lg_mtransfer_rate" in bh_colnames:
-        rate = bh["lg_mtransfer_rate"] >= -12
+        # This needs to be aligned with run_binary_extras.f
+        # old: rate = bh["lg_mtransfer_rate"] >= -12
+        rate = bh["lg_mtransfer_rate"] >= -10
     else:
         raise ValueError("No `lg_mtransfer_rate` in binary history.")
 
-    rlo1 = (bh["rl_relative_overflow_1"] >= -0.05
+    # This needs to be aligned with run_binary_extras.f
+    # old: rlo1 = (bh["rl_relative_overflow_1"] >= -0.05
+    #        if "rl_relative_overflow_1" in bh_colnames else None)
+    rlo1 = (bh["rl_relative_overflow_1"] >= 0.00
             if "rl_relative_overflow_1" in bh_colnames else None)
 
-    rlo2 = (bh["rl_relative_overflow_2"] >= -0.05
+    # This needs to be aligned with run_binary_extras.f
+    #old: rlo2 = (bh["rl_relative_overflow_2"] >= -0.05
+    #        if "rl_relative_overflow_2" in bh_colnames else None)
+    rlo2 = (bh["rl_relative_overflow_2"] >= 0.00
             if "rl_relative_overflow_2" in bh_colnames else None)
 
     if rlo1 is None:
@@ -118,6 +126,8 @@ def keep_after_RLO(bh, h1, h2):
     if rlo_1_or_2 is None:
         raise ValueError("No `rl_relative_overflow` in any star history.")
 
+    # This needs to be aligned with run_binary_extras.f, there it is less
+    # restrictive, which is fine
     conditions_met = rlo_1_or_2 & rate
     where_conditions_met = np.where(conditions_met)[0]
 


### PR DESCRIPTION
Currently, we have different criteria in MESA to switch on binary interaction for the CO-HMS grid and what we cut out when creating the PSyGrid object.
Some more details can be found on [Slack](https://posydon.slack.com/archives/CDCS3MS31/p1705565761699109).

I have now changed the POSYDON to match MESA, while the POSYDON version looks to be contain more thoughts and have being more up to date with science state of the art.

Please, discuss here the reasons, which condition to use in the future and how we should ensure that our two criterion (for MESA and POSYDON) will stay aligned.