### PR TITLE
Keeping the WD abundances for the step_merged

### DIFF
--- a/posydon/binary_evol/CE/step_CEE.py
+++ b/posydon/binary_evol/CE/step_CEE.py
@@ -37,7 +37,7 @@ import numpy as np
 from posydon.utils import common_functions as cf
 from posydon.utils import constants as const
 import warnings
-
+import copy as copy
 from posydon.binary_evol.binarystar import BINARYPROPERTIES
 from posydon.binary_evol.singlestar import STARPROPERTIES
 from posydon.utils.common_functions import PATH_TO_POSYDON
@@ -202,7 +202,8 @@ class StepCEE(object):
         else:
             raise ValueError("CEE does not apply if `event` is not "
                              "`oCE1`, 'oDoubleCE1' or `oCE2`, 'oDoubleCE1'")
-
+        if comp_star.state == 'WD' or donor_star.state == 'WD':
+            print('entering CE as' , comp_star.state,binary.star_1.co_core_mass ,comp_star.co_core_mass)
         # Check for double CE
         double_CE = binary.event in ["oDoubleCE1", "oDoubleCE2"]
 
@@ -597,7 +598,7 @@ class StepCEE(object):
                         mc2_f = comp_star.he_core_mass
                         rc2_f = donor.he_core_radius
                     elif comp_type == "CO_core":
-                        mc2_f = comp_star.co_core_mass
+                        mc2_f = copy(comp_star.co_core_mass)
                         rc2_f = donor.co_core_radius
                     elif comp_type == "not_giant_companion":
                         mc2_f = comp_star.mass
@@ -801,6 +802,8 @@ class StepCEE(object):
 
         else:
             # system merges
+            if donor.state == 'WD' or comp_star.state == 'WD':
+                print('merges',donor.state,comp_star.state,comp_star.co_core_mass)
             binary.state = 'merged'
             if binary.event in ["oCE1", "oDoubleCE1"]:
                 binary.event = "oMerging1"

--- a/posydon/binary_evol/CE/step_CEE.py
+++ b/posydon/binary_evol/CE/step_CEE.py
@@ -37,7 +37,6 @@ import numpy as np
 from posydon.utils import common_functions as cf
 from posydon.utils import constants as const
 import warnings
-import copy as copy
 from posydon.binary_evol.binarystar import BINARYPROPERTIES
 from posydon.binary_evol.singlestar import STARPROPERTIES
 from posydon.utils.common_functions import PATH_TO_POSYDON
@@ -596,7 +595,7 @@ class StepCEE(object):
                         mc2_f = comp_star.he_core_mass
                         rc2_f = donor.he_core_radius
                     elif comp_type == "CO_core":
-                        mc2_f = copy(comp_star.co_core_mass)
+                        mc2_f = comp_star.co_core_mass
                         rc2_f = donor.co_core_radius
                     elif comp_type == "not_giant_companion":
                         mc2_f = comp_star.mass

--- a/posydon/binary_evol/CE/step_CEE.py
+++ b/posydon/binary_evol/CE/step_CEE.py
@@ -202,8 +202,6 @@ class StepCEE(object):
         else:
             raise ValueError("CEE does not apply if `event` is not "
                              "`oCE1`, 'oDoubleCE1' or `oCE2`, 'oDoubleCE1'")
-        if comp_star.state == 'WD' or donor_star.state == 'WD':
-            print('entering CE as' , comp_star.state,binary.star_1.co_core_mass ,comp_star.co_core_mass)
         # Check for double CE
         double_CE = binary.event in ["oDoubleCE1", "oDoubleCE2"]
 
@@ -802,8 +800,6 @@ class StepCEE(object):
 
         else:
             # system merges
-            if donor.state == 'WD' or comp_star.state == 'WD':
-                print('merges',donor.state,comp_star.state,comp_star.co_core_mass)
             binary.state = 'merged'
             if binary.event in ["oCE1", "oDoubleCE1"]:
                 binary.event = "oMerging1"

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -123,11 +123,11 @@ class MergedStep(IsolatedStep):
         merged_star = star_base
 
         s1 = star_base.state
-        s2 = comp.state
+        s2 = comp.state 
         def mass_weighted_avg(star1=star_base,star2=comp, abundance_name="center_h1", mass_weight1="mass", mass_weight2=None):
             A1 = getattr(star1, abundance_name)
             A2 = getattr(star2, abundance_name)
-
+            print(star2.state)
             if mass_weight1 == "H-rich_envelope_mass":
                 M1 = getattr(star1, "mass") - getattr(star1, "he_core_mass")
             elif mass_weight1 == "He-rich_envelope_mass":
@@ -143,6 +143,7 @@ class MergedStep(IsolatedStep):
                 M2 = getattr(star2, "he_core_mass") - getattr(star2, "co_core_mass")
             else:
                 M2 = getattr(star2, mass_weight2)
+            print(A1,A2,M1,M2)
             return (A1*M1 + A2*M2 ) / (M1+M2)
 
         # MS + MS
@@ -403,7 +404,7 @@ class MergedStep(IsolatedStep):
                 for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
                     current = getattr(merged_star, key) + getattr(star_base, key)
                     setattr(merged_star, key,current)
-
+                
                 # weighted central abundances if merging cores. Else only from star_base
                 if star_base.co_core_mass == 0 and comp.co_core_mass == 0: # two stars with Helium cores
                     merged_star.center_h1 = mass_weighted_avg(mass_weight1="he_core_mass")
@@ -495,12 +496,12 @@ class MergedStep(IsolatedStep):
             and s2 in ["WD"]):
 
                 #WD is considered a stripped CO core
-
+                print(comp.state,comp.co_core_mass)
                 # add total and core masses
                 for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
                     current = getattr(merged_star, key) + getattr(comp, "mass")
                     setattr(merged_star, key,current)
-
+                comp.co_core_mass = comp.mass
                 # weighted central abundances if merging cores. Else only from star_base
                 if (comp.co_core_mass > 0 and star_base.co_core_mass == 0): # comp with CO core and the star_base has not
                     merged_star.center_h1 = comp.center_h1

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -127,7 +127,6 @@ class MergedStep(IsolatedStep):
         def mass_weighted_avg(star1=star_base,star2=comp, abundance_name="center_h1", mass_weight1="mass", mass_weight2=None):
             A1 = getattr(star1, abundance_name)
             A2 = getattr(star2, abundance_name)
-            print(star2.state)
             if mass_weight1 == "H-rich_envelope_mass":
                 M1 = getattr(star1, "mass") - getattr(star1, "he_core_mass")
             elif mass_weight1 == "He-rich_envelope_mass":
@@ -143,7 +142,6 @@ class MergedStep(IsolatedStep):
                 M2 = getattr(star2, "he_core_mass") - getattr(star2, "co_core_mass")
             else:
                 M2 = getattr(star2, mass_weight2)
-            print(A1,A2,M1,M2)
             return (A1*M1 + A2*M2 ) / (M1+M2)
 
         # MS + MS
@@ -496,12 +494,10 @@ class MergedStep(IsolatedStep):
             and s2 in ["WD"]):
 
                 #WD is considered a stripped CO core
-                print(comp.state,comp.co_core_mass)
                 # add total and core masses
                 for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
                     current = getattr(merged_star, key) + getattr(comp, "mass")
                     setattr(merged_star, key,current)
-                comp.co_core_mass = comp.mass
                 # weighted central abundances if merging cores. Else only from star_base
                 if (comp.co_core_mass > 0 and star_base.co_core_mass == 0): # comp with CO core and the star_base has not
                     merged_star.center_h1 = comp.center_h1

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -123,7 +123,7 @@ class MergedStep(IsolatedStep):
         merged_star = star_base
 
         s1 = star_base.state
-        s2 = comp.state 
+        s2 = comp.state
         def mass_weighted_avg(star1=star_base,star2=comp, abundance_name="center_h1", mass_weight1="mass", mass_weight2=None):
             A1 = getattr(star1, abundance_name)
             A2 = getattr(star2, abundance_name)
@@ -402,7 +402,6 @@ class MergedStep(IsolatedStep):
                 for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
                     current = getattr(merged_star, key) + getattr(star_base, key)
                     setattr(merged_star, key,current)
-                
                 # weighted central abundances if merging cores. Else only from star_base
                 if star_base.co_core_mass == 0 and comp.co_core_mass == 0: # two stars with Helium cores
                     merged_star.center_h1 = mass_weighted_avg(mass_weight1="he_core_mass")

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -332,9 +332,9 @@ class MesaGridStep:
                                       track_interpolation=True)
         else:
             self.step(binary, interp_method=self.interpolation_method)
-        
         if (self.stop_method == 'stop_at_max_time'
                 and binary.time >= binary.properties.max_simulation_time):
+            
             # self.flush_history = True # needed???
 
             # stop_at_condition looks through the MESA output appended to the
@@ -363,7 +363,6 @@ class MesaGridStep:
                              interpolate=self.stop_interpolate,
                              star_1_CO=self.star_1_CO,
                              star_2_CO=self.star_2_CO)
-        
         if self.flip_stars_before_step:
             flip_stars(binary)
         if binary.time > binary.properties.max_simulation_time:
@@ -498,7 +497,7 @@ class MesaGridStep:
                     getattr(binary, key_h).append(v_key)
                 if track_interpolation:
                     getattr(binary, key_h).extend([v_key]*length_hist)
-            elif key in ['state', 'event']:
+            elif key in ['state', 'event', 'mass_transfer_case']:
                 continue
             else:
                 key_p = POSYDON_TO_MESA['binary'][key]
@@ -655,6 +654,8 @@ class MesaGridStep:
                             getattr(star, key_h).append(empy_h[0])
                         if track_interpolation:
                             getattr(star, key_h).extend(empy_h)
+
+
                 if track_interpolation:
                     if MESA_history_bug_fix:
                         real_len = max(length_binary_hist, length_star_hist)
@@ -891,7 +892,6 @@ class MesaGridStep:
                         continue
                     else:
                         setattr(star, key, None)
-        
         # EXPERIMENTAL feature
         # infer stellar states
         interpolation_class = self.classes['interpolation_class']

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -645,7 +645,9 @@ class MesaGridStep:
                             getattr(star, key_h).append(cb_bh[key_p][0])
                         if track_interpolation:
                             getattr(star, key_h).extend(cb_bh[key_p][:-1])
-                    elif key in ['state', 'lg_mdot','co_core_mass']:
+                    elif key in ['state', 'lg_mdot']:
+                        continue
+                    elif star.state == 'WD' and key in ['co_core_mass','he_core_mass','center_h1','center_he4','center_c12','center_n14','center_o16']:
                         continue
                     else:
                         setattr(star, key, None)
@@ -885,7 +887,7 @@ class MesaGridStep:
                         setattr(star, key, fv[key_p])
                     elif key == 'state':
                         continue
-                    elif star.state == 'WD' and key in ['co_core_mass','center_h1','center_he4','center_c12','center_n14','center_o16']:
+                    elif star.state == 'WD' and key in ['co_core_mass','he_core_mass','center_h1','center_he4','center_c12','center_n14','center_o16']:
                         continue
                     else:
                         setattr(star, key, None)

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -302,9 +302,7 @@ class MesaGridStep:
             raise AttributeError("No step defined for {}".format(
                 self.__name__))
         if self.flip_stars_before_step:
-            print('Before flipping the stars', binary.star_1.state,binary.star_1.co_core_mass)
             flip_stars(binary)
-            print('After flipping the stars', binary.star_2.state,binary.star_2.co_core_mass)
         max_MESA_sim_time = self.get_final_MESA_step_time()
 
         if max_MESA_sim_time is None:
@@ -333,7 +331,6 @@ class MesaGridStep:
                                       star_2_CO=self.star_2_CO,
                                       track_interpolation=True)
         else:
-            print('After flipping the stars', binary.star_2.state,binary.star_2.co_core_mass)
             self.step(binary, interp_method=self.interpolation_method)
         
         if (self.stop_method == 'stop_at_max_time'
@@ -369,7 +366,6 @@ class MesaGridStep:
         
         if self.flip_stars_before_step:
             flip_stars(binary)
-            print('Second flipping of the stars', binary.star_1.state,binary.star_1.co_core_mass)
         if binary.time > binary.properties.max_simulation_time:
             binary.event = 'MaxTime_exceeded'
         elif binary.time == binary.properties.max_simulation_time:
@@ -502,7 +498,7 @@ class MesaGridStep:
                     getattr(binary, key_h).append(v_key)
                 if track_interpolation:
                     getattr(binary, key_h).extend([v_key]*length_hist)
-            elif key in ['state', 'event', 'mass_transfer_case']:
+            elif key in ['state', 'event']:
                 continue
             else:
                 key_p = POSYDON_TO_MESA['binary'][key]
@@ -649,7 +645,7 @@ class MesaGridStep:
                             getattr(star, key_h).append(cb_bh[key_p][0])
                         if track_interpolation:
                             getattr(star, key_h).extend(cb_bh[key_p][:-1])
-                    elif key in ['state', 'lg_mdot']:
+                    elif key in ['state', 'lg_mdot','co_core_mass']:
                         continue
                     else:
                         setattr(star, key, None)
@@ -845,7 +841,6 @@ class MesaGridStep:
             else:
                 key_p = POSYDON_TO_MESA['binary'][key]
                 setattr(self.binary, key, fv[key_p])
-        print('1',binary.star_2.co_core_mass)
         for k, star in enumerate(stars):
             for key in STARPROPERTIES:
                 if not stars_CO[k]:
@@ -889,6 +884,8 @@ class MesaGridStep:
                         key_p = POSYDON_TO_MESA['star'][key]+'_%d' % (k+1)
                         setattr(star, key, fv[key_p])
                     elif key == 'state':
+                        continue
+                    elif star.state == 'WD' and key in ['co_core_mass','center_h1','center_he4','center_c12','center_n14','center_o16']:
                         continue
                     else:
                         setattr(star, key, None)
@@ -950,7 +947,6 @@ class MesaGridStep:
             if 10**tmp_lg_mdot > mdot_edd:
                 tmp_lg_mdot = np.log10(mdot_edd)
             setattr(accretor, 'lg_mdot', tmp_lg_mdot)
-        print('3',binary.star_2.co_core_mass)
         # update post processed quanties
         key_post_processed = ['avg_c_in_c_core_at_He_depletion',
                               'co_core_mass_at_He_depletion',

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -302,8 +302,9 @@ class MesaGridStep:
             raise AttributeError("No step defined for {}".format(
                 self.__name__))
         if self.flip_stars_before_step:
+            print('Before flipping the stars', binary.star_1.state,binary.star_1.co_core_mass)
             flip_stars(binary)
-
+            print('After flipping the stars', binary.star_2.state,binary.star_2.co_core_mass)
         max_MESA_sim_time = self.get_final_MESA_step_time()
 
         if max_MESA_sim_time is None:
@@ -319,7 +320,6 @@ class MesaGridStep:
         if (step_will_exceed_max_time
                 and self.stop_method == 'stop_at_max_time'):
             # self.step(binary, interp_method='nearest_neighbour')
-
             if self.interpolation_method != 'nearest_neighbour':
                 self.closest_binary, self.nearest_neighbour_distance, \
                     self.termination_flags = self._psyTrackInterp.evaluate(
@@ -333,8 +333,9 @@ class MesaGridStep:
                                       star_2_CO=self.star_2_CO,
                                       track_interpolation=True)
         else:
+            print('After flipping the stars', binary.star_2.state,binary.star_2.co_core_mass)
             self.step(binary, interp_method=self.interpolation_method)
-
+        
         if (self.stop_method == 'stop_at_max_time'
                 and binary.time >= binary.properties.max_simulation_time):
             # self.flush_history = True # needed???
@@ -365,10 +366,10 @@ class MesaGridStep:
                              interpolate=self.stop_interpolate,
                              star_1_CO=self.star_1_CO,
                              star_2_CO=self.star_2_CO)
-
+        
         if self.flip_stars_before_step:
             flip_stars(binary)
-
+            print('Second flipping of the stars', binary.star_1.state,binary.star_1.co_core_mass)
         if binary.time > binary.properties.max_simulation_time:
             binary.event = 'MaxTime_exceeded'
         elif binary.time == binary.properties.max_simulation_time:
@@ -844,7 +845,7 @@ class MesaGridStep:
             else:
                 key_p = POSYDON_TO_MESA['binary'][key]
                 setattr(self.binary, key, fv[key_p])
-
+        print('1',binary.star_2.co_core_mass)
         for k, star in enumerate(stars):
             for key in STARPROPERTIES:
                 if not stars_CO[k]:
@@ -891,7 +892,7 @@ class MesaGridStep:
                         continue
                     else:
                         setattr(star, key, None)
-
+        
         # EXPERIMENTAL feature
         # infer stellar states
         interpolation_class = self.classes['interpolation_class']
@@ -949,7 +950,7 @@ class MesaGridStep:
             if 10**tmp_lg_mdot > mdot_edd:
                 tmp_lg_mdot = np.log10(mdot_edd)
             setattr(accretor, 'lg_mdot', tmp_lg_mdot)
-
+        print('3',binary.star_2.co_core_mass)
         # update post processed quanties
         key_post_processed = ['avg_c_in_c_core_at_He_depletion',
                               'co_core_mass_at_He_depletion',
@@ -1431,7 +1432,6 @@ class CO_HMS_RLO_step(MesaGridStep):
             self.p_min <= p <= self.p_max and
             ecc == 0.)):
             super().__call__(self.binary)
-
         # period inside the grid, but m1 outside the grid
         elif ((not self.flip_stars_before_step and
                self.p_min <= p <= self.p_max and
@@ -1455,7 +1455,6 @@ class CO_HMS_RLO_step(MesaGridStep):
                 if self.binary.state_history[-2] == 'detached':
                     set_binary_to_failed(self.binary)
                     raise ValueError('CO_HMS_RLO binary outside grid and coming from detached')
-
             self.binary.state = "detached"
             self.binary.event = "redirect_from_CO_HMS_RLO"
             return

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -549,7 +549,6 @@ class StepSN(object):
                     # 1. Check if SN_type and star state match                    
                     # Non-matching SN_type and star state
                     if not check_SN_CO_match(star):
-                        print('here in if!')
                         # raise a warning
                         warnings.warn(f'{MODEL_NAME_SEL}: The SN_type '
                                       'does not match the predicted CO! '
@@ -621,18 +620,23 @@ class StepSN(object):
 
                 # check if a white dwarf has been born
                 if star.SN_type == "WD":
-                    print('here!')
                     star.mass = m_rembar
                     star.state = "WD"
                     star.spin = 0.
                     star.log_R = np.log10(CO_radius(star.mass, star.state))
                     star.m_disk_accreted = np.nan
                     star.m_disk_radiated = np.nan
-                    star.co_core_mass = m_rembar
                     for key in STARPROPERTIES:
-                        if key not in ["state", "mass", "log_R", "spin",
-                                       "m_disk_accreted", "m_disk_radiated","co_core_mass"]:
-                            setattr(star, key, None)
+                        if key in ["he_core_mass"]:
+                            setattr(star, key, star.mass)
+                        elif key in ["co_core_mass"]:
+                            if star.center_he4 < THRESHOLD_CENTRAL_ABUNDANCE: 
+                                setattr(star, key, star.mass)
+                            else: 
+                                setattr(star, key, 0.)
+                        elif key not in ["state", "mass", "spin",
+                                "m_disk_accreted ", "m_disk_radiated","center_h1","center_he4","center_c12","center_n14","center_o16"]:
+                            setattr(star, key, None)  
                     return
 
                 # check if the star was disrupted by the PISN
@@ -728,11 +732,17 @@ class StepSN(object):
                     star.log_R = np.log10(CO_radius(star.mass, star.state))
                     star.m_disk_accreted = np.nan
                     star.m_disk_radiated = np.nan
-                    star.co_core_mass = m_rembar
                     for key in STARPROPERTIES:
-                        if key not in ["state", "mass", "log_R", "spin",
-                                       "m_disk_accreted", "m_disk_radiated","co_core_mass"]:
-                            setattr(star, key, None)
+                        if key in ["he_core_mass"]:
+                            setattr(star, key, star.mass)
+                        elif key in ["co_core_mass"]:
+                            if star.center_he4 < THRESHOLD_CENTRAL_ABUNDANCE: 
+                                setattr(star, key, star.mass)
+                            else: 
+                                setattr(star, key, 0.)
+                        elif key not in ["state", "mass", "spin",
+                                "m_disk_accreted ", "m_disk_radiated","center_h1","center_he4","center_c12","center_n14","center_o16"]:
+                            setattr(star, key, None)  
                     return
 
                 # check if the star was disrupted by the PISN

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -522,16 +522,18 @@ class StepSN(object):
                     MODEL_properties = getattr(star, MODEL_NAME_SEL)
                     for key, value in MODEL_properties.items():
                         setattr(star, key, value)
-
+                    
                     if star.state == 'WD':
                         for key in STARPROPERTIES:
-                            if key not in ["state", "mass", "spin",
-                                        "m_disk_accreted ", "m_disk_radiated","co_core_mass","center_h1","center_he4","center_c12","center_n14","center_o16"]:
+                            if key == "co_core_mass":
+                                setattr(star, key, star.mass)
+                            elif key not in ["state", "mass", "spin",
+                                        "m_disk_accreted ", "m_disk_radiated","center_h1","center_he4","center_c12","center_n14","center_o16"]:
                                 setattr(star, key, None)           
                     else:                    
                         for key in STARPROPERTIES:
                             if key not in ["state", "mass", "spin",
-                                            "m_disk_accreted ", "m_disk_radiated"]:
+                                        "m_disk_accreted ", "m_disk_radiated","co_core_mass","center_h1","center_he4","center_c12","center_n14","center_o16"]:
                                 setattr(star, key, None)
                     
                     # check if SN_type matches the predicted CO
@@ -540,6 +542,7 @@ class StepSN(object):
                     # 1. Check if SN_type and star state match                    
                     # Non-matching SN_type and star state
                     if not check_SN_CO_match(star):
+                        print('here in if!')
                         # raise a warning
                         warnings.warn(f'{MODEL_NAME_SEL}: The SN_type '
                                       'does not match the predicted CO! '
@@ -611,6 +614,7 @@ class StepSN(object):
 
                 # check if a white dwarf has been born
                 if star.SN_type == "WD":
+                    print('here!')
                     star.mass = m_rembar
                     star.state = "WD"
                     star.spin = 0.

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -403,6 +403,7 @@ class StepSN(object):
             # collapse star
             self.collapse_star(star=binary.star_1)
             self._reset_other_star_properties(star=binary.star_2)
+            
         elif binary.event == "CC2":
             # collapse star
             self.collapse_star(star=binary.star_2)
@@ -432,7 +433,9 @@ class StepSN(object):
             binary.event = "CC2"
         elif state1 in STAR_STATES_C_DEPLETION and state2 in STAR_STATES_CO:
             binary.event = "CC1"
-
+        
+        if binary.star_1.state == 'WD':
+            print('Exiting SN',binary.star_1.state ,binary.star_1.co_core_mass)
     def check(self):
         """Check the internal integrity and the values of the parameters."""
         if self.kick_distribution is None:
@@ -524,7 +527,7 @@ class StepSN(object):
 
                     for key in STARPROPERTIES:
                         if key not in ["state", "mass", "spin",
-                                        "m_disk_accreted ", "m_disk_radiated"]:
+                                        "m_disk_accreted ", "m_disk_radiated","co_core_mass"]:
                             setattr(star, key, None)
                     
                     # check if SN_type matches the predicted CO
@@ -578,7 +581,6 @@ class StepSN(object):
                     
                     if getattr(star, 'SN_type') != 'PISN':
                         star.log_R = np.log10(CO_radius(star.mass, star.state))
-                    
                     return
 
             # Verifies the selection of core-collapse mechnism to perform
@@ -611,9 +613,10 @@ class StepSN(object):
                     star.log_R = np.log10(CO_radius(star.mass, star.state))
                     star.m_disk_accreted = np.nan
                     star.m_disk_radiated = np.nan
+                    star.co_core_mass = m_rembar
                     for key in STARPROPERTIES:
                         if key not in ["state", "mass", "log_R", "spin",
-                                       "m_disk_accreted", "m_disk_radiated"]:
+                                       "m_disk_accreted", "m_disk_radiated","co_core_mass"]:
                             setattr(star, key, None)
                     return
 
@@ -710,9 +713,10 @@ class StepSN(object):
                     star.log_R = np.log10(CO_radius(star.mass, star.state))
                     star.m_disk_accreted = np.nan
                     star.m_disk_radiated = np.nan
+                    star.co_core_mass = m_rembar
                     for key in STARPROPERTIES:
                         if key not in ["state", "mass", "log_R", "spin",
-                                       "m_disk_accreted", "m_disk_radiated"]:
+                                       "m_disk_accreted", "m_disk_radiated","co_core_mass"]:
                             setattr(star, key, None)
                     return
 
@@ -804,7 +808,7 @@ class StepSN(object):
         for key in STARPROPERTIES:
             if key not in [
                 "state", "mass", "spin", "log_R", "metallicity",
-                "m_disk_accreted ", "m_disk_radiated"]:
+                "m_disk_accreted ", "m_disk_radiated","co_core_mass"]:
                 setattr(star, key, None)
 
     def PISN_prescription(self, star):

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -433,9 +433,7 @@ class StepSN(object):
             binary.event = "CC2"
         elif state1 in STAR_STATES_C_DEPLETION and state2 in STAR_STATES_CO:
             binary.event = "CC1"
-        
-        if binary.star_1.state == 'WD':
-            print('Exiting SN',binary.star_1.state ,binary.star_1.co_core_mass)
+
     def check(self):
         """Check the internal integrity and the values of the parameters."""
         if self.kick_distribution is None:
@@ -525,10 +523,16 @@ class StepSN(object):
                     for key, value in MODEL_properties.items():
                         setattr(star, key, value)
 
-                    for key in STARPROPERTIES:
-                        if key not in ["state", "mass", "spin",
-                                        "m_disk_accreted ", "m_disk_radiated","co_core_mass"]:
-                            setattr(star, key, None)
+                    if star.state == 'WD':
+                        for key in STARPROPERTIES:
+                            if key not in ["state", "mass", "spin",
+                                        "m_disk_accreted ", "m_disk_radiated","co_core_mass","center_h1","center_he4","center_c12","center_n14","center_o16"]:
+                                setattr(star, key, None)           
+                    else:                    
+                        for key in STARPROPERTIES:
+                            if key not in ["state", "mass", "spin",
+                                            "m_disk_accreted ", "m_disk_radiated"]:
+                                setattr(star, key, None)
                     
                     # check if SN_type matches the predicted CO
                     # and force the SN_type to match the predicted CO.

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -42,7 +42,8 @@ from posydon.utils.common_functions import (
     orbital_period_from_separation,
     inspiral_timescale_from_separation,
     separation_evol_wind_loss,
-    calculate_Patton20_values_at_He_depl
+    calculate_Patton20_values_at_He_depl,
+    THRESHOLD_CENTRAL_ABUNDANCE
 )
 
 from posydon.binary_evol.binarystar import BINARYPROPERTIES
@@ -525,15 +526,21 @@ class StepSN(object):
                     
                     if star.state == 'WD':
                         for key in STARPROPERTIES:
-                            if key == "co_core_mass":
+                            if key in ["he_core_mass"]:
                                 setattr(star, key, star.mass)
+                            elif key in ["co_core_mass"]:
+                                if star.center_he4 < THRESHOLD_CENTRAL_ABUNDANCE: 
+                                    setattr(star, key, star.mass)
+                                else: 
+                                    setattr(star, key, 0.)
                             elif key not in ["state", "mass", "spin",
                                         "m_disk_accreted ", "m_disk_radiated","center_h1","center_he4","center_c12","center_n14","center_o16"]:
-                                setattr(star, key, None)           
+                                setattr(star, key, None)          
+                    
                     else:                    
                         for key in STARPROPERTIES:
                             if key not in ["state", "mass", "spin",
-                                        "m_disk_accreted ", "m_disk_radiated","co_core_mass","center_h1","center_he4","center_c12","center_n14","center_o16"]:
+                                        "m_disk_accreted ", "m_disk_radiated"]:
                                 setattr(star, key, None)
                     
                     # check if SN_type matches the predicted CO

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -879,5 +879,6 @@ class BinaryStar:
         if profiles:
             binary.star_1.profile = run.final_profile1
             binary.star_2.profile = run.final_profile2
-
+        if binary.star_1.state == 'WD':
+            print('WD in binary star',binary.star_1.state ,binary.star_1.co_core_mass)
         return binary

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -879,6 +879,4 @@ class BinaryStar:
         if profiles:
             binary.star_1.profile = run.final_profile1
             binary.star_2.profile = run.final_profile2
-        if binary.star_1.state == 'WD':
-            print('WD in binary star',binary.star_1.state ,binary.star_1.co_core_mass)
         return binary

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -879,4 +879,5 @@ class BinaryStar:
         if profiles:
             binary.star_1.profile = run.final_profile1
             binary.star_2.profile = run.final_profile2
+            
         return binary

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -291,7 +291,6 @@ class BinaryPopulation:
                 try:
                     binary.evolve()
                 except Exception:
-                    traceback.print_exc()
                     binary.event = 'FAILED'
                     binary.traceback = traceback.format_exc()
                 if len(w) > 0:

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -289,6 +289,7 @@ class BinaryPopulation:
                 try:
                     binary.evolve()
                 except Exception:
+                    traceback.print_exc()
                     binary.event = 'FAILED'
                     binary.traceback = traceback.format_exc()
                 if len(w) > 0:


### PR DESCRIPTION
The merging of WD is currently failing because attributes like the "co_core_mass" and some central abundances needed for calculated the merger of WD and stars were set to None during step_CO_HMS_RLO. This PR is trying to find a way to keep this quantities from being erased.  