### PR TITLE
Suport ZAMS binaries with initial eccentricity

### DIFF
--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -1660,8 +1660,6 @@ class CO_HeMS_step(MesaGridStep):
             return
 
 
-
-
 class HMS_HMS_RLO_step(MesaGridStep):
     """Class for performing the MESA step for a HMS-HMS RLO binary.
     For binaries with an initial eccentricity at ZAMS,

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -1658,3 +1658,163 @@ class CO_HeMS_step(MesaGridStep):
             self.binary.state = 'detached'
             self.binary.event = 'redirect_from_CO_HeMS'
             return
+
+
+
+
+class HMS_HMS_RLO_step(MesaGridStep):
+    """Class for performing the MESA step for a HMS-HMS RLO binary.
+    For binaries with an initial eccentricity at ZAMS,
+    we evolve them first with step detached and map to the HMS-HMS RLO grid
+    using `initial_eccentricity_flow_chart`."""
+
+    def __init__(self, metallicity=1., grid_name=None, *args, **kwargs):
+        """Initialize a HMS_HMS_RLO_step instance."""
+        self.grid_type = 'HMS_HMS_RLO'
+        self.interp_in_q = False
+        if grid_name is None:
+            metallicity = convert_metallicity_to_string(metallicity)
+            grid_name = 'HMS-HMS_RLO/' + metallicity + '_Zsun.h5'
+        super().__init__(metallicity=metallicity,
+                         grid_name=grid_name,
+                         *args, **kwargs)
+        # special stuff for my step goes here
+        # If nothing to do, no init necessary
+
+        # load grid boundaries
+        m1_initial_values = self._psyTrackInterp.grid.initial_values['star_1_mass']
+        m2_initial_values = self._psyTrackInterp.grid.initial_values['star_2_mass']
+        self.m1_min = np.min(m1_initial_values)
+        self.m1_max = np.max(m1_initial_values)
+        self.m2_min = np.min(m2_initial_values)
+        self.m2_max = np.max(m2_initial_values)
+        self.p_min = np.min(self._psyTrackInterp.grid.initial_values['period_days'])
+        self.p_max = np.max(self._psyTrackInterp.grid.initial_values['period_days'])
+        self.q_min = np.min(m2_initial_values/m1_initial_values)
+        self.q_max = np.max(m2_initial_values/m1_initial_values)
+        self.minimum_star_mass = self.m2_min
+
+    def __call__(self, binary):
+        """Evolve a binary using the MESA step."""
+        # grid set up assume no star is CO
+        self.star_1_CO = False
+        self.star_2_CO = False
+        # check binary is ready before calling the step
+        self.binary = binary
+        event = binary.event
+        state = binary.state
+        state_1 = binary.star_1.state
+        state_2 = binary.star_2.state
+        m1 = binary.star_1.mass
+        m2 = binary.star_2.mass
+        p = binary.orbital_period
+        ecc = binary.eccentricity
+        mass_ratio = m2/m1
+
+        # TODO: import states from flow_chart.py
+        FOR_RLO_STATES = ["H-rich_Core_H_burning",
+                          "H-rich_Shell_H_burning",
+                          "H-rich_Core_He_burning",
+                          "H-rich_Central_He_depleted",
+                          "H-rich_Core_C_burning",
+                          "stripped_He_Core_H_burning",
+                          "H-rich_Central_C_depletion",  # filtered out below
+                          "H-rich_non_burning"]
+
+        # check the star states
+        # TODO: import states from flow_chart.py
+        if (state_2 in FOR_RLO_STATES and (state_1 in FOR_RLO_STATES) 
+                and event == "oRLO1"):
+            self.flip_stars_before_step = False
+            # catch and redirect double core collapse, this happens if q=1:
+            if state_1 == 'H-rich_Central_C_depletion':
+                self.binary.event = 'CC1'
+                return
+        # TODO: import states from flow_chart.py
+        elif (state_1 in FOR_RLO_STATES and (state_2 in FOR_RLO_STATES)
+                and event == "oRLO2"):
+            self.flip_stars_before_step = True
+            # catch and redirect double core collapse, this happens if q=1:
+            if state_2 == 'H-rich_Central_C_depletion':
+                self.binary.event = 'CC2'
+                return
+        else:
+            set_binary_to_failed(self.binary)
+            raise FlowError(
+                'The star_1.state = %s, star_2.state = %s, binary.state = %s, '
+                'binary.event = %s and not HMS - HMS - oRLO1/oRLO2!'
+                % (state_1, state_2, state, event))
+        # redirect if outside grids
+        # HMS-HMS grid is sampled in q so check explicity vs m1 and m2
+        if ((not self.flip_stars_before_step and
+            self.m1_min <= m1 <= self.m1_max and            
+            np.max([self.q_min, self.minimum_star_mass/m1]) <= mass_ratio <= self.q_max and
+            self.p_min <= p <= self.p_max and
+            ecc == 0.) or (self.flip_stars_before_step and
+            self.m1_min <= m2 <= self.m1_max and
+            np.max([self.q_min, self.minimum_star_mass/m2]) <= 1/mass_ratio <= self.q_max and
+            self.p_min <= p <= self.p_max and
+            ecc == 0.)):
+            super().__call__(self.binary)
+
+        # period inside the grid, but m1 outside the grid
+        elif ((not self.flip_stars_before_step and
+               self.p_min <= p <= self.p_max and
+               (m1 < self.m1_min or m1 > self.m1_max))):
+            set_binary_to_failed(self.binary)
+            raise GridError(f'The mass of m1 ({m1}) is outside the grid,'
+                                ' while the period is inside the grid.')
+
+        # period inside the grid, but m2 outside the grid
+        elif ((not self.flip_stars_before_step and
+               self.p_min <= p <= self.p_max and
+               (m2 < self.m2_min or m2 > self.m2_max))):
+            set_binary_to_failed(self.binary)
+            raise GridError(f'The mass of m2 ({m2}) is outside the grid,'
+                                ' while the period is inside the grid.')
+
+        # period inside the grid, but q outside the grid
+        elif (not self.flip_stars_before_step and
+               self.p_min <= p <= self.p_max and
+               np.max([self.q_min, self.minimum_star_mass/m1]) <= mass_ratio <= self.q_max ):
+            set_binary_to_failed(self.binary)
+            raise GridError(f'The mass ratio ({mass_ratio}) is outside the grid,'
+                                ' while the period is inside the grid.')
+
+        
+        # period inside the grid, but m2 outside the grid
+        elif ((not self.flip_stars_before_step and
+               self.p_min <= p <= self.p_max and
+               (m2 < self.m2_min or m2 > self.m2_max))):
+            set_binary_to_failed(self.binary)
+            raise GridError(f'The mass of m2 ({m2}) is outside the grid,'
+                                ' while the period is inside the grid.')
+
+
+        # period inside the grid, but m1 outside the grid (flipped stars)
+        elif ((self.flip_stars_before_step and
+                self.p_min <= p <= self.p_max and
+                (m2 < self.m1_min or m2 > self.m1_max))):
+            set_binary_to_failed(self.binary)
+            raise GridError(f'The mass of m1 ({m2}) is outside the grid,'
+                                ' while the period is inside the grid.')
+        
+        # period inside the grid, but m2 outside the grid (flipped stars)
+        elif ((self.flip_stars_before_step and
+                self.p_min <= p <= self.p_max and
+                (m1 < self.m2_min or m1 > self.m2_max))):
+            set_binary_to_failed(self.binary)
+            raise GridError(f'The mass of m2 ({m1}) is outside the grid,'
+                            ' while the period is inside the grid.')
+        
+        # period inside the grid, but q outside the grid (flipped stars)
+        elif (self.flip_stars_before_step and
+               self.p_min <= p <= self.p_max and
+               np.max([self.q_min, self.minimum_star_mass/m2]) <= 1/mass_ratio <= self.q_max ):
+            set_binary_to_failed(self.binary)
+            raise GridError(f'The mass ratio ({1/mass_ratio}) is outside the grid,'
+                                ' while the period is inside the grid.')
+        else:
+            self.binary.state = "detached"
+            self.binary.event = "redirect_from_HMS_HMS_RLO"
+            return

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -1669,7 +1669,7 @@ class HMS_HMS_RLO_step(MesaGridStep):
     def __init__(self, metallicity=1., grid_name=None, *args, **kwargs):
         """Initialize a HMS_HMS_RLO_step instance."""
         self.grid_type = 'HMS_HMS_RLO'
-        self.interp_in_q = False
+        self.interp_in_q = True
         if grid_name is None:
             metallicity = convert_metallicity_to_string(metallicity)
             grid_name = 'HMS-HMS_RLO/' + metallicity + '_Zsun.h5'

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -1781,15 +1781,6 @@ class HMS_HMS_RLO_step(MesaGridStep):
             raise GridError(f'The mass ratio ({mass_ratio}) is outside the grid,'
                                 ' while the period is inside the grid.')
 
-        
-        # period inside the grid, but m2 outside the grid
-        elif ((not self.flip_stars_before_step and
-               self.p_min <= p <= self.p_max and
-               (m2 < self.m2_min or m2 > self.m2_max))):
-            set_binary_to_failed(self.binary)
-            raise GridError(f'The mass of m2 ({m2}) is outside the grid,'
-                                ' while the period is inside the grid.')
-
 
         # period inside the grid, but m1 outside the grid (flipped stars)
         elif ((self.flip_stars_before_step and

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -1774,7 +1774,7 @@ class HMS_HMS_RLO_step(MesaGridStep):
         # period inside the grid, but q outside the grid
         elif (not self.flip_stars_before_step and
                self.p_min <= p <= self.p_max and
-               np.max([self.q_min, self.minimum_star_mass/m1]) <= mass_ratio <= self.q_max ):
+               (np.max([self.q_min, self.minimum_star_mass/m1]) > mass_ratio or mass_ratio > self.q_max) ):
             set_binary_to_failed(self.binary)
             raise GridError(f'The mass ratio ({mass_ratio}) is outside the grid,'
                                 ' while the period is inside the grid.')
@@ -1799,7 +1799,7 @@ class HMS_HMS_RLO_step(MesaGridStep):
         # period inside the grid, but q outside the grid (flipped stars)
         elif (self.flip_stars_before_step and
                self.p_min <= p <= self.p_max and
-               np.max([self.q_min, self.minimum_star_mass/m2]) <= 1/mass_ratio <= self.q_max ):
+               (np.max([self.q_min, self.minimum_star_mass/m2]) > 1/mass_ratio or 1/mass_ratio > self.q_max) ):
             set_binary_to_failed(self.binary)
             raise GridError(f'The mass ratio ({1/mass_ratio}) is outside the grid,'
                                 ' while the period is inside the grid.')

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -1692,7 +1692,7 @@ class HMS_HMS_RLO_step(MesaGridStep):
         self.p_max = np.max(self._psyTrackInterp.grid.initial_values['period_days'])
         self.q_min = np.min(m2_initial_values/m1_initial_values)
         self.q_max = np.max(m2_initial_values/m1_initial_values)
-        self.minimum_star_mass = self.m2_min
+        self.minimum_star_mass = self.m2_min # 0.5 (M_sun)
 
     def __call__(self, binary):
         """Evolve a binary using the MESA step."""
@@ -1733,7 +1733,7 @@ class HMS_HMS_RLO_step(MesaGridStep):
         # TODO: import states from flow_chart.py
         elif (state_1 in FOR_RLO_STATES and (state_2 in FOR_RLO_STATES)
                 and event == "oRLO2"):
-            self.flip_stars_before_step = True
+            self.flip_stars_before_step = False
             # catch and redirect double core collapse, this happens if q=1:
             if state_2 == 'H-rich_Central_C_depletion':
                 self.binary.event = 'CC2'

--- a/posydon/binary_evol/flow_chart.py
+++ b/posydon/binary_evol/flow_chart.py
@@ -339,3 +339,49 @@ def flow_chart(FLOW_CHART=POSYDON_FLOW_CHART, CHANGE_FLOW_CHART=None):
                 FLOW_CHART[key] = CHANGE_FLOW_CHART[key]
 
     return FLOW_CHART
+
+def initial_eccentricity_flow_chart(FLOW_CHART=None, CHANGE_FLOW_CHART=None):
+    """Modify POSYDON's default one and modify it.
+
+    Parameters
+    ----------
+    FLOW_CHART : dict or None
+    CHANGE_FLOW_CHART : dict or None
+
+    Returns
+    -------
+    dict
+        Modified flow chart.
+    """
+
+    # get POSYDON's default flow chart
+    if FLOW_CHART is None:
+        if CHANGE_FLOW_CHART is None:
+            MY_FLOW_CHART = fc.flow_chart()
+        else:
+            MY_FLOW_CHART = fc.flow_chart(CHANGE_FLOW_CHART=CHANGE_FLOW_CHART)
+    else:
+        if CHANGE_FLOW_CHART is None:
+            MY_FLOW_CHART = fc.flow_chart(FLOW_CHART=FLOW_CHART)
+        else:
+            MY_FLOW_CHART = fc.flow_chart(FLOW_CHART=FLOW_CHART,
+                                          CHANGE_FLOW_CHART=CHANGE_FLOW_CHART)
+    # modify the flow chart
+    for key in MY_FLOW_CHART.keys():
+        # here changing to go always from ZAMS to step_detached
+        if ((len(key)>3) and (key[3]=='ZAMS') and
+            (key[2] in fc.BINARY_STATES_ZAMS)): # check for event
+            MY_FLOW_CHART[key] = 'step_detached'
+        # here changing all starting RLO to end instead
+        if ((len(key)>2) and ('RLO' in key[2])): # check for state
+            MY_FLOW_CHART[key] = 'step_end'
+    # adding new entries to the flow to send RLO to end which would otherwise
+    # be jumped over in the HMS-HMS step
+    for s1 in STAR_STATES_NORMALSTAR:
+        for s2 in STAR_STATES_NORMALSTAR:
+            MY_FLOW_CHART[(s1, s2, 'RLO1', 'oRLO1')] = 'step_end'
+            MY_FLOW_CHART[(s2, s1, 'RLO1', 'oRLO1')] = 'step_end'
+            MY_FLOW_CHART[(s1, s2, 'RLO2', 'oRLO2')] = 'step_end'
+            MY_FLOW_CHART[(s2, s1, 'RLO2', 'oRLO2')] = 'step_end'
+
+    return MY_FLOW_CHART

--- a/posydon/binary_evol/flow_chart.py
+++ b/posydon/binary_evol/flow_chart.py
@@ -381,15 +381,10 @@ def initial_eccentricity_flow_chart(FLOW_CHART=None, CHANGE_FLOW_CHART=None):
             MY_FLOW_CHART[key] = 'step_detached'
 
     # Add two stars initating RLO (now coming from detached) into flow chart
-    for _s1 in STAR_STATES_H_RICH_EVOLVABLE:
-        for _s2 in STAR_STATES_H_RICH_EVOLVABLE:
-            MY_FLOW_CHART[(_s1, _s2, 'RLO1', 'oRLO1')] = 'step_HMS_HMS_RLO'
-            MY_FLOW_CHART[(_s1, _s2, 'RLO2', 'oRLO2')] = 'step_HMS_HMS_RLO'
-    
     # Add stripped stars (from winds) initating RLO
-    for _s1 in STAR_STATES_HE_RICH_EVOLVABLE:
-        for _s2 in STAR_STATES_HE_RICH_EVOLVABLE:
-            MY_FLOW_CHART[(_s1, _s2, 'RLO1', 'oRLO1')] = 'step_HMS_HMS_RLO'
-            MY_FLOW_CHART[(_s1, _s2, 'RLO2', 'oRLO2')] = 'step_HMS_HMS_RLO'
-
+    for s1 in STAR_STATES_H_RICH_EVOLVABLE + STAR_STATES_HE_RICH_EVOLVABLE:
+        for s2 in STAR_STATES_H_RICH_EVOLVABLE + STAR_STATES_HE_RICH_EVOLVABLE:
+            MY_FLOW_CHART[(s1, s2, 'RLO1', 'oRLO1')] = 'step_HMS_HMS_RLO'
+            MY_FLOW_CHART[(s1, s2, 'RLO2', 'oRLO2')] = 'step_HMS_HMS_RLO'
+    
     return MY_FLOW_CHART

--- a/posydon/user_modules/my_flow_chart_example.py
+++ b/posydon/user_modules/my_flow_chart_example.py
@@ -1,0 +1,55 @@
+"""An example of a modified function of the flow chart."""
+
+
+__authors__ = [
+    "Matthias Kruckow <Matthias.Kruckow@unige.ch>",
+]
+
+import posydon.binary_evol.flow_chart as fc
+from posydon.binary_evol.flow_chart import (flow_chart, STAR_STATES_NORMALSTAR)
+
+def modified_flow_chart(FLOW_CHART=None, CHANGE_FLOW_CHART=None):
+    """Derive a flow chart from POSYDON's standard one and modify it.
+
+    Parameters
+    ----------
+    FLOW_CHART : dict or None
+    CHANGE_FLOW_CHART : dict or None
+
+    Returns
+    -------
+    dict
+        Modified flow chart.
+    """
+
+    # get POSYDON's default flow chart
+    if FLOW_CHART is None:
+        if CHANGE_FLOW_CHART is None:
+            MY_FLOW_CHART = fc.flow_chart()
+        else:
+            MY_FLOW_CHART = fc.flow_chart(CHANGE_FLOW_CHART=CHANGE_FLOW_CHART)
+    else:
+        if CHANGE_FLOW_CHART is None:
+            MY_FLOW_CHART = fc.flow_chart(FLOW_CHART=FLOW_CHART)
+        else:
+            MY_FLOW_CHART = fc.flow_chart(FLOW_CHART=FLOW_CHART,
+                                          CHANGE_FLOW_CHART=CHANGE_FLOW_CHART)
+    # modify the flow chart
+    for key in MY_FLOW_CHART.keys():
+        # here changing to go always from ZAMS to step_detached
+        if ((len(key)>3) and (key[3]=='ZAMS') and
+            (key[2] in fc.BINARY_STATES_ZAMS)): # check for event
+            MY_FLOW_CHART[key] = 'step_detached'
+        # here changing all starting RLO to end instead
+        if ((len(key)>2) and ('RLO' in key[2])): # check for state
+            MY_FLOW_CHART[key] = 'step_end'
+    # adding new entries to the flow to send RLO to end which would otherwise
+    # be jumped over in the HMS-HMS step
+    for s1 in STAR_STATES_NORMALSTAR:
+        for s2 in STAR_STATES_NORMALSTAR:
+            MY_FLOW_CHART[(s1, s2, 'RLO1', 'oRLO1')] = 'step_end'
+            MY_FLOW_CHART[(s2, s1, 'RLO1', 'oRLO1')] = 'step_end'
+            MY_FLOW_CHART[(s1, s2, 'RLO2', 'oRLO2')] = 'step_end'
+            MY_FLOW_CHART[(s2, s1, 'RLO2', 'oRLO2')] = 'step_end'
+
+    return MY_FLOW_CHART


### PR DESCRIPTION
Currently ZAMS binaries are born with $e=0$. In order to allow for $e\neq0$ (for eccentric MT in the future 👀 😎) we need to adjust the flow and introduce a new step `HMS_HMS_RLO_step` which will allow binaries to be initially evolved in detached step but then mapped to the HMS mesa grid as in the `CO_HMS` and `CO_HeMS` steps. (Made with @mkruckow, @ZepeiX)

Here is an example of some code which runs this new setup. (Along with the RLO post-processed HMS-HMS grid in the POSYDON_data folder)
```python
from posydon.popsyn.binarypopulation import BinaryPopulation
from posydon.popsyn.io import binarypop_kwargs_from_ini

from posydon.binary_evol.flow_chart import flow_chart, initial_eccentricity_flow_chart
from posydon.binary_evol.MESA.step_mesa import HMS_HMS_RLO_step
from pprint import pprint

bpkw = binarypop_kwargs_from_ini('/projects/b1119/karocha/software/fork/POSYDON-public/posydon/popsyn/population_params_default.ini')

# New flow chart
bpkw['population_properties'].kwargs['flow'] = (initial_eccentricity_flow_chart, {})

# replace step_HMS_HMS with step_HMS_HMS_RLO
default_HMS_HMS_kwargs = bpkw['population_properties'].kwargs['step_HMS_HMS'][-1]
bpkw['population_properties'].kwargs['step_HMS_HMS_RLO'] = ( HMS_HMS_RLO_step, default_HMS_HMS_kwargs )
bpkw['population_properties'].kwargs['verbose'] = True
bpkw['population_properties'].kwargs.pop('step_HMS_HMS') # remove

# Add initial eccentricity
from posydon.binary_evol.simulationproperties import EvolveHooks
class AddInitialEccentricity( EvolveHooks ):
    def pre_evolve(self, binary):
        binary.eccentricity = np.random.uniform(0,1)
        binary.eccentricity_history[0] = binary.eccentricity
        return binary
bpkw['population_properties'].kwargs['extra_hooks'].append( (EvolveHooks, {}) )
bpkw['population_properties'].kwargs['extra_hooks'].append( (AddInitialEccentricity, {}) )
bpkw['population_properties'].all_hooks_classes = [cls(**kwargs) for (cls, kwargs) in bpkw['population_properties'].kwargs['extra_hooks']]

bpkw['number_of_binaries'] = 5_000
bpkw['metallicity'] = 1

binary_pop = BinaryPopulation(**bpkw)
binary_pop.evolve()
```
And the output from the population: black x's are initial_RLO after step_detached into step_HMS_HMS_RLO, blue are ZAMS, and purple show post step_HMS_HMS_RLO which have been circularized.
<img width="987" alt="Screen Shot 2024-06-22 at 11 26 06 AM" src="https://github.com/POSYDON-code/POSYDON/assets/48293898/692dabe0-d2b3-45a6-a264-0d4176c37633">
