### PR TITLE
Further change to make MESA's and POSYDON's RLO detection the same

### DIFF
--- a/posydon/grids/termination_flags.py
+++ b/posydon/grids/termination_flags.py
@@ -131,8 +131,8 @@ def get_mass_transfer_flag(binary_history, history1, history2,
         return "contact_during_MS"
 
     where_transfer = rate > LG_MTRANSFER_RATE_THRESHOLD
-    where_rlof_1 = where_rl_rel_1 & where_transfer
-    where_rlof_2 = where_rl_rel_2 & where_transfer
+    where_rlof_1 = where_rl_rel_1 | where_transfer
+    where_rlof_2 = where_rl_rel_2 | where_transfer
 
     if not np.any(where_rlof_1) and not np.any(where_rlof_2):
         return "no_RLOF"


### PR DESCRIPTION
The reason come from the recent repost-processing of the grids, see [slack](https://posydon.slack.com/archives/C04K8DQ4EMU/p1716634325558919).

Change `and` to `or` for the two RLO conditions: the mass-transfer rate and the Roche lobe-filling factor.