### PR TITLE
replace np.NaN and np.NAN by np.nan

### DIFF
--- a/bin/posydon-setup-pipeline
+++ b/bin/posydon-setup-pipeline
@@ -1231,12 +1231,12 @@ def create_csv(GRID_TYPES=[],
                     print(f'In {column} the following grids are skipped!')
                     for row in drop_rows:
                         print(df.at[row,column])
-                        df.at[row,column] = np.NaN
+                        df.at[row,column] = np.nan
                     print('')
                     newcol = df[column].dropna().to_list()
                     if len(newcol)==0:
                         drop_columns.append(column)
-                    newcol.extend((df.shape[0]-len(newcol))*[np.NaN])
+                    newcol.extend((df.shape[0]-len(newcol))*[np.nan])
                     df[column] = newcol
             # report about empty tasks and remove them
             if len(drop_columns)>0:

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -334,7 +334,7 @@ class BinaryStar:
             Can be used in combination with `extra_columns`.
         null_value : float
             Replace all None values with something else (for saving).
-            Default is np.NAN.
+            Default is np.nan.
         include_S1, include_S2 : bool
             Choose to include star 1 or 2 data to the DataFrame.
             The default is to include both.
@@ -389,9 +389,9 @@ class BinaryStar:
                 str(err) + "\n\nAvailable attributes in BinaryStar: \n{}".
                 format(self.__dict__.keys()))
 
-        # Convert None to np.NAN by default
+        # Convert None to np.nan by default
         bin_data = np.array(data_to_save, dtype=object)
-        bin_data[where_none] = kwargs.get('null_value', np.NAN)
+        bin_data[where_none] = kwargs.get('null_value', np.nan)
 
         bin_data = np.transpose(bin_data)
 
@@ -420,11 +420,11 @@ class BinaryStar:
         if kwargs.get('include_S1', True):
             # we are hard coding the prefix
             frames.append(self.star_1.to_df(
-                prefix='S1_', null_value=kwargs.get('null_value', np.NAN),
+                prefix='S1_', null_value=kwargs.get('null_value', np.nan),
                 **kwargs.get('S1_kwargs', {})))
         if kwargs.get('include_S2', True):
             frames.append(self.star_2.to_df(
-                prefix='S2_', null_value=kwargs.get('null_value', np.NAN),
+                prefix='S2_', null_value=kwargs.get('null_value', np.nan),
                 **kwargs.get('S2_kwargs', {})))
         binary_df = pd.concat(frames, axis=1)
 

--- a/posydon/binary_evol/singlestar.py
+++ b/posydon/binary_evol/singlestar.py
@@ -234,7 +234,7 @@ class SingleStar:
             Include the star's profile in the dataframe (NOT RECOMMENDED)
         null_value : float, optional
             Replace all None values with something else (for saving).
-            Default is np.NAN.
+            Default is np.nan.
         prefix : str, optional
             Prefix to all column names. (e.g. 'star_1', 'S1')
             Default has no prefix.
@@ -293,8 +293,8 @@ class SingleStar:
 
         # casting into object array keeps things general
         star_data = np.array(data_to_save, dtype=object)
-        # Convert None to np.NAN by default
-        star_data[where_none] = kwargs.get('null_value', np.NAN)
+        # Convert None to np.nan by default
+        star_data[where_none] = kwargs.get('null_value', np.nan)
         # sets rows as time steps, columns as history output
         star_data = np.transpose(star_data)
 


### PR DESCRIPTION
It looks like that the [development version](https://numpy.org/devdocs/reference/constants.html#numpy.nan) of numpy doesn't support the aliases for nan anymore.

Hence, we need to only use `np.nan` in the future.
- [x] replace `np.NaN`
- [x] replace `np.NAN`