### PR TITLE
Another place where we need to adjust the RLO condition

### DIFF
--- a/posydon/grids/scrubbing.py
+++ b/posydon/grids/scrubbing.py
@@ -122,9 +122,8 @@ def keep_after_RLO(bh, h1, h2):
     if rlo_1_or_2 is None:
         raise ValueError("No `rl_relative_overflow` in any star history.")
 
-    # This needs to be aligned with run_binary_extras.f, there it is less
-    # restrictive, which is fine
-    conditions_met = rlo_1_or_2 & rate
+    # This needs to be aligned with run_binary_extras.f
+    conditions_met = rlo_1_or_2 | rate
     where_conditions_met = np.where(conditions_met)[0]
 
     if len(where_conditions_met) == 0:


### PR DESCRIPTION
In addition to PR #334 :
We need to adjust the RLO condition in scrubbing.py, because this is used to detect RLO for the grids starting at RLO instead of the other functions, which were already adjusted in the previous PR.

I hope that's the last place in the code. It's bad, that we have code for the same kind of check at so many different places in the code.

A test on CO-HMS gird looked as expected.