### PR TITLE
CO-H(e)MS period outside grid being failed fix

### DIFF
--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -1431,7 +1431,9 @@ class CO_HMS_RLO_step(MesaGridStep):
             self.p_min <= p <= self.p_max and
             ecc == 0.)):
             super().__call__(self.binary)
-
+        elif p > self.p_max:
+            self.binary.event = 'redirect_from_CO_HMS_RLO'
+            return
         # period inside the grid, but m1 outside the grid
         elif ((not self.flip_stars_before_step and
                self.p_min <= p <= self.p_max and

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -1545,6 +1545,9 @@ class CO_HeMS_RLO_step(MesaGridStep):
             self.p_min <= p <= self.p_max and
             ecc == 0.)):
             super().__call__(self.binary)
+        elif p > self.p_max:
+            self.binary.event = 'redirect_from_CO_HeMS_RLO'
+            return
         # period inside the grid, but m1 outside the grid
         elif ((not self.flip_stars_before_step and
                self.p_min <= p <= self.p_max and
@@ -1662,6 +1665,10 @@ class CO_HeMS_step(MesaGridStep):
             self.p_min <= p <= self.p_max and
             ecc == 0.)):
             super().__call__(binary)
+        # binary outside grid
+        elif p > self.p_max:
+            binary.event = 'redirect_from_CO_HeMS'
+            return
         else:
             if len(self.binary.state_history) > 2:
                 if self.binary.state_history[-2] == 'detached':

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -1705,5 +1705,6 @@ class CO_HeMS_step(MesaGridStep):
         #    binary.event = 'redirect_from_CO_HeMS'
         #    return
         else:
+            self.binary.state = 'detached'
             self.binary.event = 'redirect_from_CO_HeMS'
             return


### PR DESCRIPTION
The CO-H(e)MS looping fix was too strong and would cause too many systems to fail.

This fix checks if the period is outside the grid period and then redirects the binary back to detached.

example binary at 1Zsun
```
STAR1 = SingleStar(**{'mass': 58.947503,
                      'state': 'H-rich_Core_H_burning'})
STAR2 = SingleStar(**{'mass': 56.660506,
                      'state': 'H-rich_Core_H_burning'})

BINARY = BinaryStar(STAR1, STAR2,  
                    **{'time': 0.0, 'state': 'detached', 'event': 'ZAMS', 'orbital_period':211.300659, 'eccentricity': 0.0},
                    properties = sim_pop)
```