### PR TITLE
Fix get_combined_tilt calculation

### DIFF
--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -1702,11 +1702,6 @@ class StepSN(object):
             #Check if this is the first SN
             if flag_binary:
                 # update the tilt
-
-                for key in BINARYPROPERTIES:
-                    if key != 'nearest_neighbour_distance':
-                        setattr(binary, key, None)
-
                 if not binary.first_SN_already_occurred:
                     # update the tilt
                     binary.star_1.spin_orbit_tilt_first_SN = tilt
@@ -1717,7 +1712,7 @@ class StepSN(object):
                     if binary.event == 'CC2':
                         # Assume progenitor has aligned with the preSN orbital angular momentum
                         binary.star_2.spin_orbit_tilt_second_SN = tilt
-                        binary.star_1.spin_orbit_tilt_second_SN = get_combined_tilt(
+                        binary.star_1.spin_orbit_tilt_second_SN = self.get_combined_tilt(
                             tilt_1 = binary.star_1.spin_orbit_tilt_first_SN, 
                             tilt_2 = tilt, 
                             true_anomaly_1 = binary.true_anomaly_first_SN, 
@@ -1727,7 +1722,7 @@ class StepSN(object):
                     elif binary.event == 'CC1':
                         # Assume progenitor has aligned with the preSN orbital angular momentum
                         binary.star_1.spin_orbit_tilt_second_SN = tilt
-                        binary.star_2.spin_orbit_tilt_second_SN = get_combined_tilt(
+                        binary.star_2.spin_orbit_tilt_second_SN = self.get_combined_tilt(
                             tilt_1 = binary.star_1.spin_orbit_tilt_first_SN, 
                             tilt_2 = tilt, 
                             true_anomaly_1 = binary.true_anomaly_first_SN, 
@@ -1738,7 +1733,10 @@ class StepSN(object):
                         raise ValueError("This should never happen!")
 
                 # compute new orbital period before reseting the binary properties
-
+                for key in BINARYPROPERTIES:
+                    if key != 'nearest_neighbour_distance':
+                        setattr(binary, key, None)
+                        
                 binary.state = "detached"
                 binary.event = None
                 binary.separation = Apost / const.Rsun
@@ -1831,7 +1829,7 @@ class StepSN(object):
 
         return Vkick
         
-    def get_combined_tilt(tilt_1, tilt_2, true_anomaly_1, true_anomaly_2):
+    def get_combined_tilt(self,tilt_1, tilt_2, true_anomaly_1, true_anomaly_2):
         """Get the combined spin-orbit-tilt after two supernovae, assuming
         the spin as not realigned with the orbital angular momentum after
         SN1

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -1700,6 +1700,9 @@ class StepSN(object):
 
             # update the binary object which was bound at least before the SN
             #Check if this is the first SN
+            for key in BINARYPROPERTIES:
+                if key not in ['nearest_neighbour_distance','event']:
+                    setattr(binary, key, None)
             if flag_binary:
                 # update the tilt
                 if not binary.first_SN_already_occurred:
@@ -1732,11 +1735,7 @@ class StepSN(object):
                     else:
                         raise ValueError("This should never happen!")
 
-                # compute new orbital period before reseting the binary properties
-                for key in BINARYPROPERTIES:
-                    if key != 'nearest_neighbour_distance':
-                        setattr(binary, key, None)
-                        
+                # compute new orbital period before reseting the binary properties     
                 binary.state = "detached"
                 binary.event = None
                 binary.separation = Apost / const.Rsun
@@ -1751,9 +1750,6 @@ class StepSN(object):
                 binary.mass_transfer_case = 'None'
 
             else:
-                for key in BINARYPROPERTIES:
-                    if key != 'nearest_neighbour_distance':
-                        setattr(binary, key, None)
                 # update the tilt
                 if not binary.first_SN_already_occurred:
                     binary.star_1.spin_orbit_tilt_first_SN = np.nan


### PR DESCRIPTION
We reset the BINARY_PROPERTIES before using the `get_combined_tilt`, as such all binaries that got there failed.

This PR changes it to be after the tilt calculation. I'm not sure what the reset of parameters is used for. 

This has to include PR #272 to work.

@kasdaglie found these!


