### PR TITLE
Add functions to read initial values from file

### DIFF
--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -20,7 +20,8 @@ __authors__ = [
     "Konstantinos Kovlakas <Konstantinos.Kovlakas@unige.ch>",
     "Devina Misra <devina.misra@unige.ch>",
     "Simone Bavera <Simone.Bavera@unige.ch>",
-    "Max Briel <max.briel@gmail.com>"
+    "Max Briel <max.briel@gmail.com>",
+    "Matthias Kruckow <matthias.kruckow@unige.ch>",
 ]
 
 
@@ -45,6 +46,7 @@ from posydon.popsyn.star_formation_history import get_formation_times
 
 from posydon.popsyn.independent_sample import (generate_independent_samples,
                                                binary_fraction_value)
+from posydon.popsyn.sample_from_file import get_samples_from_file
 from posydon.utils.common_functions import (orbital_period_from_separation,
                                             orbital_separation_from_period)
 from posydon.popsyn.defaults import default_kwargs
@@ -517,7 +519,14 @@ class PopulationManager:
         self.history_dfs = []
         self.oneline_dfs = []
 
-        self.binary_generator = BinaryGenerator(**kwargs)
+        if (('read_samples_from_file' in self.kwargs) and
+            (self.kwargs['read_samples_from_file']!='')):
+            self.binary_generator = BinaryGenerator(\
+                                     sampler=get_samples_from_file, **kwargs)
+        else:
+            self.binary_generator = BinaryGenerator(\
+                                     sampler=generate_independent_samples,\
+                                     **kwargs)
         self.entropy = self.binary_generator.entropy
 
         if file_name:

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -46,7 +46,8 @@ from posydon.popsyn.star_formation_history import get_formation_times
 
 from posydon.popsyn.independent_sample import (generate_independent_samples,
                                                binary_fraction_value)
-from posydon.popsyn.sample_from_file import get_samples_from_file
+from posydon.popsyn.sample_from_file import (get_samples_from_file,
+                                             get_kick_samples_from_file)
 from posydon.utils.common_functions import (orbital_period_from_separation,
                                             orbital_separation_from_period)
 from posydon.popsyn.defaults import default_kwargs
@@ -815,15 +816,30 @@ class BinaryGenerator:
 
         # indices
         indices = np.arange(self._num_gen, self._num_gen+N_binaries, 1)
+        
+        # kicks
+        if 'read_samples_from_file' in kwargs:
+            kick1, kick2 = get_kick_samples_from_file(**kwargs)
+        else:
+            if 'number_of_binaries' in kwargs:
+                number_of_binaries = kwargs['number_of_binaries']
+            else:
+                number_of_binaries = 1
+            kick1 = np.array(number_of_binaries*[[None, None, None, None]])
+            kick2 = np.array(number_of_binaries*[[None, None, None, None]])
+        
+        # output
         output_dict = {
             'binary_index': indices,
-            'binary_fraction':binary_fraction,
+            'binary_fraction': binary_fraction,
             'time': formation_times,
             'separation': separation,
             'eccentricity': eccentricity,
             'orbital_period': orbital_period,
             'S1_mass': m1,
             'S2_mass': m2,
+            'S1_natal_kick_array': kick1,
+            'S2_natal_kick_array': kick2,
         }
         self._num_gen += N_binaries
         return output_dict
@@ -869,6 +885,8 @@ class BinaryGenerator:
             Y = zams_table[Z_div_Zsun]
             Z = Z_div_Zsun*Zsun
             X = 1. - Z - Y
+            kick1 = output['S1_natal_kick_array'][0]
+            kick2 = output['S2_natal_kick_array'][0]
 
             binary_params = dict(
                 index=kwargs.get('index', default_index),
@@ -885,6 +903,7 @@ class BinaryGenerator:
                 metallicity=Z,
                 center_h1=X,
                 center_he4=Y,
+                natal_kick_array=kick1,
             )
             star2_params = dict(
                 mass=m2,
@@ -892,6 +911,7 @@ class BinaryGenerator:
                 metallicity=Z,
                 center_h1=X,
                 center_he4=Y,
+                natal_kick_array=kick2,
             )
         #If binary_fraction not default a initially single star binary is created.
         else:
@@ -912,6 +932,7 @@ class BinaryGenerator:
             Y = zams_table[Z_div_Zsun]
             Z = Z_div_Zsun*Zsun
             X = 1. - Z - Y
+            kick1 = output['S1_natal_kick_array'][0]
 
             binary_params = dict(
                 index=kwargs.get('index', default_index),
@@ -928,6 +949,7 @@ class BinaryGenerator:
                 metallicity=Z,
                 center_h1=X,
                 center_he4=Y,
+                natal_kick_array=kick1,
             )
             star2_params = properties_massless_remnant()
 

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -21,7 +21,7 @@ __authors__ = [
     "Devina Misra <devina.misra@unige.ch>",
     "Simone Bavera <Simone.Bavera@unige.ch>",
     "Max Briel <max.briel@gmail.com>",
-    "Matthias Kruckow <matthias.kruckow@unige.ch>",
+    "Matthias Kruckow <Matthias.Kruckow@unige.ch>",
 ]
 
 

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -866,26 +866,30 @@ class BinaryGenerator:
         default_index = output['binary_index'].item()
         binary_fraction = output['binary_fraction']
 
+        formation_time = output['time'].item()
+        m1 = output['S1_mass'].item()
+        Z_div_Zsun = kwargs.get('metallicity', 1.)
+        zams_table = {2.: 2.915e-01,
+                      1.: 2.703e-01,
+                      0.45: 2.586e-01,
+                      0.2: 2.533e-01,
+                      0.1: 2.511e-01,
+                      0.01: 2.492e-01,
+                      0.001: 2.49e-01,
+                      0.0001: 2.49e-01}
+        Z = Z_div_Zsun*Zsun
+        if Z_div_Zsun in zams_table.keys():
+            Y = zams_table[Z_div_Zsun]
+        else:
+            raise KeyError(f"{Z_div_Zsun} is a not defined metallicity")
+        X = 1. - Z - Y
+        kick1 = output['S1_natal_kick_array'][0]
+
         if self.RNG.uniform() < binary_fraction:
-            formation_time = output['time'].item()
             separation = output['separation'].item()
             orbital_period = output['orbital_period'].item()
             eccentricity = output['eccentricity'].item()
-            m1 = output['S1_mass'].item()
             m2 = output['S2_mass'].item()
-            Z_div_Zsun = kwargs.get('metallicity', 1.)
-            zams_table = {2.: 2.915e-01,
-                          1.: 2.703e-01,
-                          0.45: 2.586e-01,
-                          0.2: 2.533e-01,
-                          0.1: 2.511e-01,
-                          0.01: 2.492e-01,
-                          0.001: 2.49e-01,
-                          0.0001: 2.49e-01}
-            Y = zams_table[Z_div_Zsun]
-            Z = Z_div_Zsun*Zsun
-            X = 1. - Z - Y
-            kick1 = output['S1_natal_kick_array'][0]
             kick2 = output['S2_natal_kick_array'][0]
 
             binary_params = dict(
@@ -915,24 +919,9 @@ class BinaryGenerator:
             )
         #If binary_fraction not default a initially single star binary is created.
         else:
-            formation_time = output['time'].item()
             separation = np.nan
             orbital_period = np.nan
             eccentricity = np.nan
-            m1 = output['S1_mass'].item()
-            Z_div_Zsun = kwargs.get('metallicity', 1.)
-            zams_table = {2.: 2.915e-01,
-                          1.: 2.703e-01,
-                          0.45: 2.586e-01,
-                          0.2: 2.533e-01,
-                          0.1: 2.511e-01,
-                          0.01: 2.492e-01,
-                          0.001: 2.49e-01,
-                          0.0001: 2.49e-01}
-            Y = zams_table[Z_div_Zsun]
-            Z = Z_div_Zsun*Zsun
-            X = 1. - Z - Y
-            kick1 = output['S1_natal_kick_array'][0]
 
             binary_params = dict(
                 index=kwargs.get('index', default_index),

--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -283,6 +283,8 @@
   max_simulation_time = 13.8e9
     # float (0,inf)
 
+  read_samples_from_file = ''
+    # path to file to read initial parameters from (if empty string get random samples)
   primary_mass_scheme = 'Kroupa2001'
     # 'Salpeter', 'Kroupa1993', 'Kroupa2001'
   primary_mass_min = 7

--- a/posydon/popsyn/sample_from_file.py
+++ b/posydon/popsyn/sample_from_file.py
@@ -2,7 +2,7 @@
 
 
 __authors__ = [
-    "Matthias Kruckow <matthias.kruckow@unige.ch>",
+    "Matthias Kruckow <Matthias.Kruckow@unige.ch>",
 ]
 
 
@@ -10,7 +10,6 @@ import os
 import numpy as np
 import pandas as pd
 import warnings
-from posydon.utils.posydonerror import FileError
 from posydon.popsyn.independent_sample import (generate_orbital_periods,
                                                generate_orbital_separations,
                                                generate_eccentricities,
@@ -92,7 +91,7 @@ def get_samples_from_file(orbital_scheme='', **kwargs):
     if os.path.isfile(filename):
         df = pd.read_csv(filename)
     else:
-        raise FileError(f'{filename} not found!')
+        raise FileNotFoundError(f'{filename} not found!')
 
     # Get number of data frame entries
     set_n = len(df)
@@ -202,7 +201,7 @@ def get_kick_samples_from_file(**kwargs):
     if os.path.isfile(filename):
         df = pd.read_csv(filename)
     else:
-        raise FileError(f'{filename} not found!')
+        raise FileNotFoundError(f'{filename} not found!')
 
     # Get number of data frame entries
     set_n = len(df)

--- a/posydon/popsyn/sample_from_file.py
+++ b/posydon/popsyn/sample_from_file.py
@@ -23,6 +23,18 @@ PERIOD_NAMES = ['orbital_period', 'period', 'p_orb', 'porb', 'p']
 SEPARATION_NAMES = ['orbital_separation', 'separation', 'semi-major_axis',\
                     'semi_major_axis', 'a']
 ECCENTRICITY_NAMES = ['eccentricity', 'ecc', 'e']
+PRIMARY_KICK_VELOCITY_NAMES = ['s1_natal_kick_array_0', 'w_1', 'w1']
+SECONDARY_KICK_VELOCITY_NAMES = ['s2_natal_kick_array_0', 'w_2', 'w2']
+PRIMARY_KICK_AZIMUTHAL_ANGLE_NAMES = ['s1_natal_kick_array_1', 'phi_1', 'phi1']
+SECONDARY_KICK_AZIMUTHAL_ANGLE_NAMES = ['s2_natal_kick_array_1', 'phi_2',\
+                                        'phi2']
+PRIMARY_KICK_POLAR_ANGLE_NAMES = ['s1_natal_kick_array_2', 'theta_1', 'theta1']
+SECONDARY_KICK_POLAR_ANGLE_NAMES = ['s2_natal_kick_array_2', 'theta_2',\
+                                    'theta2']
+PRIMARY_KICK_MEAN_ANOMALY_NAMES = ['s1_natal_kick_array_3', 'mean_anomaly_1',\
+                                   'mean_anomaly1']
+SECONDARY_KICK_MEAN_ANOMALY_NAMES = ['s2_natal_kick_array_3',\
+                                     'mean_anomaly_2', 'mean_anomaly2']
 
 def infer_key(available_keys=[], allowed_keys=[]):
     """Infer key from list of allowed keys.
@@ -82,7 +94,7 @@ def get_samples_from_file(orbital_scheme='', **kwargs):
     else:
         raise FileError(f'{filename} not found!')
 
-    # get number of data frame entries
+    # Get number of data frame entries
     set_n = len(df)
     
     # Get eccentricities
@@ -95,7 +107,7 @@ def get_samples_from_file(orbital_scheme='', **kwargs):
     else:
         eccentricity_set = np.array(df[key])
 
-    # Generate primary masses
+    # Get primary masses
     key = infer_key(available_keys=df.keys(), allowed_keys=PRIMARY_MASS_NAMES)
     if key=='':
         warnings.warn(f'No primary mass column found in {filename}, hence get'
@@ -104,7 +116,7 @@ def get_samples_from_file(orbital_scheme='', **kwargs):
     else:
         m1_set = np.array(df[key])
 
-    # Generate secondary masses
+    # Get secondary masses
     key = infer_key(available_keys=df.keys(),
                     allowed_keys=SECONDARY_MASS_NAMES)
     if key=='':
@@ -116,7 +128,7 @@ def get_samples_from_file(orbital_scheme='', **kwargs):
         m2_set = np.array(df[key])
 
     if orbital_scheme == 'separation':
-        # Generate orbital separations
+        # Get orbital separations
         key = infer_key(available_keys=df.keys(),
                         allowed_keys=SEPARATION_NAMES)
         if key=='':
@@ -127,7 +139,7 @@ def get_samples_from_file(orbital_scheme='', **kwargs):
         else:
             orbital_scheme_set = np.array(df[key])
     elif orbital_scheme == 'period':
-        # Generate orbital periods
+        # Get orbital periods
         key = infer_key(available_keys=df.keys(), allowed_keys=PERIOD_NAMES)
         if key=='':
             warnings.warn(f'No period column found in {filename}, hence get'
@@ -145,18 +157,149 @@ def get_samples_from_file(orbital_scheme='', **kwargs):
             index = kwargs['index']
         else:
             index = 0
-        # expand the sets by doubling them as long as it is needed
+        # Expand the sets by doubling them as long as it is needed
         while len(orbital_scheme_set)<index+number_of_binaries:
             orbital_scheme_set = np.append(orbital_scheme_set,\
-                                           orbital_scheme_set)
-            eccentricity_set = np.append(eccentricity_set, eccentricity_set)
-            m1_set = np.append(m1_set, m1_set)
-            m2_set = np.append(m2_set, m2_set)
-        # only return the requested set size
+                                           orbital_scheme_set, axis=0)
+            eccentricity_set = np.append(eccentricity_set, eccentricity_set,\
+                                         axis=0)
+            m1_set = np.append(m1_set, m1_set, axis=0)
+            m2_set = np.append(m2_set, m2_set, axis=0)
+        # Only return the requested set size
         return orbital_scheme_set[index:index+number_of_binaries],\
                eccentricity_set[index:index+number_of_binaries],\
                m1_set[index:index+number_of_binaries],\
                m2_set[index:index+number_of_binaries]
     else:
         return orbital_scheme_set, eccentricity_set, m1_set, m2_set
+
+def get_kick_samples_from_file(**kwargs):
+    """Read a kicks for population of binaries from a file.
+
+    Parameters
+    ----------
+    **kwargs : dictionary
+        kwargs from BinaryPopulation class, which should contain
+        read_samples_from_file
+
+    Returns
+    -------
+    s1_natal_kick_array_set : ndarray of floats
+        natal kick array for the primary star
+        containing: kick velocity, azimuthal angle, polar angle, mean anomaly
+    s2_natal_kick_array_set : ndarray of floats
+        natal kick array for the secondary star
+        containing: kick velocity, azimuthal angle, polar angle, mean anomaly
+
+    """
+
+    if 'read_samples_from_file' in kwargs:
+        filename = kwargs['read_samples_from_file']
+    else:
+        raise KeyError("In get_kick_samples_from_file no "
+                       "'read_samples_from_file' in kwargs.")
+    # Check and read file into dataframe
+    if os.path.isfile(filename):
+        df = pd.read_csv(filename)
+    else:
+        raise FileError(f'{filename} not found!')
+
+    # Get number of data frame entries
+    set_n = len(df)
+    
+    ## Get primary kick
+    # Velocity
+    key = infer_key(available_keys=df.keys(),\
+                    allowed_keys=PRIMARY_KICK_VELOCITY_NAMES)
+    if key=='':
+        warnings.warn('No kick velocity column of primary found in '
+                      f'{filename}, hence do not set them.')
+        w_set = np.array(set_n*[None])
+    else:
+        w_set = np.array(df[key])
+    # Azimuthal angle
+    key = infer_key(available_keys=df.keys(),\
+                    allowed_keys=PRIMARY_KICK_AZIMUTHAL_ANGLE_NAMES)
+    if key=='':
+        warnings.warn('No azimuthal angle column of primary found in '
+                      f'{filename}, hence do not set them.')
+        phi_set = np.array(set_n*[None])
+    else:
+        phi_set = np.array(df[key])
+    # Polar angle
+    key = infer_key(available_keys=df.keys(),\
+                    allowed_keys=PRIMARY_KICK_POLAR_ANGLE_NAMES)
+    if key=='':
+        warnings.warn('No polar angle column of primary found in '
+                      f'{filename}, hence do not set them.')
+        theta_set = np.array(set_n*[None])
+    else:
+        theta_set = np.array(df[key])
+    # Mean anomaly
+    key = infer_key(available_keys=df.keys(),\
+                    allowed_keys=PRIMARY_KICK_MEAN_ANOMALY_NAMES)
+    if key=='':
+        warnings.warn('No mean anomaly column of primary found in '
+                      f'{filename}, hence do not set them.')
+        mean_anomaly_set = np.array(set_n*[None])
+    else:
+        mean_anomaly_set = np.array(df[key])
+    kick_1_set = np.transpose(np.array([w_set, phi_set, theta_set,\
+                                        mean_anomaly_set]))
+
+    ## Get secondary kick
+    # Velocity
+    key = infer_key(available_keys=df.keys(),\
+                    allowed_keys=SECONDARY_KICK_VELOCITY_NAMES)
+    if key=='':
+        warnings.warn('No kick velocity column of secondary found in '
+                      f'{filename}, hence do not set them.')
+        w_set = np.array(set_n*[None])
+    else:
+        w_set = np.array(df[key])
+    # Azimuthal angle
+    key = infer_key(available_keys=df.keys(),\
+                    allowed_keys=SECONDARY_KICK_AZIMUTHAL_ANGLE_NAMES)
+    if key=='':
+        warnings.warn('No azimuthal angle column of secondary found in '
+                      f'{filename}, hence do not set them.')
+        phi_set = np.array(set_n*[None])
+    else:
+        phi_set = np.array(df[key])
+    # Polar angle
+    key = infer_key(available_keys=df.keys(),\
+                    allowed_keys=SECONDARY_KICK_POLAR_ANGLE_NAMES)
+    if key=='':
+        warnings.warn('No polar angle column of secondary found in '
+                      f'{filename}, hence do not set them.')
+        theta_set = np.array(set_n*[None])
+    else:
+        theta_set = np.array(df[key])
+    # Mean anomaly
+    key = infer_key(available_keys=df.keys(),\
+                    allowed_keys=SECONDARY_KICK_MEAN_ANOMALY_NAMES)
+    if key=='':
+        warnings.warn('No mean anomaly column of secondary found in '
+                      f'{filename}, hence do not set them.')
+        mean_anomaly_set = np.array(set_n*[None])
+    else:
+        mean_anomaly_set = np.array(df[key])
+    kick_2_set = np.transpose(np.array([w_set, phi_set, theta_set,\
+                                        mean_anomaly_set]))
+
+    if 'number_of_binaries' in kwargs:
+        number_of_binaries = kwargs['number_of_binaries']
+        if 'index' in kwargs:
+            index = kwargs['index']
+        else:
+            index = 0
+        # expand the sets by doubling them as long as it is needed
+        while len(kick_1_set)<index+number_of_binaries:
+            kick_1_set = np.append(kick_1_set, kick_1_set, axis=0)
+            kick_2_set = np.append(kick_2_set, kick_2_set, axis=0)
+        # only return the requested set size
+        return kick_1_set[index:index+number_of_binaries],\
+               kick_2_set[index:index+number_of_binaries]
+    else:
+        return kick_1_set, kick_2_set
 

--- a/posydon/popsyn/sample_from_file.py
+++ b/posydon/popsyn/sample_from_file.py
@@ -87,6 +87,11 @@ def get_samples_from_file(orbital_scheme='', **kwargs):
     else:
         raise KeyError("In get_samples_from_file no 'read_samples_from_file'"
                        " in kwargs.")
+    # Check for number of binaries and save its value
+    if 'number_of_binaries' in kwargs:
+        number_of_binaries = kwargs['number_of_binaries']
+    else:
+        number_of_binaries = 0
     # Check and read file into dataframe
     if os.path.isfile(filename):
         df = pd.read_csv(filename)
@@ -101,8 +106,8 @@ def get_samples_from_file(orbital_scheme='', **kwargs):
     if key=='':
         warnings.warn(f'No eccentricity column found in {filename}, hence get'
                       ' independent random ones.')
-        eccentricity_set = generate_eccentricities(number_of_binaries=set_n,\
-                                                   **kwargs)
+        kwargs['number_of_binaries'] = set_n
+        eccentricity_set = generate_eccentricities(**kwargs)
     else:
         eccentricity_set = np.array(df[key])
 
@@ -111,7 +116,8 @@ def get_samples_from_file(orbital_scheme='', **kwargs):
     if key=='':
         warnings.warn(f'No primary mass column found in {filename}, hence get'
                       ' independent random ones.')
-        m1_set = generate_primary_masses(number_of_binaries=set_n, **kwargs)
+        kwargs['number_of_binaries'] = set_n
+        m1_set = generate_primary_masses(**kwargs)
     else:
         m1_set = np.array(df[key])
 
@@ -121,8 +127,8 @@ def get_samples_from_file(orbital_scheme='', **kwargs):
     if key=='':
         warnings.warn(f'No secondary mass column found in {filename}, hence'
                       ' get independent random ones.')
-        m2_set = generate_secondary_masses(m1_set, number_of_binaries=set_n,\
-                                           **kwargs)
+        kwargs['number_of_binaries'] = set_n
+        m2_set = generate_secondary_masses(m1_set, **kwargs)
     else:
         m2_set = np.array(df[key])
 
@@ -133,8 +139,8 @@ def get_samples_from_file(orbital_scheme='', **kwargs):
         if key=='':
             warnings.warn(f'No separation column found in {filename}, hence'
                           ' get independent random ones.')
-            orbital_scheme_set = generate_orbital_separations(\
-                                  number_of_binaries=set_n, **kwargs)
+            kwargs['number_of_binaries'] = set_n
+            orbital_scheme_set = generate_orbital_separations(**kwargs)
         else:
             orbital_scheme_set = np.array(df[key])
     elif orbital_scheme == 'period':
@@ -143,15 +149,14 @@ def get_samples_from_file(orbital_scheme='', **kwargs):
         if key=='':
             warnings.warn(f'No period column found in {filename}, hence get'
                           ' independent random ones.')
-            orbital_scheme_set = generate_orbital_periods(m1_set,\
-                                  number_of_binaries=set_n, **kwargs)
+            kwargs['number_of_binaries'] = set_n
+            orbital_scheme_set = generate_orbital_periods(m1_set, **kwargs)
         else:
             orbital_scheme_set = np.array(df[key])
     else:
         raise ValueError("Allowed orbital schemes are separation or period.")
 
-    if 'number_of_binaries' in kwargs:
-        number_of_binaries = kwargs['number_of_binaries']
+    if number_of_binaries>0:
         if 'index' in kwargs:
             index = kwargs['index']
         else:

--- a/posydon/popsyn/sample_from_file.py
+++ b/posydon/popsyn/sample_from_file.py
@@ -17,19 +17,12 @@ from posydon.popsyn.independent_sample import (generate_orbital_periods,
                                                generate_primary_masses,
                                                generate_secondary_masses)
 
-PRIMARY_MASS_NAMES = ['primary_mass', 'Primary_Mass', 'PRIMARY_MASS',\
-                      'mass_1', 'Mass_1', 'MASS_1', 'm_1', 'M_1', 'm1', 'M1']
-SECONDARY_MASS_NAMES = ['secondary_mass', 'Secondary_Mass', 'SECONDARY_MASS',\
-                        'mass_2', 'Mass_2', 'MASS_2', 'm_2', 'M_2', 'm2', 'M2']
-PERIOD_NAMES = ['orbital_period', 'Orbital_Period', 'ORBITAL_PERIOD',\
-                'period', 'Period', 'PERIOD', 'P_orb', 'porb', 'P']
-SEPARATION_NAMES = ['orbital_separation', 'Orbital_Separation',\
-                    'ORBITAL_SEPARATION', 'separation', 'Separation',\
-                    'SEPARATION', 'semi-major_axis', 'Semi-Major_Axis',\
-                    'SEMI-MAJOR_AXIS', 'semi_major_axis', 'Semi_Major_Axis',\
-                    'SEMI_MAJOR_AXIS', 'a']
-ECCENTRICITY_NAMES = ['eccentricity', 'Eccentricity', 'ECCENTRICITY',\
-                      'ecc', 'Ecc', 'ECC', 'e']
+PRIMARY_MASS_NAMES = ['primary_mass', 'mass_1', 'm_1', 'm1']
+SECONDARY_MASS_NAMES = ['secondary_mass', 'mass_2', 'm_2', 'm2']
+PERIOD_NAMES = ['orbital_period', 'period', 'p_orb', 'porb', 'p']
+SEPARATION_NAMES = ['orbital_separation', 'separation', 'semi-major_axis',\
+                    'semi_major_axis', 'a']
+ECCENTRICITY_NAMES = ['eccentricity', 'ecc', 'e']
 
 def infer_key(available_keys=[], allowed_keys=[]):
     """Infer key from list of allowed keys.
@@ -48,8 +41,9 @@ def infer_key(available_keys=[], allowed_keys=[]):
     """
 
     for k in allowed_keys:
-        if k in available_keys:
-            return k
+        for key in available_keys:
+            if key.casefold() == k.casefold():
+                return key
 
     return ''
 

--- a/posydon/popsyn/sample_from_file.py
+++ b/posydon/popsyn/sample_from_file.py
@@ -17,8 +17,8 @@ from posydon.popsyn.independent_sample import (generate_orbital_periods,
                                                generate_primary_masses,
                                                generate_secondary_masses)
 
-PRIMARY_MASS_NAMES = ['S1_mass', 'primary_mass', 'mass_1', 'm_1', 'm1']
-SECONDARY_MASS_NAMES = ['S2_mass', 'secondary_mass', 'mass_2', 'm_2', 'm2']
+PRIMARY_MASS_NAMES = ['s1_mass', 'primary_mass', 'mass_1', 'm_1', 'm1']
+SECONDARY_MASS_NAMES = ['s2_mass', 'secondary_mass', 'mass_2', 'm_2', 'm2']
 PERIOD_NAMES = ['orbital_period', 'period', 'p_orb', 'porb', 'p']
 SEPARATION_NAMES = ['orbital_separation', 'separation', 'semi-major_axis',\
                     'semi_major_axis', 'a']

--- a/posydon/popsyn/sample_from_file.py
+++ b/posydon/popsyn/sample_from_file.py
@@ -1,0 +1,168 @@
+"""Get the initial parameters for a binary population."""
+
+
+__authors__ = [
+    "Matthias Kruckow <matthias.kruckow@unige.ch>",
+]
+
+
+import os
+import numpy as np
+import pandas as pd
+import warnings
+from posydon.utils.posydonerror import FileError
+from posydon.popsyn.independent_sample import (generate_orbital_periods,
+                                               generate_orbital_separations,
+                                               generate_eccentricities,
+                                               generate_primary_masses,
+                                               generate_secondary_masses)
+
+PRIMARY_MASS_NAMES = ['primary_mass', 'Primary_Mass', 'PRIMARY_MASS',\
+                      'mass_1', 'Mass_1', 'MASS_1', 'm_1', 'M_1', 'm1', 'M1']
+SECONDARY_MASS_NAMES = ['secondary_mass', 'Secondary_Mass', 'SECONDARY_MASS',\
+                        'mass_2', 'Mass_2', 'MASS_2', 'm_2', 'M_2', 'm2', 'M2']
+PERIOD_NAMES = ['orbital_period', 'Orbital_Period', 'ORBITAL_PERIOD',\
+                'period', 'Period', 'PERIOD', 'P_orb', 'porb', 'P']
+SEPARATION_NAMES = ['orbital_separation', 'Orbital_Separation',\
+                    'ORBITAL_SEPARATION', 'separation', 'Separation',\
+                    'SEPARATION', 'semi-major_axis', 'Semi-Major_Axis',\
+                    'SEMI-MAJOR_AXIS', 'semi_major_axis', 'Semi_Major_Axis',\
+                    'SEMI_MAJOR_AXIS', 'a']
+ECCENTRICITY_NAMES = ['eccentricity', 'Eccentricity', 'ECCENTRICITY',\
+                      'ecc', 'Ecc', 'ECC', 'e']
+
+def infer_key(available_keys=[], allowed_keys=[]):
+    """Infer key from list of allowed keys.
+
+    Parameters
+    ----------
+    available_keys : iterable object of str, e.g. list of str
+        Collection of available keys.
+    allowed_keys : iterable object of str, e.g. list of str
+        Collection of allowed keys.
+
+    Returns
+    -------
+    key : str
+        The first matched key.
+    """
+
+    for k in allowed_keys:
+        if k in available_keys:
+            return k
+
+    return ''
+
+def get_samples_from_file(orbital_scheme='', **kwargs):
+    """Read a population of binaries at ZAMS from a file.
+
+    Parameters
+    ----------
+    orbital_scheme : str
+        Scheme to get the orbit: 'separation', 'period'
+    **kwargs : dictionary
+        kwargs from BinaryPopulation class, which should contain
+        read_samples_from_file
+
+    Returns
+    -------
+    orbital_scheme_set : ndarray of floats
+        orbital separations/periods depending on the scheme
+    eccentricity_set : ndarray of floats
+        eccentricities
+    m1_set : ndarray of floats
+        primary masses
+    m2_set : ndarray of floats
+        secondary masses
+
+    """
+
+    if 'read_samples_from_file' in kwargs:
+        filename = kwargs['read_samples_from_file']
+    else:
+        raise KeyError("In get_samples_from_file no 'read_samples_from_file'"
+                       " in kwargs.")
+    # Check and read file into dataframe
+    if os.path.isfile(filename):
+        df = pd.read_csv(filename)
+    else:
+        raise FileError(f'{filename} not found!')
+
+    # get number of data frame entries
+    set_n = len(df)
+    
+    # Get eccentricities
+    key = infer_key(available_keys=df.keys(), allowed_keys=ECCENTRICITY_NAMES)
+    if key=='':
+        warnings.warn(f'No eccentricity column found in {filename}, hence get'
+                      ' independent random ones.')
+        eccentricity_set = generate_eccentricities(number_of_binaries=set_n,\
+                                                   **kwargs)
+    else:
+        eccentricity_set = np.array(df[key])
+
+    # Generate primary masses
+    key = infer_key(available_keys=df.keys(), allowed_keys=PRIMARY_MASS_NAMES)
+    if key=='':
+        warnings.warn(f'No primary mass column found in {filename}, hence get'
+                      ' independent random ones.')
+        m1_set = generate_primary_masses(number_of_binaries=set_n, **kwargs)
+    else:
+        m1_set = np.array(df[key])
+
+    # Generate secondary masses
+    key = infer_key(available_keys=df.keys(),
+                    allowed_keys=SECONDARY_MASS_NAMES)
+    if key=='':
+        warnings.warn(f'No secondary mass column found in {filename}, hence'
+                      ' get independent random ones.')
+        m2_set = generate_secondary_masses(m1_set, number_of_binaries=set_n,\
+                                           **kwargs)
+    else:
+        m2_set = np.array(df[key])
+
+    if orbital_scheme == 'separation':
+        # Generate orbital separations
+        key = infer_key(available_keys=df.keys(),
+                        allowed_keys=SEPARATION_NAMES)
+        if key=='':
+            warnings.warn(f'No separation column found in {filename}, hence'
+                          ' get independent random ones.')
+            orbital_scheme_set = generate_orbital_separations(\
+                                  number_of_binaries=set_n, **kwargs)
+        else:
+            orbital_scheme_set = np.array(df[key])
+    elif orbital_scheme == 'period':
+        # Generate orbital periods
+        key = infer_key(available_keys=df.keys(), allowed_keys=PERIOD_NAMES)
+        if key=='':
+            warnings.warn(f'No period column found in {filename}, hence get'
+                          ' independent random ones.')
+            orbital_scheme_set = generate_orbital_periods(m1_set,\
+                                  number_of_binaries=set_n, **kwargs)
+        else:
+            orbital_scheme_set = np.array(df[key])
+    else:
+        raise ValueError("Allowed orbital schemes are separation or period.")
+
+    if 'number_of_binaries' in kwargs:
+        number_of_binaries = kwargs['number_of_binaries']
+        if 'index' in kwargs:
+            index = kwargs['index']
+        else:
+            index = 0
+        # expand the sets by doubling them as long as it is needed
+        while len(orbital_scheme_set)<index+number_of_binaries:
+            orbital_scheme_set = np.append(orbital_scheme_set,\
+                                           orbital_scheme_set)
+            eccentricity_set = np.append(eccentricity_set, eccentricity_set)
+            m1_set = np.append(m1_set, m1_set)
+            m2_set = np.append(m2_set, m2_set)
+        # only return the requested set size
+        return orbital_scheme_set[index:index+number_of_binaries],\
+               eccentricity_set[index:index+number_of_binaries],\
+               m1_set[index:index+number_of_binaries],\
+               m2_set[index:index+number_of_binaries]
+    else:
+        return orbital_scheme_set, eccentricity_set, m1_set, m2_set
+

--- a/posydon/popsyn/sample_from_file.py
+++ b/posydon/popsyn/sample_from_file.py
@@ -17,8 +17,8 @@ from posydon.popsyn.independent_sample import (generate_orbital_periods,
                                                generate_primary_masses,
                                                generate_secondary_masses)
 
-PRIMARY_MASS_NAMES = ['primary_mass', 'mass_1', 'm_1', 'm1']
-SECONDARY_MASS_NAMES = ['secondary_mass', 'mass_2', 'm_2', 'm2']
+PRIMARY_MASS_NAMES = ['S1_mass', 'primary_mass', 'mass_1', 'm_1', 'm1']
+SECONDARY_MASS_NAMES = ['S2_mass', 'secondary_mass', 'mass_2', 'm_2', 'm2']
 PERIOD_NAMES = ['orbital_period', 'period', 'p_orb', 'porb', 'p']
 SEPARATION_NAMES = ['orbital_separation', 'separation', 'semi-major_axis',\
                     'semi_major_axis', 'a']

--- a/posydon/utils/posydonerror.py
+++ b/posydon/utils/posydonerror.py
@@ -40,20 +40,23 @@ class POSYDONError(Exception):
                 pass
         return result + '\n'+ super().__str__()
 
-class GridError(POSYDONError):
-    """POSYDON error specific for PSyGrid operations."""
+class FileError(POSYDONError):
+    """POSYDON error specific for reading/writing files."""
 
 class FlowError(POSYDONError):
     """POSYDON error specific for binary evolution flow errors."""
+
+class GridError(POSYDONError):
+    """POSYDON error specific for PSyGrid operations."""
+
+class MatchingError(POSYDONError):
+    """POSYDON error specific for matching stars to single grid during the detached."""
 
 class ModelError(POSYDONError):
     """POSYDON error specific for when a binary FAILS due to limitations of physics modeling assumptions."""
 
 class NumericalError(POSYDONError):
     """POSYDON error specific for when a binary FAILS due to limitations of numerical methods."""
-
-class MatchingError(POSYDONError):
-    """POSYDON error specific for matching stars to single grid during the detached."""
 
 def initial_condition_message(binary,ini_params = None ):
     if ini_params is None:

--- a/posydon/utils/posydonerror.py
+++ b/posydon/utils/posydonerror.py
@@ -3,6 +3,7 @@
 
 __authors__ = [
     "Camille Liotine <cliotine@u.northwestern.edu>",
+    "Eirini Kasdagli <kasdaglie@ufl.edu>",
     "Konstantinos Kovlakas <Konstantinos.Kovlakas@unige.ch>",
     "Matthias Kruckow <Matthias.Kruckow@unige.ch>",
 ]

--- a/posydon/utils/posydonerror.py
+++ b/posydon/utils/posydonerror.py
@@ -1,5 +1,13 @@
 """The POSYDON exception class and subclasses for more specific errors."""
 
+
+__authors__ = [
+    "Camille Liotine <cliotine@u.northwestern.edu>",
+    "Konstantinos Kovlakas <Konstantinos.Kovlakas@unige.ch>",
+    "Matthias Kruckow <Matthias.Kruckow@unige.ch>",
+]
+
+
 import copy
 from posydon.binary_evol.binarystar import BinaryStar
 from posydon.binary_evol.singlestar import SingleStar
@@ -40,8 +48,9 @@ class POSYDONError(Exception):
                 pass
         return result + '\n'+ super().__str__()
 
-class FileError(POSYDONError):
-    """POSYDON error specific for reading/writing files."""
+# Subclasses of POSYODONError in alphabetic order
+# Before you add a new subclass check the list of python error classes at the
+# end of this file
 
 class FlowError(POSYDONError):
     """POSYDON error specific for binary evolution flow errors."""
@@ -75,3 +84,60 @@ def initial_condition_message(binary,ini_params = None ):
     for i in ini_params:
         message +=  i 
     return message
+
+
+# There are 5 base exception classes in python: BaseException, Exception,
+# ArithmeticError, BufferError, LookupError. Those are not aimed to be raised
+# directly but their subclasses.
+#
+# List of Python's default exception (sub)classes in alphabetic order
+# AssertionError: Raised when an assert statement fails.
+# AttributeError: Raised when an attribute reference or assignment fails.
+# EOFError: Raised when the input() function hits an end-of-file condition
+#     (EOF) without reading any data.
+# GeneratorExit: Raised when a generator or coroutine is closed.
+# ImportError: Raised when the import statement has troubles trying to load a
+#     module or a requested object does not exist in the module.
+#     "ModuleNotFoundError" is a subclass of this error.
+# IndexError: Raised when a sequence subscript is out of range.
+# KeyError: Raised when a mapping key is not found in the set of existing keys.
+# KeyboardInterrupt: Raised when the user hits the interrupt key (normally
+#     Control-C or Delete).
+# MemoryError: Raised when an operation runs out of memory.
+# NameError: Raised when a local or global name is not found.
+#     "UnboundLocalError" is a subclass of this error.
+# RuntimeError: Raised when an error is detected that doesn’t fall in any of
+#     the other categories. "NotImplementedError"(indicates a planned but not
+#     yet implemented class/function) and "RecursionError"(reached maximum
+#     recursion depth) are subclasses of this error.
+# OSError: This exception is raised when a system function returns a
+#     system-related error. This error has different names in old or platform
+#     specfic versions like "EnvironmentError", "IOError", "WindowsError".
+#     There is a bunch of subclasses: "BlockingIOError", "ChildProcessError",
+#     "ConnectionError", "BrokenPipeError", "ConnectionAbortedError",
+#     "ConnectionRefusedError", "ConnectionResetError", "FileExistsError",
+#     "FileNotFoundError", "InterruptedError", "IsADirectoryError",
+#     "NotADirectoryError", "PermissionError", "ProcessLookupError",
+#     "TimeoutError".
+# OverflowError: Raised when the result of an arithmetic operation is too large
+#     to be represented.
+# ReferenceError: Raised when a reference is no longer valid because the
+#     referred object is garbage collected.
+# StopIteration: Raised if there is no next item, while requested.
+# StopAsyncIteration: Raised to stop asynchronous interation.
+# SyntaxError: Raised when the parser encounters a syntax error.
+#     "IndentationError"(has an own subclass TabError) is a subclasses of this
+#     error.
+# SystemError: Raised when the interpreter finds an internal error.
+# SystemExit: This exception is subclass of BaseException instead of Exception
+#     to be not caugth with other exceptions.
+# TypeError: Raised when an operation or function is applied to an object of
+#     inappropriate type.
+# ValueError: Raised when an operation or function receives an argument that
+#     has the right type but an inappropriate value. "UnicodeError"(has own
+#     subclasses: "UnicodeEncodeError", "UnicodeDecodeError",
+#     "UnicodeTranslateError") is a subclass of this error.
+# ZeroDivisionError: Raised when the second argument of a division or modulo
+#     operation is zero.
+#
+# for more details see https://docs.python.org/3/library/exceptions.html


### PR DESCRIPTION
Add the functionality to be able to read the initial binary values from a given file.

- [x] add a field to the `population_params_default.ini` to take a file name, if empty data will be randomly generated as before
- [x] add function to read the file
  - try to infer the name a value may have in the file otherwise take a random sample of the same length as the file provides
  - extend the population in the file by doubling it, if needed
  - read kick values additionally to initial values
- [x] sort POSYDON errors and add description of python standard ones
- [x] tested with `ZAMS_values.csv`, see below

`ZAMS_values.csv` content:
> M_1,M_2,P_orb,e,w1,phi1,theta1,s1_natal_kick_array_3
> 10.0,10.0,10.0,0.0,0.0,0.0,0.0,0.0
> 10.0,10.0,100.0,0.0,1.0,0.0,0.0,0.0
> 10.0,10.0,1000.0,0.0,10.0,0.0,0.0,0.0
> 20.0,10.0,10.0,0.0,10.0,0.785398163,0.0,0.0
> 20.0,10.0,100.0,0.0,10.0,1.570796327,0.0,0.0
> 20.0,10.0,1000.0,0.0,10.0,2.35619449,0.0,0.0
> 40.0,10.0,10.0,0.0,10.0,3.141592654,0.0,0.0
> 40.0,10.0,100.0,0.0,10.0,0.785398163,0.785398163,0.0
> 40.0,10.0,1000.0,0.0,10.0,1.570796327,0.785398163,0.0
> 20.0,20.0,10.0,0.0,10.0,2.35619449,0.785398163,0.0
> 20.0,20.0,100.0,0.0,10.0,3.141592654,0.785398163,0.0
> 20.0,20.0,1000.0,0.0,10.0,0.785398163,0.785398163,0.785398163
> 40.0,20.0,10.0,0.0,10.0,1.570796327,0.785398163,0.785398163
> 40.0,20.0,100.0,0.0,10.0,2.35619449,0.785398163,0.785398163
> 40.0,20.0,1000.0,0.0,10.0,3.141592654,0.785398163,0.785398163
> 40.0,40.0,10.0,0.0,10.0,4.712388981,0.785398163,0.785398163
> 40.0,40.0,100.0,0.0,10.0,4.712388981,0.785398163,1.570796327
> 40.0,40.0,1000.0,0.0,10.0,4.712388981,0.785398163,4.712388981