### PR TITLE
fixing v1 environment bug with scikit-learn version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ install_requires = [
     'configparser >= 5.3.0',
     'astropy >= 5.2.2',
     'pandas >= 2.0.0',
-    'scikit-learn < 1.3.0', # 1.2.2
+    'scikit-learn==0.21.3',
     'matplotlib >=  3.7.1',
     'matplotlib-label-lines >= 0.5.2',
     'h5py >= 3.8.0',


### PR DESCRIPTION
current requirement 'scikit-learn < 1.3.0' is conflicting with the old scikit-learn naming conventions in v1 code. Will first try just resetting to scikit-learn 0.21.3. If this doesn't work, we may consider changing the v1 code to be compatible with the current scikit-learn, which would also require updating the pickle files. 