### PR TITLE
Kicks on massless remnants

### DIFF
--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -1390,6 +1390,9 @@ class StepSN(object):
                         sigma = self.sigma_kick_CCSN_NS
                     elif binary.star_1.state == 'BH':
                         sigma = self.sigma_kick_CCSN_BH
+                    elif binary.star_1.state == 'massless_remnant':
+                        # No kick on a massless object
+                        sigma = None
                     else:
                         raise ValueError("CCSN/PPISN/PISN only for NS/BH.")
                     # Kick for core-collapse SN
@@ -1486,6 +1489,9 @@ class StepSN(object):
                         sigma = self.sigma_kick_CCSN_NS
                     elif binary.star_2.state == 'BH':
                         sigma = self.sigma_kick_CCSN_BH
+                    elif binary.star_2.state == 'massless_remnant':
+                        # No kick on a massless object
+                        sigma = None
                     else:
                         raise ValueError("CCSN/PPISN/PISN only for NS/BH.")
                     # Kick for core-collapse SN


### PR DESCRIPTION
@ZepeiX reported an error in the kick calculation.
```
File "/projects/b1119/xzp/POSYDON/posydon/binary_evol/SN/step_SN.py", line 427, in __call__
self.orbital_kick(binary=binary)
File "/projects/b1119/xzp/POSYDON/posydon/binary_evol/SN/step_SN.py", line 1394, in orbital_kick
raise ValueError("CCSN/PPISN/PISN only for NS/BH.")
ValueError: CCSN/PPISN/PISN only for NS/BH.
```
It turned out to happen, when a PISN leaves a massless remnant.

- [x] Have zero kick on a massless remnant