### PR TITLE
Generalize and improve on compress MESA

### DIFF
--- a/bin/compress-mesa
+++ b/bin/compress-mesa
@@ -102,72 +102,75 @@ def compress_dir(args):
     """
     def get_size(start_path="."):
         total_size = 0
+        remove_files = []
+        compress_files = []
+        n_runs = 0
+        n_remove_files = 0
+        n_compress_files = 0
         for dirpath, _, filenames in os.walk(start_path):
+            if "_grid_index_" in dirpath:   # checking if directory is mesa run
+                new_remove_files = []
+                new_compress_files = []
+                if "_grid_index_" in os.path.basename(dirpath):
+                    n_runs += 1
+            else:
+                new_remove_files = None
+                new_compress_files = None
             for filename in filenames:
                 filepath = os.path.join(dirpath, filename)
                 # skip if it is symbolic link
                 if not os.path.islink(filepath):
                     total_size += os.path.getsize(filepath)
-        return total_size
-
-    def compress_subdirs(track_dirs):
-        for track_obj in track_dirs:
-            for root, _dir, files in os.walk(track_obj):
-                # traversing over directory tree of copied mesa tracks
-                # and compressing .data, .mod, .txt files
-                for file in files:
-                    ext = file.split(".")[-1]
-                    if ext not in ["data", "mod", "txt"]:
-                        continue
-                    os.system(f"gzip -1 {os.path.join(root, file)}")
-
-    def remove_core_dumps(track_dirs):
-        for track_obj in track_dirs:
-            for root, _dir, files in os.walk(track_obj):
-                for file in files:
-                    core_string = file.split(".")[0]
-                    if (core_string == 'core'
-                            and os.path.isfile(os.path.join(root, file))):
-                        os.remove(os.path.join(root, file))
+                # check for files in mesa run, whether to remove or compress it
+                if new_remove_files is not None:
+                    name, ext = os.path.splitext(filename)
+                    if name == "core":
+                        # remove core dump files
+                        new_remove_files.append(filename)
+                    elif ext in [".data", ".mod", ".txt"]:
+                        # compress .data, .mod, .txt files
+                        new_compress_files.append(filename)
+            if ((new_remove_files is not None) and
+                (len(new_remove_files)>0)):
+                remove_files.append((dirpath, new_remove_files))
+                n_remove_files += len(new_remove_files)
+            if ((new_compress_files is not None) and
+                (len(new_compress_files)>0)):
+                compress_files.append((dirpath, new_compress_files))
+                n_compress_files += len(new_compress_files)
+        return total_size, remove_files, compress_files, n_runs,\
+            n_remove_files, n_compress_files
 
     if not os.path.isdir(args.mesa_dir):
         sys.exit("The MESA directory does not exist.")
 
-    og_size = textsize(get_size(args.mesa_dir))
-
-    for folder in tqdm(os.listdir(args.mesa_dir)):
-
-        # To add the option of cycling through files one directory above
-        if "_grid_index_" in folder:
-            track_dirs = []
-
-            if (os.path.isdir(os.path.join(args.mesa_dir, folder))
-                    and folder not in ["star1", "star2", "binary"]):
-                track_dirs.append(os.path.join(args.mesa_dir, folder))
-            
-            compress_subdirs(track_dirs)
-            remove_core_dumps(track_dirs)
-            continue
-
-        if os.path.isdir(os.path.join(args.mesa_dir, folder)):
-            is_mesa_run = False
-            sub_dir = os.listdir(os.path.join(args.mesa_dir, folder))
-            track_dirs = []
-
-            for _f in sub_dir:
-                if "_grid_index_" in _f:    # checking if directory is mesa run
-                    is_mesa_run = True
-
-                if (os.path.isdir(os.path.join(args.mesa_dir, folder, _f))
-                        and _f not in ["star1", "star2", "binary"]):
-                    track_dirs.append(os.path.join(args.mesa_dir, folder, _f))
-
-            if is_mesa_run:
-                compress_subdirs(track_dirs)
-                remove_core_dumps(track_dirs)
-
+    og_size, to_remove, to_compress, n_runs, n_remove_files, n_compress_files\
+        = get_size(args.mesa_dir)
+    
+    print("remove", n_remove_files, "core dump files in", len(to_remove),
+        "directories of", n_runs, "MESA runs")
+    for folder, files in tqdm(to_remove):
+        for remove_file in files:
+            if os.path.isfile(os.path.join(folder, remove_file)):
+#                print("remove:", os.path.join(folder, remove_file))
+                os.remove(os.path.join(folder, remove_file))
+    
+    print("compress", n_compress_files, "files in", len(to_compress),
+        "directories of", n_runs, "MESA runs")
+    for folder, files in tqdm(to_compress):
+        for compress_file in files:
+            if os.path.isfile(os.path.join(folder, compress_file)):
+#                print(f"gzip -1 {os.path.join(folder, compress_file)}")
+                os.system(f"gzip -1 {os.path.join(folder, compress_file)}")
+    
+    new_size, to_remove, to_compress, n_runs, n_remove_files, n_compress_files\
+        = get_size(args.mesa_dir)
     print("\nCompressed MESA tracks\nOriginal size {} | Compressed size {}\n".
-          format(og_size, textsize(get_size(args.mesa_dir))))
+          format(textsize(og_size), textsize(new_size)))
+    if len(to_remove)>0:
+        print("Warning: still files to remove:", to_remove)
+    if len(to_compress)>0:
+        print("Warning: still files to compress:", to_compress)
 
 
 if __name__ == "__main__":

--- a/bin/compress-mesa
+++ b/bin/compress-mesa
@@ -13,7 +13,7 @@ def textsize(filesize, floatfmt=".3g", base=1024, threshold=1000):
     Parameters
     ----------
     filesize : int or float
-        The size of the file, or directory, ...
+        The size of the file, or directory, ... (in bytes)
     floatfmt : str
         The format for the float before the size descriptor (e.g., 2.34K).
     base : int
@@ -28,14 +28,19 @@ def textsize(filesize, floatfmt=".3g", base=1024, threshold=1000):
         The filesize in string format using b, K, M, ...
 
     """
-    assert base in [1000, 1024]
+    if base not in [1000, 1024]:
+        raise ValueError(f"base={base} should be 1000 or 1024")
+    if threshold <= 0:
+        raise ValueError(f"threshold={threshold} should be larger than 0")
+    if base < threshold:
+        raise ValueError(f"threshold={threshold} should be smaller or equal "\
+                         f"to base={base}")
+    if filesize < 0:
+        return "-" + textsize(-filesize, floatfmt=floatfmt, base=base,\
+                              threshold=threshold)
 
     units = ["b", "K", "M", "G", "T", "P", "E", "Z", "Y"]
     unit_values = [base**i for i in range(len(units))]
-
-    if filesize < 0:
-        return "-" + textsize(
-            -filesize, floatfmt=floatfmt, base=base)
 
     for unit, unit_value in zip(units, unit_values):
         if filesize < unit_value * threshold:
@@ -48,19 +53,26 @@ def textsize(filesize, floatfmt=".3g", base=1024, threshold=1000):
 def set_up_test(args):
     """Set up a testing directory in the requested directory.
 
-    Parameters (keys in `args`):
-    ----------
+    Parameters (keys in `args`)
+    ---------------------------
+    mesa_dir : string
+        The directory where the MESA tracks are stored.
     test_dir : string
         The directory where the test directory is to be set up.
     dsr : float
         Downsampling rate when creating testing directory.
 
     """
-    if not os.path.isdir(args.test_dir):
-        sys.exit(f"Directory {args.test_dir} does not exist.")
+    if args.test_dir is None:
+        raise NameError("--test_dir needs to be specified for set_up_test")
+    elif not os.path.isdir(args.test_dir):
+        raise NotADirectoryError(f"Directory {args.test_dir} does not exist.")
+    if args.mesa_dir is None:
+        raise NameError("mesa_dir needs to be specified for set_up_test")
+    elif not os.path.isdir(args.mesa_dir):
+        raise NotADirectoryError(f"Directory {args.mesa_dir} does not exist.")
 
     for folder in os.listdir(args.mesa_dir):
-
         if os.path.isdir(os.path.join(args.mesa_dir, folder)):
             is_mesa_run = False
             sub_dir = os.listdir(os.path.join(args.mesa_dir, folder))
@@ -94,8 +106,10 @@ def set_up_test(args):
 def compress_dir(args):
     """Compresses a directory containing tracks evolved with MESA.
 
-    Parameters (keys in `args`):
-    -----------
+    Parameters (keys in `args`)
+    ---------------------------
+    verbose : bool
+        Enable/Disable additional output.
     mesa_dir : string
         The directory where the MESA tracks are stored.
 
@@ -141,22 +155,26 @@ def compress_dir(args):
         return total_size, remove_files, compress_files, n_runs,\
             n_remove_files, n_compress_files
 
-    if not os.path.isdir(args.mesa_dir):
-        sys.exit("The MESA directory does not exist.")
+    if args.mesa_dir is None:
+        raise NameError("mesa_dir needs to be specified for set_up_test")
+    elif not os.path.isdir(args.mesa_dir):
+        raise NotADirectoryError(f"Directory {args.mesa_dir} does not exist.")
 
     og_size, to_remove, to_compress, n_runs, n_remove_files, n_compress_files\
         = get_size(args.mesa_dir)
-    
-    print("remove", n_remove_files, "core dump files in", len(to_remove),
-        "directories of", n_runs, "MESA runs")
+
+    if args.verbose:
+        print("remove", n_remove_files, "core dump files in", len(to_remove),\
+              "directories of", n_runs, "MESA runs")
     for folder, files in tqdm(to_remove):
         for remove_file in files:
             if os.path.isfile(os.path.join(folder, remove_file)):
 #                print("remove:", os.path.join(folder, remove_file))
                 os.remove(os.path.join(folder, remove_file))
-    
-    print("compress", n_compress_files, "files in", len(to_compress),
-        "directories of", n_runs, "MESA runs")
+
+    if args.verbose:
+        print("compress", n_compress_files, "files in", len(to_compress),\
+              "directories of", n_runs, "MESA runs")
     for folder, files in tqdm(to_compress):
         for compress_file in files:
             if os.path.isfile(os.path.join(folder, compress_file)):
@@ -165,8 +183,11 @@ def compress_dir(args):
     
     new_size, to_remove, to_compress, n_runs, n_remove_files, n_compress_files\
         = get_size(args.mesa_dir)
-    print("\nCompressed MESA tracks\nOriginal size {} | Compressed size {}\n".
-          format(textsize(og_size), textsize(new_size)))
+    if args.verbose:
+        print("")
+        print("Compressed MESA tracks")
+        print(f"Original size {textsize(og_size)} | "\
+              f"Compressed size {textsize(new_size)}")
     if len(to_remove)>0:
         print("Warning: still files to remove:", to_remove)
     if len(to_compress)>0:
@@ -175,18 +196,19 @@ def compress_dir(args):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("-f", "--function", type=str,
-                        help="The name of the function to be called.",
-                        default='compress_dir')
-    parser.add_argument("-td", "--test_dir", type=str,
-                        help="The path to where the testing directory should "
-                        "be set up, either set_up_test or compress_dir.")
-    parser.add_argument("-dsr", "--dsr", type=str,
-                        help="Downsampling rate when creating testing "
-                        "directory", default=0.01)
-    parser.add_argument("mesa_dir", type=str,
-                        help="The path to the directory containing "
-                        "MESA-generated data")
+    parser.add_argument("-f", "--function", type=str, help="The name of the "\
+                        "function to be called, either set_up_test or "\
+                        "compress_dir.", default='compress_dir')
+    parser.add_argument("-td", "--test_dir", type=str, help="The path to "\
+                        "where the testing directory should be set up.",\
+                        default=None)
+    parser.add_argument("-dsr", "--dsr", type=float, help="Downsampling rate "\
+                        "when creating testing directory", default=0.01)
+    parser.add_argument("-v", "--verbose", type=bool, help="Enable/Disable "\
+                        "outputs", default=True)
+    parser.add_argument("mesa_dir", type=str, help="The path to the "\
+                        "directory containing MESA-generated data",\
+                        default=None)
 
     functions = {"set_up_test": set_up_test, "compress_dir": compress_dir}
     arguments = parser.parse_args()

--- a/bin/compress-mesa
+++ b/bin/compress-mesa
@@ -170,7 +170,10 @@ def compress_dir(args):
         for remove_file in files:
             if os.path.isfile(os.path.join(folder, remove_file)):
 #                print("remove:", os.path.join(folder, remove_file))
-                os.remove(os.path.join(folder, remove_file))
+                try:
+                    os.remove(os.path.join(folder, remove_file))
+                except:
+                    print("Could not remove:", remove_file, "in", folder)
 
     if args.verbose:
         print("compress", n_compress_files, "files in", len(to_compress),\
@@ -180,7 +183,7 @@ def compress_dir(args):
             if os.path.isfile(os.path.join(folder, compress_file)):
 #                print(f"gzip -1 {os.path.join(folder, compress_file)}")
                 os.system(f"gzip -1 {os.path.join(folder, compress_file)}")
-    
+
     new_size, to_remove, to_compress, n_runs, n_remove_files, n_compress_files\
         = get_size(args.mesa_dir)
     if args.verbose:

--- a/docs/_source/components-overview/mesa_grids/fixed.rst
+++ b/docs/_source/components-overview/mesa_grids/fixed.rst
@@ -17,6 +17,7 @@ edited for your own installation.
 .. code-block::
 
     export MESA_DIR="/projects/b1119/mesa_sdk/mesa-r11701"
+    export OMP_NUM_THREADS=4
     export MESASDK_ROOT="/projects/b1119/mesa_sdk/mesasdk"
     source $MESASDK_ROOT/bin/mesasdk_init.sh
 
@@ -87,7 +88,20 @@ Finally, we are ready to submit our jobs with:
 
 .. code-block::
 
-    sbatch slurm_job_array_grid_submit.sh
+    ./run_grid.sh
+
+This shell script will submit the two slurm jobs
+:samp:`slurm_job_array_grid_submit.sh` and :samp:`cleanup.sh`. The first one
+will run the MESA simulations, where several runs will go in paralell. The
+second job, will run after all MESA runs are completed. It is doing some
+cleanup:
+
+- removing files no longer needed (e.g. memory copies created as backups)
+- compressing files containing a lot of text (those files are individually
+  compressed and will keep in place, hence getting a file extension `.gz`
+  added)
+- changing the owning group and permissions (this will only be done if a new
+  group was specified in the .ini file for the setup)
 
 Once the grid of runs is completed, we recommend you use our provided PSyGrid
 functionality to interpret and collate the individual binary runs

--- a/docs/_source/components-overview/mesa_grids/inifile.rst
+++ b/docs/_source/components-overview/mesa_grids/inifile.rst
@@ -23,26 +23,24 @@ quantities that need to be adjusted for your specific case.
 
 Here is a link to the most recent stable release version of the default inifile
 for POSYDON:
-`Stable Version INIFILE <https://github.com/POSYDON-code/POSYDON/blob/development/grid_params/grid_params.ini>`_
+`Stable Version INIFILE <https://github.com/POSYDON-code/POSYDON/blob/main/grid_params/grid_params.ini>`_
 
 Here is a link to the unstable development version of the default inifile for
 POSYDON:
-`Development Version INIFILE <https://github.com/POSYDON-code/POSYDON/blob/main/grid_params/grid_params.ini>`_
+`Development Version INIFILE <https://github.com/POSYDON-code/POSYDON/blob/development/grid_params/grid_params.ini>`_
 
 .. _inifile_slurm:
+
 
 [slurm]
 -------
 
 This section designates all the SLURM-related parameters.
 
-=======================  ===============================================================
-
-=======================  ===============================================================
-
 .. code-block:: ini
 
     [slurm]
+
     ; Number of nodes you would like to request
     number_of_nodes=1
 
@@ -69,17 +67,41 @@ This section designates all the SLURM-related parameters.
     ; wall-time
     walltime='2-00:00:00'
 
+    ; work-directory: place, where MESA writes during runtime
+    work_dir={WORK_DIRECTORY}
+
     ;email
     email={YOUR_EMAIL_ADDRESS}
+
+    ; new group to be set with write permission
+    ; if empty string no changes on group and permission
+    ; group on yggdrasil: GL_S_Astro_POSYDON
+    ; group on Quest: b1119
+    newgroup=''
+
+.. table:: general settings
+
+    =======================  ===========
+    Setting name             Description
+    =======================  ===========
+    number_of_nodes          The number of nodes each job will request
+    number_of_mpi_tasks      (outdated) The number of parallel processes ganerates by MPI (recommended to not change)
+    number_of_cpus_per_task  The number of CPUs each job will request (in best this should align with the number of threads set for MESA)
+    job_array                Set to `True` to run a SLURM job array
+    user                     User name
+    partition                SLURM partition to run the jobs on
+    account                  SLURM account to run the jobs on
+    walltime                 Maximum time for each run, otherwise it will get cancelled by SLURM to avoid never ending MESA runs going on too short time steps
+    work_dir                 The path to the place, where the data will be writting during runtime (it is recommended to use fast local node storage here), afterwards the data will be copied/moved to the current directory (uncommend this line to write always to the final location)
+    email                    Your email address to receive notifications from SLURM
+    newgroup                 The name of the owning group all the files should get (leave empty if no changes are needed here)
+    =======================  ===========
+
 
 [mesa_inlists]
 --------------
 
 This section designates all the basic MESA-specific parameters.
-
-=======================  ===================================================================================
-
-=======================  ===================================================================================
 
 .. code-block:: ini
 
@@ -195,15 +217,63 @@ This section designates all the basic MESA-specific parameters.
     ; save final model of star2
     final_model_star2 = False
 
+.. table:: settings for the MESA inlist
+
+    =========================================  ===========
+    Setting name                               Description
+    =========================================  ===========
+    posydon_github_root                        The path to your used POSYDON version
+    scenario                                   List containing multiple information: 1) the source ('posydon' or 'user'(for future use)), 2) the git commit (the branch and full git hash for the inlist submodule separated by a dash), 3) the systems type ('HMS-HMS', 'CO-H_star', 'CO-He_star')
+    zams_filename                              The location of the file containing the ZAMS models
+    single_star_grid                           Flag to indicate single star or binary evolution
+    star1_formation_job_mesa_defaults          (outdated) Path to the MESA job section defaults to form star 1
+    star1_formation_job_posydon_defaults       (outdated) Path to the MESA job section inlist of POSYDON to form star 1
+    star1_formation_job_user                   (outdated) Path to the MESA job section inlist of the user to form star 1
+    star2_formation_job_mesa_defaults          (outdated) Path to the MESA job section defaults to form star 2
+    star2_formation_job_posydon_defaults       (outdated) Path to the MESA job section inlist of POSYDON to form star 2
+    star2_formation_job_user                   (outdated) Path to the MESA job section inlist of the user to form star 2
+    star1_formation_controls_mesa_defaults     (outdated) Path to the MESA controls section defaults to form star 1
+    star1_formation_controls_posydon_defaults  (outdated) Path to the MESA controls section inlist of POSYDON to form star 1
+    star1_formation_controls_user              (outdated) Path to the MESA controls section inlist of the user to form star 1
+    star2_formation_controls_mesa_defaults     (outdated) Path to the MESA controls section defaults to form star 2
+    star2_formation_controls_posydon_defaults  (outdated) Path to the MESA controls section inlist of POSYDON to form star 2
+    star2_formation_controls_user              (outdated) Path to the MESA controls section inlist of the user to form star 2
+    binary_controls_mesa_defaults              (outdated) Path to the MESA controls section defaults to evolve the binary
+    binary_controls_posydon_defaults           (outdated) Path to the MESA controls section inlist of POSYDON to evolve the binary
+    binary_controls_user                       (outdated) Path to the MESA controls section inlist of the user to evolve the binary
+    binary_job_mesa_defaults                   (outdated) Path to the MESA job section defaults to evolve the binary
+    binary_job_posydon_defaults                (outdated) Path to the MESA job section inlist of POSYDON to evolve the binary
+    binary_job_user                            (outdated) Path to the MESA job section inlist of the user to evolve the binary
+    star1_job_mesa_defaults                    (outdated) Path to the MESA job section defaults to evolve star 1
+    star1_job_posydon_defaults                 (outdated) Path to the MESA job section inlist of POSYDON to evolve star 1
+    star1_job_user                             (outdated) Path to the MESA job section inlist of the user to evolve star 1
+    star1_controls_mesa_defaults               (outdated) Path to the MESA controls section defaults to evolve star 1
+    star1_controls_posydon_defaults            (outdated) Path to the MESA controls section inlist of POSYDON to evolve star 1
+    star1_controls_user                        (outdated) Path to the MESA controls section inlist of the user to evolve star 1
+    star2_job_mesa_defaults                    (outdated) Path to the MESA job section defaults to evolve star 2
+    star2_job_posydon_defaults                 (outdated) Path to the MESA job section inlist of POSYDON to evolve star 2
+    star2_job_user                             (outdated) Path to the MESA job section inlist of the user to evolve star 2
+    star2_controls_mesa_defaults               (outdated) Path to the MESA controls section defaults to evolve star 2
+    star2_controls_posydon_defaults            (outdated) Path to the MESA controls section inlist of POSYDON to evolve star 2
+    star2_controls_user                        (outdated) Path to the MESA controls section inlist of the user to evolve star 2
+    star_history_columns                       (outdated) Path to the history columns list of the stars
+    binary_history_columns                     (outdated) Path to the history columns list of the binary
+    profile_columns                            (outdated) Path to the profile columns list to write the final stellar profile
+    history_interval                           Interval how often MESA will add a model to the star's histories
+    binary_history                             Interval how often MESA will add a model to the binary history
+    history_star1                              Flag, whether the history of star 1 should be saved
+    final_profile_star1                        (outdated, done in :samp:`run_star_extras.f`) Flag, whether the final profil of star 1 should be saved
+    final_model_star1                          Flag, whether the final model of star 1 should be saved
+    history_star2                              Flag, whether the history of star 2 should be saved
+    final_profile_star2                        (outdated, done in :samp:`run_star_extras.f`) Flag, whether the final profil of star 2 should be saved
+    final_model_star2                          Flag, whether the final model of star 2 should be saved
+    =========================================  ===========
+
 
 [mesa_extras]
 -------------
 
 This section designates all the parameters for MESA makefiles and fortran files.
-
-===========================  ===================================================================================
-
-===========================  ===================================================================================
 
 .. code-block:: ini
 
@@ -238,13 +308,30 @@ This section designates all the parameters for MESA makefiles and fortran files.
     ; star_run.f
     star_run = ${MESA_DIR}/star/work/src/run.f
 
+.. table:: settings for the MESA extras
+
+    =======================  ===========
+    Setting name             Description
+    =======================  ===========
+    makefile_binary          Path to the make file of MESA's binary module
+    makefile_star            Path to the make file of MESA's star module
+    mesa_binary_extras       Path to MESA's binary module default :samp:`run_binary_extras.f`
+    user_binary_extras       Path to the users/POSYDON :samp:`run_binary_extras.f`
+    mesa_star_binary_extras  Path to MESA's binary module default :samp:`run_star_extras.f`
+    user_star_binary_extras  Path to the users/POSYDON :samp:`run_star_extras.f`
+    mesa_star1_extras        Path to MESA's star module default :samp:`run_star_extras.f`
+    user_star1_extras        Path to the users/POSYDON :samp:`run_star_extras.f`
+    mesa_star2_extras        Path to MESA's star module default :samp:`run_star_extras.f`
+    user_star2_extras        Path to the users/POSYDON :samp:`run_star_extras.f`
+    binary_run               Path to MESA's binary module :samp:`binary_run.f`
+    star_run                 Path to MESA's star module :samp:`run.f`
+    =======================  ===========
+
+
 [run_parameters]
 ----------------
 
 This section designates the run parameters for a grid.
-
-==================== ========================================================
-==================== ========================================================
 
 .. code-block:: ini
 
@@ -257,3 +344,5 @@ This section designates the run parameters for a grid.
     ; run MESA on (i.e. generate grid points on the fly).
 
     grid = {PATH_TO_GRID}
+
+The :samp:`grid` specifies where to find the csv file to read the runs from.


### PR DESCRIPTION
- [x] Reduce the number of filesystem walks from 4 to 2, hence it is a bit faster now
- [x] Generalize the code to be able to be run on any directory level above the MESA runs
- [x] Ensure that only files in the MESA runs are changed without assuming a certain file structure (e.g. not only exclude files in `star1`, `star2` and `binary` instead only include files in a MESA run file)
- [x] Give more statistical output: number of runs, number of changed files and number of their base directories (the last number is the one shown on the progress bar; the first two are for checks for the user, whether it acts on what is expected)
- [x] Final check, that there are no files to act on after the file actions are completed
- [x] Update documentation
- [x] Added by @astroJeff : catch fails on removals, e.g. because of missing permissions
- [x] Testing, here the new output format from the test:
> remove 0 core dump files in 0 directories of 803 MESA runs
0it [00:00, ?it/s]
compress 7194 files in 2026 directories of 803 MESA runs
100%|███████████████████████████████████| 2026/2026 [20:14<00:00,  1.67it/s]
>
> Compressed MESA tracks
Original size 41.3G | Compressed size 10.8G