### PR TITLE
Rerun for He stars and rapid mass transfer (CO-HeMS and moderate mass ratio HMS-HMS)

### DIFF
--- a/bin/posydon-run-pipeline
+++ b/bin/posydon-run-pipeline
@@ -667,6 +667,8 @@ def copy_ini_file(grid_type, rerun_metallicity, rerun_type, destination,
         replace_text = "fix_iniHe_pre_rerun5-0e736a853c3c2e522b76299a54aea8f5eea15d08"
     elif rerun_type == "dedt_energy_eqn":
         replace_text = "seth_dedt_energy_eqn-deac5c26392b36cb7a8ff337e0d53c26568a3971"
+    elif rerun_type == "dedt_forcemltpp":
+        replace_text = "seth_dedt_force_mltpp-397d1379935fc5580e134237a46fddfeae4ca73b"
     elif rerun_type == 'other': # e.g. 'envelope_mass_limit', 'fe_core_infall_limit'
         # this rerun uses the default inlist commit
         return
@@ -835,6 +837,8 @@ def logic_rerun(grid, rerun_type):
                 runs_to_rerun += [i]
         runs_to_rerun = np.array(runs_to_rerun)
     elif rerun_type == 'dedt_energy_eqn':
+        termination_flags = TF1_POOL_ERROR
+    elif rerun_type == 'dedt_force_mltpp':
         termination_flags = TF1_POOL_ERROR
     elif rerun_type == 'envelope_mass_limit': # maybe 'fe_core_infall_limit' as well?
         runs_to_rerun = None # implement logic

--- a/bin/posydon-run-pipeline
+++ b/bin/posydon-run-pipeline
@@ -668,7 +668,7 @@ def copy_ini_file(grid_type, rerun_metallicity, rerun_type, destination,
     elif rerun_type == "dedt_energy_eqn":
         replace_text = "seth_dedt_energy_eqn-deac5c26392b36cb7a8ff337e0d53c26568a3971"
     elif rerun_type == "dedt_hepulse":
-        replace_text = "seth_dedt_hepulse-73820cf05d504e03d9a59531132f7c95693533b3"
+        replace_text = "seth_dedt_hepulse-70bf87736e45dbbd60eb9d3707797e15918eea60"
     elif rerun_type == 'other': # e.g. 'envelope_mass_limit', 'fe_core_infall_limit'
         # this rerun uses the default inlist commit
         return

--- a/bin/posydon-run-pipeline
+++ b/bin/posydon-run-pipeline
@@ -667,7 +667,7 @@ def copy_ini_file(grid_type, rerun_metallicity, rerun_type, destination,
         replace_text = "fix_iniHe_pre_rerun5-0e736a853c3c2e522b76299a54aea8f5eea15d08"
     elif rerun_type == "dedt_energy_eqn":
         replace_text = "seth_dedt_energy_eqn-deac5c26392b36cb7a8ff337e0d53c26568a3971"
-    elif rerun_type == "dedt_forcemltpp":
+    elif rerun_type == "dedt_force_mltpp":
         replace_text = "seth_dedt_force_mltpp-397d1379935fc5580e134237a46fddfeae4ca73b"
     elif rerun_type == 'other': # e.g. 'envelope_mass_limit', 'fe_core_infall_limit'
         # this rerun uses the default inlist commit

--- a/bin/posydon-run-pipeline
+++ b/bin/posydon-run-pipeline
@@ -668,7 +668,7 @@ def copy_ini_file(grid_type, rerun_metallicity, rerun_type, destination,
     elif rerun_type == "dedt_energy_eqn":
         replace_text = "seth_dedt_energy_eqn-f1803afe400ed16a4fad47b0bad6abbf0965cae1"
     elif rerun_type == "dedt_hepulse":
-        replace_text = "seth_dedt_hepulse-3819c125634704d7ee1b558bd3f0254e651e0daf"
+        replace_text = "seth_dedt_hepulse-12aff51d64ecd9fe97dacfbedcb5bbe859ca8fa0"
     elif rerun_type == 'other': # e.g. 'envelope_mass_limit', 'fe_core_infall_limit'
         # this rerun uses the default inlist commit
         return

--- a/bin/posydon-run-pipeline
+++ b/bin/posydon-run-pipeline
@@ -665,6 +665,8 @@ def copy_ini_file(grid_type, rerun_metallicity, rerun_type, destination,
         replace_text = "development-435d16c9158e4608530f21b8169ce6f31160e23e"
     elif rerun_type == 'initial_He':
         replace_text = "fix_iniHe_pre_rerun5-0e736a853c3c2e522b76299a54aea8f5eea15d08"
+    elif rerun_type == "dedt_energy_eqn":
+        replace_text = "seth_dedt_energy_eqn-deac5c26392b36cb7a8ff337e0d53c26568a3971"
     elif rerun_type == "dedt_hepulse":
         replace_text = "seth_dedt_hepulse-70bf87736e45dbbd60eb9d3707797e15918eea60"
     elif rerun_type == 'other': # e.g. 'envelope_mass_limit', 'fe_core_infall_limit'
@@ -834,6 +836,8 @@ def logic_rerun(grid, rerun_type):
             if np.isnan(iniY) or iniY<0.96:
                 runs_to_rerun += [i]
         runs_to_rerun = np.array(runs_to_rerun)
+    elif rerun_type == 'dedt_energy_eqn':
+        termination_flags = TF1_POOL_ERROR    
     elif rerun_type == 'dedt_hepulse':
         termination_flags = TF1_POOL_ERROR
     elif rerun_type == 'envelope_mass_limit': # maybe 'fe_core_infall_limit' as well?

--- a/bin/posydon-run-pipeline
+++ b/bin/posydon-run-pipeline
@@ -666,9 +666,9 @@ def copy_ini_file(grid_type, rerun_metallicity, rerun_type, destination,
     elif rerun_type == 'initial_He':
         replace_text = "fix_iniHe_pre_rerun5-0e736a853c3c2e522b76299a54aea8f5eea15d08"
     elif rerun_type == "dedt_energy_eqn":
-        replace_text = "seth_dedt_energy_eqn-deac5c26392b36cb7a8ff337e0d53c26568a3971"
+        replace_text = "seth_dedt_energy_eqn-f1803afe400ed16a4fad47b0bad6abbf0965cae1"
     elif rerun_type == "dedt_hepulse":
-        replace_text = "seth_dedt_hepulse-5bce1cd5f52b63e19d94ca220c041b5717baf56a"
+        replace_text = "seth_dedt_hepulse-3819c125634704d7ee1b558bd3f0254e651e0daf"
     elif rerun_type == 'other': # e.g. 'envelope_mass_limit', 'fe_core_infall_limit'
         # this rerun uses the default inlist commit
         return

--- a/bin/posydon-run-pipeline
+++ b/bin/posydon-run-pipeline
@@ -667,8 +667,8 @@ def copy_ini_file(grid_type, rerun_metallicity, rerun_type, destination,
         replace_text = "fix_iniHe_pre_rerun5-0e736a853c3c2e522b76299a54aea8f5eea15d08"
     elif rerun_type == "dedt_energy_eqn":
         replace_text = "seth_dedt_energy_eqn-deac5c26392b36cb7a8ff337e0d53c26568a3971"
-    elif rerun_type == "dedt_force_mltpp":
-        replace_text = "seth_dedt_force_mltpp-397d1379935fc5580e134237a46fddfeae4ca73b"
+    elif rerun_type == "dedt_hepulse":
+        replace_text = "seth_dedt_hepulse-73820cf05d504e03d9a59531132f7c95693533b3"
     elif rerun_type == 'other': # e.g. 'envelope_mass_limit', 'fe_core_infall_limit'
         # this rerun uses the default inlist commit
         return
@@ -838,7 +838,7 @@ def logic_rerun(grid, rerun_type):
         runs_to_rerun = np.array(runs_to_rerun)
     elif rerun_type == 'dedt_energy_eqn':
         termination_flags = TF1_POOL_ERROR
-    elif rerun_type == 'dedt_force_mltpp':
+    elif rerun_type == 'dedt_hepulse':
         termination_flags = TF1_POOL_ERROR
     elif rerun_type == 'envelope_mass_limit': # maybe 'fe_core_infall_limit' as well?
         runs_to_rerun = None # implement logic

--- a/bin/posydon-run-pipeline
+++ b/bin/posydon-run-pipeline
@@ -668,7 +668,7 @@ def copy_ini_file(grid_type, rerun_metallicity, rerun_type, destination,
     elif rerun_type == "dedt_energy_eqn":
         replace_text = "seth_dedt_energy_eqn-deac5c26392b36cb7a8ff337e0d53c26568a3971"
     elif rerun_type == "dedt_hepulse":
-        replace_text = "seth_dedt_hepulse-70bf87736e45dbbd60eb9d3707797e15918eea60"
+        replace_text = "seth_dedt_hepulse-b0405a8260a998536e8f8d8b54dd8c242763b509"
     elif rerun_type == 'other': # e.g. 'envelope_mass_limit', 'fe_core_infall_limit'
         # this rerun uses the default inlist commit
         return

--- a/bin/posydon-run-pipeline
+++ b/bin/posydon-run-pipeline
@@ -665,8 +665,6 @@ def copy_ini_file(grid_type, rerun_metallicity, rerun_type, destination,
         replace_text = "development-435d16c9158e4608530f21b8169ce6f31160e23e"
     elif rerun_type == 'initial_He':
         replace_text = "fix_iniHe_pre_rerun5-0e736a853c3c2e522b76299a54aea8f5eea15d08"
-    elif rerun_type == "dedt_energy_eqn":
-        replace_text = "seth_dedt_energy_eqn-deac5c26392b36cb7a8ff337e0d53c26568a3971"
     elif rerun_type == "dedt_hepulse":
         replace_text = "seth_dedt_hepulse-70bf87736e45dbbd60eb9d3707797e15918eea60"
     elif rerun_type == 'other': # e.g. 'envelope_mass_limit', 'fe_core_infall_limit'
@@ -836,8 +834,6 @@ def logic_rerun(grid, rerun_type):
             if np.isnan(iniY) or iniY<0.96:
                 runs_to_rerun += [i]
         runs_to_rerun = np.array(runs_to_rerun)
-    elif rerun_type == 'dedt_energy_eqn':
-        termination_flags = TF1_POOL_ERROR
     elif rerun_type == 'dedt_hepulse':
         termination_flags = TF1_POOL_ERROR
     elif rerun_type == 'envelope_mass_limit': # maybe 'fe_core_infall_limit' as well?

--- a/bin/posydon-run-pipeline
+++ b/bin/posydon-run-pipeline
@@ -668,7 +668,7 @@ def copy_ini_file(grid_type, rerun_metallicity, rerun_type, destination,
     elif rerun_type == "dedt_energy_eqn":
         replace_text = "seth_dedt_energy_eqn-f1803afe400ed16a4fad47b0bad6abbf0965cae1"
     elif rerun_type == "dedt_hepulse":
-        replace_text = "seth_dedt_hepulse-12aff51d64ecd9fe97dacfbedcb5bbe859ca8fa0"
+        replace_text = "seth_dedt_hepulse-0274be9895480cae3aa2a4d14b056a2447d5921b"
     elif rerun_type == 'other': # e.g. 'envelope_mass_limit', 'fe_core_infall_limit'
         # this rerun uses the default inlist commit
         return

--- a/bin/posydon-run-pipeline
+++ b/bin/posydon-run-pipeline
@@ -668,7 +668,7 @@ def copy_ini_file(grid_type, rerun_metallicity, rerun_type, destination,
     elif rerun_type == "dedt_energy_eqn":
         replace_text = "seth_dedt_energy_eqn-deac5c26392b36cb7a8ff337e0d53c26568a3971"
     elif rerun_type == "dedt_hepulse":
-        replace_text = "seth_dedt_hepulse-b0405a8260a998536e8f8d8b54dd8c242763b509"
+        replace_text = "seth_dedt_hepulse-5bce1cd5f52b63e19d94ca220c041b5717baf56a"
     elif rerun_type == 'other': # e.g. 'envelope_mass_limit', 'fe_core_infall_limit'
         # this rerun uses the default inlist commit
         return

--- a/docs/_source/components-overview/post_processing/pipeline/pipeline_steps.rst
+++ b/docs/_source/components-overview/post_processing/pipeline/pipeline_steps.rst
@@ -205,5 +205,6 @@ type of the rerun specifying the logic and changes, and the cluster name.
     more_mesh              workaround      it modifies the remeshing and allows for more cells in MESA
     conv_bdy_weight        caution         it disabled the convective_bdy_weight where this caused segmentation faults (this avoids a bug in the old MESA version r11701)
     dedt_energy_eqn        caution         it enables MESA's dedt-form of the energy equation for numerical stability during superthermal mass transfer
+    dedt_force_mltpp       caution         it enables MESA's dedt-form of the energy equation and near TAHeMS sets MLT++ to default value, but forced everywhere (no Pgas/P, Ledd/L limit) to help stripped He star pulsations 
     =====================  ==============  ===========
 

--- a/docs/_source/components-overview/post_processing/pipeline/pipeline_steps.rst
+++ b/docs/_source/components-overview/post_processing/pipeline/pipeline_steps.rst
@@ -205,6 +205,6 @@ type of the rerun specifying the logic and changes, and the cluster name.
     more_mesh              workaround      it modifies the remeshing and allows for more cells in MESA
     conv_bdy_weight        caution         it disabled the convective_bdy_weight where this caused segmentation faults (this avoids a bug in the old MESA version r11701)
     dedt_energy_eqn        caution         it enables MESA's dedt-form of the energy equation for numerical stability during superthermal mass transfer
-    dedt_hepulse           caution         it enables MESA's dedt-form of the energy equation and sets lnPgas_flag = .true. for numerical stability. Several MLT++ changes, v_flag set to .true., and convecitve_bdy_weight disabled and to help with stripped He star pulsations and WD cooling. 
+    dedt_hepulse           caution         it enables MESA's dedt-form of the energy equation. Several MLT++ changes, v_flag and lnPgas_flag set to .true., and convecitve_bdy_weight disabled to help with stripped He star pulsations and WD cooling. 
     =====================  ==============  ===========
 

--- a/docs/_source/components-overview/post_processing/pipeline/pipeline_steps.rst
+++ b/docs/_source/components-overview/post_processing/pipeline/pipeline_steps.rst
@@ -205,6 +205,6 @@ type of the rerun specifying the logic and changes, and the cluster name.
     more_mesh              workaround      it modifies the remeshing and allows for more cells in MESA
     conv_bdy_weight        caution         it disabled the convective_bdy_weight where this caused segmentation faults (this avoids a bug in the old MESA version r11701)
     dedt_energy_eqn        caution         it enables MESA's dedt-form of the energy equation for numerical stability during superthermal mass transfer
-    dedt_force_mltpp       caution         it enables MESA's dedt-form of the energy equation and near TAHeMS sets lnPgas_flag = .true., MLT++ back to its default value, and forces it everywhere (no Pgas/P, Ledd/L limit) to help stripped He star pulsations. 
+    dedt_hepulse           caution         it enables MESA's dedt-form of the energy equation and sets lnPgas_flag = .true. for numerical stability. Several MLT++ changes, v_flag set to .true., and convecitve_bdy_weight disabled and to help with stripped He star pulsations and WD cooling. 
     =====================  ==============  ===========
 

--- a/docs/_source/components-overview/post_processing/pipeline/pipeline_steps.rst
+++ b/docs/_source/components-overview/post_processing/pipeline/pipeline_steps.rst
@@ -205,6 +205,6 @@ type of the rerun specifying the logic and changes, and the cluster name.
     more_mesh              workaround      it modifies the remeshing and allows for more cells in MESA
     conv_bdy_weight        caution         it disabled the convective_bdy_weight where this caused segmentation faults (this avoids a bug in the old MESA version r11701)
     dedt_energy_eqn        caution         it enables MESA's dedt-form of the energy equation for numerical stability during rapid (superthermal) mass transfer
-    dedt_hepulse           caution         it enables MESA's dedt-form of the energy equation for rapid mass transfer. Several MLT++ changes, v_flag and lnPgas_flag set to .true., and convecitve_bdy_weight disabled to help with stripped He star pulsations and WD cooling. 
+    dedt_hepulse           caution         it enables MESA's dedt-form of the energy equation for rapid mass transfer. Several MLT++ changes, v_flag and lnPgas_flag set to .true., and convecitve_bdy_weight disabled to help with stripped He star superadiabatic envelopes, pulsations, and WD cooling. 
     =====================  ==============  ===========
 

--- a/docs/_source/components-overview/post_processing/pipeline/pipeline_steps.rst
+++ b/docs/_source/components-overview/post_processing/pipeline/pipeline_steps.rst
@@ -204,6 +204,7 @@ type of the rerun specifying the logic and changes, and the cluster name.
     HeMB_MLTp_mesh         workaround      it turns off magnetic braking for He stars; it uses less extreme parameters of the MLT++; it changes some more input values to change the resulation close to the surface
     more_mesh              workaround      it modifies the remeshing and allows for more cells in MESA
     conv_bdy_weight        caution         it disabled the convective_bdy_weight where this caused segmentation faults (this avoids a bug in the old MESA version r11701)
+    dedt_energy_eqn        caution         it enables MESA's dedt-form of the energy equation for numerical stability during rapid (superthermal) mass transfer
     dedt_hepulse           caution         it enables MESA's dedt-form of the energy equation for rapid mass transfer. Several MLT++ changes, v_flag and lnPgas_flag set to .true., and convecitve_bdy_weight disabled to help with stripped He star pulsations and WD cooling. 
     =====================  ==============  ===========
 

--- a/docs/_source/components-overview/post_processing/pipeline/pipeline_steps.rst
+++ b/docs/_source/components-overview/post_processing/pipeline/pipeline_steps.rst
@@ -204,7 +204,6 @@ type of the rerun specifying the logic and changes, and the cluster name.
     HeMB_MLTp_mesh         workaround      it turns off magnetic braking for He stars; it uses less extreme parameters of the MLT++; it changes some more input values to change the resulation close to the surface
     more_mesh              workaround      it modifies the remeshing and allows for more cells in MESA
     conv_bdy_weight        caution         it disabled the convective_bdy_weight where this caused segmentation faults (this avoids a bug in the old MESA version r11701)
-    dedt_energy_eqn        caution         it enables MESA's dedt-form of the energy equation for numerical stability during superthermal mass transfer
-    dedt_hepulse           caution         it enables MESA's dedt-form of the energy equation. Several MLT++ changes, v_flag and lnPgas_flag set to .true., and convecitve_bdy_weight disabled to help with stripped He star pulsations and WD cooling. 
+    dedt_hepulse           caution         it enables MESA's dedt-form of the energy equation for rapid mass transfer. Several MLT++ changes, v_flag and lnPgas_flag set to .true., and convecitve_bdy_weight disabled to help with stripped He star pulsations and WD cooling. 
     =====================  ==============  ===========
 

--- a/docs/_source/components-overview/post_processing/pipeline/pipeline_steps.rst
+++ b/docs/_source/components-overview/post_processing/pipeline/pipeline_steps.rst
@@ -205,6 +205,6 @@ type of the rerun specifying the logic and changes, and the cluster name.
     more_mesh              workaround      it modifies the remeshing and allows for more cells in MESA
     conv_bdy_weight        caution         it disabled the convective_bdy_weight where this caused segmentation faults (this avoids a bug in the old MESA version r11701)
     dedt_energy_eqn        caution         it enables MESA's dedt-form of the energy equation for numerical stability during rapid (superthermal) mass transfer
-    dedt_hepulse           caution         it enables MESA's dedt-form of the energy equation for rapid mass transfer. Several MLT++ changes, v_flag and lnPgas_flag set to .true., and convecitve_bdy_weight disabled to help with stripped He star superadiabatic envelopes, pulsations, and WD cooling. 
+    dedt_hepulse           caution         it enables MESA's dedt-form of the energy equation for rapid mass transfer. At stripped HeZAMS, several MLT++ changes, v_flag and lnPgas_flag set to .true., and convective_bdy_weight disabled to help with stripped He star superadiabatic envelopes, pulsations, and WD cooling. 
     =====================  ==============  ===========
 

--- a/docs/_source/components-overview/post_processing/pipeline/pipeline_steps.rst
+++ b/docs/_source/components-overview/post_processing/pipeline/pipeline_steps.rst
@@ -205,6 +205,6 @@ type of the rerun specifying the logic and changes, and the cluster name.
     more_mesh              workaround      it modifies the remeshing and allows for more cells in MESA
     conv_bdy_weight        caution         it disabled the convective_bdy_weight where this caused segmentation faults (this avoids a bug in the old MESA version r11701)
     dedt_energy_eqn        caution         it enables MESA's dedt-form of the energy equation for numerical stability during superthermal mass transfer
-    dedt_force_mltpp       caution         it enables MESA's dedt-form of the energy equation and near TAHeMS sets MLT++ to default value, but forced everywhere (no Pgas/P, Ledd/L limit) to help stripped He star pulsations 
+    dedt_force_mltpp       caution         it enables MESA's dedt-form of the energy equation and near TAHeMS sets lnPgas_flag = .true., MLT++ back to its default value, and forces it everywhere (no Pgas/P, Ledd/L limit) to help stripped He star pulsations. 
     =====================  ==============  ===========
 


### PR DESCRIPTION
This rerun type is meant to address issues especially associated with stripped He stars that pulsate after core exhaustion. In particular it will impact

- CO-HeMS grid
- Remaining crashed models especially at moderate mass ratios where stripped He stars occur

This is an extension of [PR#275](https://github.com/POSYDON-code/POSYDON/pull/275). Changes introduced in this PR compared to that one are indicated by "🚩" below.

## General changes (rapid mass transfer and memory allocation errors)

The following included reruns have these general changes:

- `dedt_energy_eqn` (updated from [PR#275](https://github.com/POSYDON-code/POSYDON/pull/275))
- `dedt_hepulse` 🚩

1. Enables MESA's `dedt`-form of its energy equation for rapid mass transfer cases.
2.  `lnPgas_flag` is also set to `.true.` at model 1, helping convergence further. 🚩

In addition, when a star's `center_gamma` (Coulomb coupling parameter, i.e., ratio of Coulomb energy to thermal energy) reaches a value greater than 1, approx. when the model is forming a degenerate core:

3. Set `convective_bdy_weight = 0` to avoid seg. faults & memory alloc. errors, especially on the WD cooling track. 🚩

Lastly, 

4. Go back to the default `w_div_w_crit_lim = 0.99` and `w_div_w_crit_tol = 0.05`. 🚩

At some point we switched to `w_div_w_crit_lim = 0.95` and `w_div_w_crit_tol = 0.1` during reruns. Some rapidly rotating models find spuriously large mass transfer rates with these values though, and going back to the defaults avoids this.

## Changes for stripped He stars (superadiabaticity and pulsations)

The following included reruns have these changes:
- `dedt_hepulse` 🚩

These changes are only ever enabled if `x_logical_ctrl(7) = .true.` in `inlist1` or `inlist2` for the respective models. These changes are especially relevant to the CO-HeMS and stripped He stars on the HMS-HMS grids.

When a star becomes a stripped He star at HeZAMS (defined in code as when the surface H envelope drops below 5% of the total stellar mass and He nuclear burning is an order of magnitude greater than H nuclear burning power):

1. Forces MLT++ to operate regardless of Pgas/P, Ledd/L limits (throughout the star) w/ `gradT_excess_lambda1 = -1`. 🚩
2. Goes back to the default strength of MLT++ (`gradT_excess_f2 = 1d-3`).  🚩
3. Turns on `v_flag` to enable calculation of cell velocities within star, helping resolve He star pulsations. 🚩

These three changes are only allowed if the star is not undergoing RLOF. This is to avoid anomalous structural behavior due to the sudden changes during mass transfer. If stripping happens during RLOF, we skip these changes.

[MESA src changes are here](https://github.com/POSYDON-code/POSYDON-MESA-INLISTS/tree/seth_dedt_hepulse)

[Google drive test rerun results (will be updated as runs complete)](https://drive.google.com/drive/folders/1JNgm5iuTV7RTRX-lix_FICbtl3skhLwz?usp=drive_link)
