### PR TITLE
Add extra hooks columns to binary.restore()

### DIFF
--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -187,6 +187,7 @@ class BinaryStar:
             self.properties = properties
         else:
             self.properties = SimulationProperties()
+        
 
     def evolve(self):
         """Evolve a binary from start to finish."""
@@ -256,8 +257,8 @@ class BinaryStar:
         """Switch stars."""
         self.star_1, self.star_2 = self.star_2, self.star_1
 
-    def restore(self, i=0, delete_history=True):
-        """Restore the object to the i-th state.
+    def restore(self, i=0):
+        """Restore the BinaryStar() object to its i-th state, keeping the binary history before the i-th state.
 
         Parameters
         ----------
@@ -270,25 +271,21 @@ class BinaryStar:
         for p in BINARYPROPERTIES:            
             setattr(self, p, getattr(self, '{}_history'.format(p))[i])
 
-            # Remove the obsolete history data
-            if delete_history:
-                setattr(self, p + '_history', getattr(self, p + '_history')[0:i + 1])
-                
-        
+            ## delete the binary history after the i-th index
+            setattr(self, p + '_history', getattr(self, p + '_history')[0:i+1])
+                       
         ## if running with extra hooks, restore any extra hook columns
         for hook in self.properties.all_hooks_classes:
+            
             if hasattr(hook, 'extra_binary_col_names'):
                 extra_columns = getattr(hook, 'extra_binary_col_names')
 
                 for col in extra_columns:
-                    setattr(self, col,[getattr(self, col)[i]])
-                    # Remove the obsolete history data
-                    if delete_history:
-                        setattr(self, col, getattr(self, col)[0:i+1])
+                    setattr(self, col, getattr(self, col)[0:i+1])                    
         
         for star in (self.star_1, self.star_2):
-            star.restore(i)
-       
+            star.restore(i, hooks=self.properties.all_hooks_classes)
+                             
 
     def reset(self, properties=None):
         """Reset the binary to its ZAMS state.

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -227,8 +227,10 @@ class TimingHooks(EvolveHooks):
 
     Example
     -------
-    >>> pop.to_df(extra_columns=['step_times'])
+    >>> pop.to_df(extra_columns={'step_times': float})
     """
+    def __init__(self):
+        self.extra_binary_col_names = ["step_times"]
 
     def pre_evolve(self, binary):
         """Initialize the step time to match history."""
@@ -264,8 +266,11 @@ class StepNamesHooks(EvolveHooks):
 
     Name of evolutionary step as defined in SimulationProperties.
 
-    >>> pop.to_df(extra_columns=['step_names'])
+    >>> pop.to_df(extra_columns={'step_names': str})
     """
+    def __init__(self):
+        self.extra_binary_col_names = ["step_names"]
+
 
     def pre_evolve(self, binary):
         """Initialize the step name to match history."""

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -204,6 +204,16 @@ class SimulationProperties:
 
 class EvolveHooks:
     """Base class for hooking into binary evolution."""
+    
+    def __init__(self):
+        """
+        Add any new output columns to the hooks constructor.
+        Example for extra binary columns: 
+            self.extra_binary_col_names = ["column_name_1", "column_name_2"]
+        Example for extra star columns: 
+            self.extra_star_col_names = ["column_name_1", "column_name_2"]           
+        """
+        pass
 
     def pre_evolve(self, binary):
         """Perform actions before a binary evolves."""
@@ -234,7 +244,8 @@ class TimingHooks(EvolveHooks):
 
     def pre_evolve(self, binary):
         """Initialize the step time to match history."""
-        binary.step_times = [0.0]
+        if not hasattr(binary, 'step_times'):
+            binary.step_times = [0.0]
         return binary
 
     def pre_step(self, binary, step_name):
@@ -271,10 +282,10 @@ class StepNamesHooks(EvolveHooks):
     def __init__(self):
         self.extra_binary_col_names = ["step_names"]
 
-
     def pre_evolve(self, binary):
         """Initialize the step name to match history."""
-        binary.step_names = ['initial_cond']
+        if not hasattr(binary, 'step_names'):
+            binary.step_names = ['initial_cond']
         return binary
 
     def pre_step(self, binary, step_name):

--- a/posydon/binary_evol/singlestar.py
+++ b/posydon/binary_evol/singlestar.py
@@ -177,7 +177,7 @@ class SingleStar:
         for item in STARPROPERTIES:
             getattr(self, item + '_history').append(getattr(self, item))
 
-    def restore(self, i=0, hooks=[]):
+    def restore(self, i=0, hooks=None):
         """Restore the SingleStar() object to its i-th state, keeping the star history before the i-th state.
 
         Parameters
@@ -190,6 +190,9 @@ class SingleStar:
             object containing this SingleStar(), if applicable. This parameter is 
             automatically set when restoring a BinaryStar() object. 
         """
+        if hooks is None:
+            hooks = []
+            
         # Move current star properties to the ith step, using its history
         for p in STARPROPERTIES:
             setattr(self, p, getattr(self, '{}_history'.format(p))[i])

--- a/posydon/binary_evol/singlestar.py
+++ b/posydon/binary_evol/singlestar.py
@@ -177,24 +177,35 @@ class SingleStar:
         for item in STARPROPERTIES:
             getattr(self, item + '_history').append(getattr(self, item))
 
-    def restore(self, i=0, delete_history=True):
-        """Restore the object to the i-th state.
+    def restore(self, i=0, hooks=[]):
+        """Restore the SingleStar() object to its i-th state, keeping the star history before the i-th state.
 
         Parameters
         ----------
         i : int
             Index of the star object history to reset the star to. By default
             i == 0, i.e. the star will be restored to its initial state.
+        hooks : list
+            List of extra hooks associated with the SimulationProperties() of the BinaryStar()
+            object containing this SingleStar(), if applicable. This parameter is 
+            automatically set when restoring a BinaryStar() object. 
         """
         # Move current star properties to the ith step, using its history
         for p in STARPROPERTIES:
             setattr(self, p, getattr(self, '{}_history'.format(p))[i])
 
-        # Remove the obsolete history data
-        if delete_history:
-            for p in STARPROPERTIES:
-                setattr(self, p + '_history',
-                        getattr(self, p + '_history')[0:i + 1])
+            ## delete the star history after the i-th index
+            setattr(self, p + '_history', getattr(self, p + '_history')[0:i+1])
+        
+        ## if running with extra hooks, restore any extra hook columns
+        for hook in hooks:
+
+            if hasattr(hook, 'extra_star_col_names'):
+                extra_columns = getattr(hook, 'extra_star_col_names')
+                
+                for col in extra_columns:
+                    setattr(self, col, getattr(self, col)[0:i+1])  
+           
 
     def to_df(self, **kwargs):
         """Return history parameters from the star in a DataFrame.

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -648,7 +648,11 @@ class PopulationManager:
 
         """
         if where is None:
-            query_str = f'index=={indices}'
+            if len(indices) > 0:
+                query_str = f'index=={indices}'
+            else:
+                raise ValueError("You must specify either the binary indices or a query string "
+                                 "to read from file.")
         else:
             query_str = str(where)
 

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -634,7 +634,7 @@ class PopulationManager:
         self.append(binary)
         return binary
 
-    def from_hdf(self, indices=[], where=None, restore=False):
+    def from_hdf(self, indices=None, where=None, restore=False):
         """Load a BinaryStar instance from an hdf file of a saved population.
 
         Parameters
@@ -648,11 +648,11 @@ class PopulationManager:
 
         """
         if where is None:
-            if len(indices) > 0:
-                query_str = f'index=={indices}'
-            else:
+            if indices is None:
                 raise ValueError("You must specify either the binary indices or a query string "
-                                 "to read from file.")
+                                 "to read from file.")               
+            else:
+                query_str = 'index==indices'                
         else:
             query_str = str(where)
 

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -634,7 +634,7 @@ class PopulationManager:
         self.append(binary)
         return binary
 
-    def from_hdf(self, indices, where=None, restore=False):
+    def from_hdf(self, indices=[], where=None, restore=False):
         """Load a BinaryStar instance from an hdf file of a saved population.
 
         Parameters

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -644,11 +644,11 @@ class PopulationManager:
         where : str
             Query performed on disk to select history and oneline DataFrames.
         restore : bool
-            Restore binaries back to initial conditions.
+            If true, restore binaries back to initial conditions.
 
         """
         if where is None:
-            query_str = 'index==indices'
+            query_str = f'index=={indices}'
         else:
             query_str = str(where)
 


### PR DESCRIPTION
This PR adds extra columns associated with hooks in the SimulationProperties (e.g. step names, step times) to the BinaryStar and SingleStar restore() functions. It looks for any hooks classes in the simulation properties and checks if they add extra binary or star columns to the evolution. These column names now must defined in the hooks constructors as shown. 

NOTE: Currently, the hooks columns can only be restored if a binary is initialized and evolved with the desired simulation properties/hooks. The binary cannot be restored with these columns, for example, if the user reads a binary from an hdf file. If we want this functionality, the dev is more involved and I would suggest a separate PR.