### PR TITLE
Replace scipy.integrate.simps call with scipy.integrate.simpson call

### DIFF
--- a/posydon/binary_evol/SN/profile_collapse.py
+++ b/posydon/binary_evol/SN/profile_collapse.py
@@ -175,7 +175,7 @@ def get_initial_BH_properties(star, mass_collapsing, mass_central_BH,
     f_temp2 = (f_nu_AM*density[:index_initial_BH+1]
                * angular_frequency[:index_initial_BH+1]
                * radius[:index_initial_BH+1]**4)
-    temp2 = integrate.simps(f_temp2, x=radius[:index_initial_BH + 1])
+    temp2 = integrate.simpson(f_temp2, x=radius[:index_initial_BH + 1])
 
     J_initial_BH = 2 * np.pi * temp1 * temp2
 


### PR DESCRIPTION
Replaces the `simps` function call with `simpson`.
This is the only call to this function.

This call has been deprecated in scipy 1.14.0.

No additional version limit is required than our current 1.10.1, since `simpson` is already present in 1.7.0 of scipy.