### PR TITLE
Add correction for eccentric pre SN orbits for SNflag2

### DIFF
--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -1723,8 +1723,13 @@ class StepSN(object):
 
                 # SNflag2: Equations 22-23, Willems, B., Henninger, M., Levin, T., et al. 2005, ApJ, 625, 324
                 # (see, e.g., Kalogera, V. & Lorimer, D.R. 2000, ApJ, 530, 890)
-                tmp1 = 2 - Mtot_pre / Mtot_post * (Vkick / Vr - 1) ** 2
-                tmp2 = 2 - Mtot_pre / Mtot_post * (Vkick / Vr + 1) ** 2
+                # The derivation in the papers above assume a circular pre SN
+                # orbit. Hence, need a correction for eccentric pre SN orbits:
+                eccentirc_orbit_correction = Vr**2 * rpre / (G * Mtot_pre)
+                tmp1 = 2 - Mtot_pre / Mtot_post * (Vkick / Vr - 1) ** 2\
+                           * eccentirc_orbit_correction
+                tmp2 = 2 - Mtot_pre / Mtot_post * (Vkick / Vr + 1) ** 2\
+                           * eccentirc_orbit_correction
                 SNflag2 = ((rpre / Apost - tmp1 < err)
                            and (err > tmp2 - rpre / Apost))
 

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -1725,11 +1725,11 @@ class StepSN(object):
                 # (see, e.g., Kalogera, V. & Lorimer, D.R. 2000, ApJ, 530, 890)
                 # The derivation in the papers above assume a circular pre SN
                 # orbit. Hence, need a correction for eccentric pre SN orbits:
-                eccentirc_orbit_correction = Vr**2 * rpre / (G * Mtot_pre)
+                eccentric_orbit_correction = Vr**2 * rpre / (G * Mtot_pre)
                 tmp1 = 2 - Mtot_pre / Mtot_post * (Vkick / Vr - 1) ** 2\
-                           * eccentirc_orbit_correction
+                           * eccentric_orbit_correction
                 tmp2 = 2 - Mtot_pre / Mtot_post * (Vkick / Vr + 1) ** 2\
-                           * eccentirc_orbit_correction
+                           * eccentric_orbit_correction
                 SNflag2 = ((rpre / Apost - tmp1 < err)
                            and (err > tmp2 - rpre / Apost))
 


### PR DESCRIPTION
It turned out, that the derivation of SNflag2 assumed a circular pre supernova orbit to simplify the equation.
We use this flag to determine, whether a post SN orbit is bound or disrupted. Hence, we classified too many eccentric pre SN cases as disrupted in the SN.
In a circular pre SN orbit, the correction factor would be 1, because it becomes Kepler's third law.

P.S.: I encountered the issue by making a check with 0 kick, where the two inequalities of the SNflag would become equal, hence no kick could hide the missing factor anymore. Maybe this would not mean that we had to many disrupted systems overall, but the kick range leading to disruptions was shifted surely.