### PR TITLE
Updates on running MESA grids

### DIFF
--- a/bin/posydon-run-grid
+++ b/bin/posydon-run-grid
@@ -874,7 +874,8 @@ if __name__ == '__main__':
             run_mesa(args.mesa_star1_executable, work_dir, final_dir,
                      outfile_name='out_star1_formation_step{0}.txt'.format(index),
                      keep_profiles=args.keep_profiles, keep_photos=args.keep_photos,
-                     job_start=args.job_start, job_end=args.job_end)
+                     job_start=args.job_start, job_end=args.job_end,
+                     keep_work_dir=index<last_step)
 
         sys.exit(0)
 

--- a/bin/posydon-setup-grid
+++ b/bin/posydon-setup-grid
@@ -1137,7 +1137,7 @@ if __name__ == '__main__':
         with open('run_grid.sh') as f:
             f.write('#!/bin/bash\n')
             f.write('ID_GRID=$(sbatch --parsable {0})\n'.format(grid_script))
-            f.write('echo \"{0}'.format(grid_script)' submitted as \"${ID_GRID}\n')
+            f.write('echo \"{0}'.format(grid_script)+' submitted as \"${ID_GRID}\n')
             f.write('ID_cleanup=$(sbatch --parsable --dependency=afterany:${ID_GRID} '
                     '--kill-on-invalid-dep=yes cleanup.sh)\n')
             f.write('echo \"cleanup.sh submitted as \"${ID_cleanup}\n')

--- a/bin/posydon-setup-grid
+++ b/bin/posydon-setup-grid
@@ -1111,7 +1111,7 @@ if __name__ == '__main__':
                 f.write('export MESA_DIR={0}\n\n\n'.format(os.environ['MESA_DIR']))
                 f.write(command_line)
         # create a cleanup script
-        with open('cleanup.sh') as f:
+        with open('cleanup.sh', 'w') as f:
             f.write('#!/bin/bash\n')
             
             f.write('#SBATCH --account={0}\n'.format(slurm['account']))
@@ -1134,7 +1134,7 @@ if __name__ == '__main__':
                 f.write('chmod -fR g+rwX .\n')
             f.write('\necho \"Done.\"')
         # create a runfile script
-        with open('run_grid.sh') as f:
+        with open('run_grid.sh', 'w') as f:
             f.write('#!/bin/bash\n')
             f.write('ID_GRID=$(sbatch --parsable {0})\n'.format(grid_script))
             f.write('echo \"{0}'.format(grid_script)+' submitted as \"${ID_GRID}\n')

--- a/bin/posydon-setup-grid
+++ b/bin/posydon-setup-grid
@@ -1065,7 +1065,8 @@ if __name__ == '__main__':
                 grid = pandas.read_csv(run_parameters['grid'])
             else:
                 raise ValueError('Grid format not recognized, please feed in an acceptable format: csv')
-            with open('slurm_job_array_grid_submit.sh', 'w') as f:
+            grid_script = 'slurm_job_array_grid_submit.sh'
+            with open(grid_script, 'w') as f:
                 f.write('#!/bin/bash\n')
 
                 f.write('#SBATCH --account={0}\n'.format(slurm['account']))
@@ -1088,7 +1089,8 @@ if __name__ == '__main__':
                 f.write('export MESA_DIR={0}\n\n\n'.format(os.environ['MESA_DIR']))
                 f.write(command_line)
         else:
-            with open('slurm_mpi_grid_submit.sh', 'w') as f:
+            grid_script = 'slurm_mpi_grid_submit.sh'
+            with open(grid_script, 'w') as f:
                 f.write('#!/bin/bash\n')
 
                 f.write('#SBATCH --account={0}\n'.format(slurm['account']))
@@ -1108,3 +1110,36 @@ if __name__ == '__main__':
                 f.write('source $MESASDK_ROOT/bin/mesasdk_init.sh\n')
                 f.write('export MESA_DIR={0}\n\n\n'.format(os.environ['MESA_DIR']))
                 f.write(command_line)
+        # create a cleanup script
+        with open('cleanup.sh') as f:
+            f.write('#!/bin/bash\n')
+            
+            f.write('#SBATCH --account={0}\n'.format(slurm['account']))
+            f.write('#SBATCH --partition={0}\n'.format(slurm['partition']))
+            f.write('#SBATCH -N 1\n')
+            f.write('#SBATCH --cpus-per-task {0}\n'.format(slurm['number_of_cpus_per_task']))
+            f.write('#SBATCH --ntasks-per-node 1\n')
+            f.write('#SBATCH --time={0}\n'.format(slurm['walltime']))
+            f.write('#SBATCH --job-name=\"mesa_grid_cleanup\"\n')
+            f.write('#SBATCH --output=mesa_cleanup.out\n')
+            f.write('#SBATCH --mail-type=ALL\n')
+            f.write('#SBATCH --mail-user={0}\n'.format(slurm['email']))
+            f.write('#SBATCH --mem-per-cpu=4G\n\n')
+            
+            f.write('compress-mesa .\n')
+            if 'newgroup' in slurm.keys():
+                f.write('echo \"Change group to {0}\"\n'.format(slurm['newgroup']))
+                f.write('chgrp -fR {0} .\n'.format(slurm['newgroup']))
+                f.write('echo \"Change group permission to rwX at least\"\n')
+                f.write('chmod -fR g+rwX .\n')
+            f.write('\necho \"Done.\"')
+        # create a runfile script
+        with open('run_grid.sh') as f:
+            f.write('#!/bin/bash\n')
+            f.write('ID_GRID=$(sbatch --parsable {0})\n'.format(grid_script))
+            f.write('echo \"{0}'.format(grid_script)' submitted as \"${ID_GRID}\n')
+            f.write('ID_cleanup=$(sbatch --parsable --dependency=afterany:${ID_GRID} '
+                    '--kill-on-invalid-dep=yes cleanup.sh)\n')
+            f.write('echo \"cleanup.sh submitted as \"${ID_cleanup}\n')
+        # make the runfile script executable
+        os.system("chmod 755 run_grid.sh")

--- a/grid_params/grid_params.ini
+++ b/grid_params/grid_params.ini
@@ -1,5 +1,6 @@
 ; POSYDON MESA Grid INI file
 [slurm]
+
 ; Number of nodes you would like to request
 number_of_nodes=1
 
@@ -32,9 +33,14 @@ work_dir={WORK_DIRECTORY}
 ;email
 email={YOUR_EMAIL_ADDRESS}
 
-[mesa_inlists]
-; inlist types: binary_control,binary_job,star_job,star_control
+; new group to be set with write permission
+; if empty string no changes on group and permission
+newgroup=''
 
+
+[mesa_inlists]
+
+; inlist types: binary_control,binary_job,star_job,star_control
 ; Please leave MESA defaults lines alone, please fill in the path to
 ; you local clone of POSYDON
 posydon_github_root={PATH_TO_POSYDON_DIRECTORY}
@@ -46,16 +52,15 @@ posydon_github_root={PATH_TO_POSYDON_DIRECTORY}
 ; you can also supply a scenario using syntax such as below, and the setup script
 ; will automatically find the inlists from POSYDON
 ; you want to use based on the git tag/commit and the scenario
-; (in this case you are simulating MS-MS binaries)
+; (in this case you are simulating HMS-HMS binaries)
 ; NOTE: You can use the scenario logic below and *still* supply your own local
 ; user mesa inlists that will overwrite or tweak some of the physics associated
 ; with the scenario.
-
-scenario = ['posydon', 'master-9ddb61bb0c482399fa5a41dd22fde41ccd8175d9', 'CO-H_star']
+scenario = ['posydon', 'main-9fca4599683fd214a7ac9d21e79f5ce2c0d74396', 'HMS-HMS']
 
 ; zams_filename if a zams_filename is supplied this supercedes any star1 or star2 formation inlists
 ; and skips to running the binary with this pre-computed zams model.
-zams_filename = ${posydon_github_root}/grid_params/POSYDON-MESA-INLISTS/r11701/ZAMS_models/zams_z0.0142m2_y0.2703.data
+zams_filename = ${posydon_github_root}/grid_params/POSYDON-MESA-INLISTS/r11701/ZAMS_models/zams_z1.42m2_y0.2703.data
 
 ; single_star_grid, this boolean, when True, will take the inlist1 from the binary mesa inlist section
 ; and run in a single star grid configuration
@@ -120,7 +125,7 @@ binary_history_columns = ${posydon_github_root}/grid_params/POSYDON-MESA-INLISTS
 ; profile columns
 profile_columns = ${posydon_github_root}/grid_params/POSYDON-MESA-INLISTS/r11701/default_common_inlists/profile_columns.list
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;; MESA OUTPUT CONTROLS ;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -132,7 +137,7 @@ binary_history = True
 
 ; save history of star1
 history_star1 = True
-;save final profile of star1
+; save final profile of star1
 final_profile_star1 = False
 ; save final model of star1
 final_model_star1 = True
@@ -146,6 +151,7 @@ final_model_star2 = False
 
 
 [mesa_extras]
+
 ; path to MESA makefile for executable binary and star
 makefile_binary = ${MESA_DIR}/binary/work/make/makefile
 makefile_star = ${MESA_DIR}/star/work/make/makefile
@@ -178,11 +184,11 @@ star_run = ${MESA_DIR}/star/work/src/run.f
 
 
 [run_parameters]
+
 ; If running posydon-run-grid with option --grid-type fixed
 ; then the grid is a file with all the different samples you would like to
 ; run MESA on.
 ; If posydon-make-grid is run with --grid-type dynamic, then grid is
 ; a file of pre-run MESA simulations from which you will generate new samples to
 ; run MESA on (i.e. generate grid points on the fly).
-
 grid = {PATH_TO_GRID}

--- a/grid_params/grid_params.ini
+++ b/grid_params/grid_params.ini
@@ -35,6 +35,8 @@ email={YOUR_EMAIL_ADDRESS}
 
 ; new group to be set with write permission
 ; if empty string no changes on group and permission
+; group on yggdrasil: GL_S_Astro_POSYDON
+; group on Quest: b1119
 newgroup=''
 
 


### PR DESCRIPTION
- [x] Keep work directory in first steps of single stars [`posydon-run-grid`]
- [x] Add cleanup script [`posydon-setup-grid`, `grid_params.ini`]
  - compress files and remove core dump files after runs finished
  - change group/permission after runs finished
- [x] Add run script [`posydon-setup-grid`], now you will submit the grid via running the run_script instead of sbatching the grid script
- [x] Tested on a CO-HMS grid. More tests are welcome.
- More to do?
**After this PR got merged, we need to setup new shared POSYDON environments to run grids.**