### PR TITLE
Fixing a small typo in grids IO module.

### DIFF
--- a/posydon/grids/io.py
+++ b/posydon/grids/io.py
@@ -144,7 +144,7 @@ class RunReader:
             elif file in ["final_star1.mod", "final_star1.mod.gz"]:
                 self.final_star1_path = fullpath
             elif file in ["final_star2.mod", "final_star2.mod.gz"]:
-                self.final_star1_path = fullpath
+                self.final_star2_path = fullpath
             elif file in ["out.txt", "out.txt.gz"] and self.binary:
                 self.out_txt_path = fullpath
             elif ((file in ["out_star1_formation_step0.txt",


### PR DESCRIPTION
Correcting a copy-paste mistake, possibly from the PRs related to `PSyGrid` reading zipped MESA files.

The path of the MESA model (`*.mod`) for *star 2* was stored as if it was *star 1*'s model path. Consequently, the information was lost, and depending on the order of reading the MESA files, substituting the correct path to *star 1*'s model.