### PR TITLE
Update absolute import support for ini files.

### DIFF
--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -10,13 +10,15 @@
 
 [flow]
   import = ['posydon.binary_evol.flow_chart', 'flow_chart']
+    # builtin posydon flow
   absolute_import = None
-  # 'package' kwarg for importlib.import_module
+    # If given, use an absolute filepath to user defined flow: ['<PATH_TO_PY_FILE>', '<NAME>']
 
 [step_HMS_HMS]
   import = ['posydon.binary_evol.MESA.step_mesa', 'MS_MS_step']
+    # builtin posydon step
   absolute_import = None
-    # 'package' kwarg for importlib.import_module
+    # If given, use an absolute filepath to user defined step: ['<PATH_TO_PY_FILE>', '<NAME>']
   interpolation_path = None
     # found by default
   interpolation_filename = None
@@ -43,8 +45,9 @@
 
 [step_CO_HeMS]
   import = ['posydon.binary_evol.MESA.step_mesa', 'CO_HeMS_step']
+    # builtin posydon step
   absolute_import = None
-    # 'package' kwarg for importlib.import_module
+    # If given, use an absolute filepath to user defined step: ['<PATH_TO_PY_FILE>', '<NAME>']
   interpolation_path = None
     # found by default
   interpolation_filename = None
@@ -70,8 +73,9 @@
 
 [step_CO_HMS_RLO]
   import = ['posydon.binary_evol.MESA.step_mesa', 'CO_HMS_RLO_step']
+    # builtin posydon step
   absolute_import = None
-    # 'package' kwarg for importlib.import_module
+    # If given, use an absolute filepath to user defined step: ['<PATH_TO_PY_FILE>', '<NAME>']
   interpolation_path = None
     # found by default
   interpolation_filename = None
@@ -97,8 +101,9 @@
 
 [step_CO_HeMS_RLO]
   import = ['posydon.binary_evol.MESA.step_mesa', 'CO_HeMS_RLO_step']
+    # builtin posydon step
   absolute_import = None
-    # 'package' kwarg for importlib.import_module
+    # If given, use an absolute filepath to user defined step: ['<PATH_TO_PY_FILE>', '<NAME>']
   interpolation_path = None
     # found by default
   interpolation_filename = None
@@ -125,8 +130,9 @@
 
 [step_detached]
   import = ['posydon.binary_evol.DT.step_detached', 'detached_step']
+    # builtin posydon step
   absolute_import = None
-    # 'package' kwarg for importlib.import_module
+    # If given, use an absolute filepath to user defined step: ['<PATH_TO_PY_FILE>', '<NAME>']
   matching_method = 'minimize'
     #'minimize' 'root'
   do_wind_loss = True
@@ -146,17 +152,27 @@
 
 [step_disrupted]
   import = ['posydon.binary_evol.DT.step_disrupted','DisruptedStep']
+    # builtin posydon step
+  absolute_import = None
+    # If given, use an absolute filepath to user defined step: ['<PATH_TO_PY_FILE>', '<NAME>']
 
 [step_merged]
   import = ['posydon.binary_evol.DT.step_merged','MergedStep']
+    # builtin posydon step
+  absolute_import = None
+    # If given, use an absolute filepath to user defined step: ['<PATH_TO_PY_FILE>', '<NAME>']
 
 [step_initially_single]
   import = ['posydon.binary_evol.DT.step_initially_single','InitiallySingleStep']
+    # builtin posydon step
+  absolute_import = None
+    # If given, use an absolute filepath to user defined step: ['<PATH_TO_PY_FILE>', '<NAME>']
 
 [step_CE]
   import = ['posydon.binary_evol.CE.step_CEE', 'StepCEE']
+    # builtin posydon step
   absolute_import = None
-    # 'package' kwarg for importlib.import_module
+    # If given, use an absolute filepath to user defined step: ['<PATH_TO_PY_FILE>', '<NAME>']
   prescription='alpha-lambda'
     # 'alpha-lambda'
   common_envelope_efficiency=1.0
@@ -186,6 +202,7 @@
 
 [step_SN]
   import = ['posydon.binary_evol.SN.step_SN', 'StepSN']
+    # builtin posydon step
   absolute_import = None
     # 'package' kwarg for importlib.import_module
   mechanism = 'Patton&Sukhbold20-engine'
@@ -228,22 +245,28 @@
 
 [step_dco]
   import = ['posydon.binary_evol.DT.double_CO', 'DoubleCO']
+    # builtin posydon step
   absolute_import = None
-    # 'package' kwarg for importlib.import_module
+    # If given, use an absolute filepath to user defined step: ['<PATH_TO_PY_FILE>', '<NAME>']
   n_o_steps_interval = None
 
 [step_end]
   import = ['posydon.binary_evol.step_end', 'step_end']
+    # builtin posydon step
   absolute_import = None
-    # 'package' kwarg for importlib.import_module
+    # If given, use an absolute filepath to user defined step: ['<PATH_TO_PY_FILE>', '<NAME>']
 
 [extra_hooks]
   import_1 = ['posydon.binary_evol.simulationproperties', 'TimingHooks']
+    # builtin posydon hook
   absolute_import_1 = None
+    # If given, use an absolute filepath to user defined step: ['<PATH_TO_PY_FILE>', '<NAME>']
   kwargs_1 = {}
 
   import_2 = ['posydon.binary_evol.simulationproperties', 'StepNamesHooks']
+    # builtin posydon hook
   absolute_import_2 = None
+    # If given, use an absolute filepath to user defined step: ['<PATH_TO_PY_FILE>', '<NAME>']
   kwargs_2 = {}
 
 


### PR DESCRIPTION
Many people have been trying to run posydon with custom code for many different reasons. Old code for relative imports was not working well so I have updated it so the syntax is cleaner. Here is an example using the new feature:
```ini
[step_HMS_HMS]
  import = ['posydon.binary_evol.MESA.step_mesa', 'MS_MS_step']
    # builtin posydon step
  absolute_import =[ '/projects/b1119/karocha/dev_posydon/custom_steps/step_end.py', 'StepEnd']
    # If given, use an absolute filepath to user defined step: ['<PATH_TO_PY_FILE>', '<NAME>']
  ...
```
If both `import` and `absolute_import` are provided, the default behavior is to use `absolute_import`. If we parse this ini file we get:

```python
from posydon.popsyn.io import simprop_kwargs_from_ini

sim_prop_kwargs = simprop_kwargs_from_ini('./custom_steps/test_rel_path.ini')
for key, val in sim_prop_kwargs.items():
    if key == 'flow': continue
    print(key, val)
```
Results in the following:
```txt
>>> step_HMS_HMS (<class 'projects.b1119.karocha.dev_posydon.custom_steps.step_end.StepEnd'>, {})
```
Which includes the full path as the module name :)

TODO:
- [ ] Probably should be tested with a population synthesis.