### PR TITLE
new rerun types LBV_wind and LBV_wind+*

### DIFF
--- a/bin/posydon-run-pipeline
+++ b/bin/posydon-run-pipeline
@@ -691,15 +691,14 @@ def copy_ini_file(grid_type, rerun_metallicity, rerun_type, destination,
         replace_text = "matthias_LBV_wind-051343856f50dc5518abdf28904d62df4caacaff"
     elif rerun_type == 'LBV_wind+thermohaline_mixing':
         replace_text = "matthias_LBV_wind-051343856f50dc5518abdf28904d62df4caacaff"
-    elif rerun_type == 'LBV_wind+HeMB_MLTp_mesh':
-        raise ValueError(f'Not yet supported rerun type {rerun_type}!')
-        replace_text = "matthias_LBV_wind-051343856f50dc5518abdf28904d62df4caacaff" #TODO: update to new MESA-INLIST branch/commit
+#    elif rerun_type == 'LBV_wind+HeMB_MLTp_mesh':
+#        raise ValueError(f'Not yet supported rerun type {rerun_type}!')
+#        replace_text = "matthias_LBV_wind-051343856f50dc5518abdf28904d62df4caacaff" #TODO: update to new MESA-INLIST branch/commit
     elif rerun_type == 'LBV_wind+dedt_energy_eqn':
-        raise ValueError(f'Not yet supported rerun type {rerun_type}!')
-        replace_text = "matthias_LBV_wind-051343856f50dc5518abdf28904d62df4caacaff" #TODO: update to new MESA-INLIST branch/commit
-    elif rerun_type == 'LBV_wind+dedt_hepulse':
-        raise ValueError(f'Not yet supported rerun type {rerun_type}!')
-        replace_text = "matthias_LBV_wind-051343856f50dc5518abdf28904d62df4caacaff" #TODO: update to new MESA-INLIST branch/commit
+        replace_text = "seth_lbv_thermo_dedt-936f76f82d44b16139ff89e41e5b0f2232fd9b30"
+#    elif rerun_type == 'LBV_wind+dedt_hepulse':
+#        raise ValueError(f'Not yet supported rerun type {rerun_type}!')
+#        replace_text = "matthias_LBV_wind-051343856f50dc5518abdf28904d62df4caacaff" #TODO: update to new MESA-INLIST branch/commit
     elif rerun_type == 'other': # e.g. 'envelope_mass_limit', 'fe_core_infall_limit'
         # this rerun uses the default inlist commit
         return
@@ -823,8 +822,9 @@ def logic_rerun(grid, rerun_type):
           (rerun_type == 'LBV_wind+thermohaline_mixing')):
         termination_flags = TF1_POOL_ERROR
         new_mesa_flag = {'thermohaline_coeff' : 17.5}
-    elif ((rerun_type == 'HeMB_MLTp_mesh') or
-          (rerun_type == 'LBV_wind+HeMB_MLTp_mesh')):
+    elif ((rerun_type == 'HeMB_MLTp_mesh')
+#          or (rerun_type == 'LBV_wind+HeMB_MLTp_mesh')
+         ):
         termination_flags = TF1_POOL_ERROR
     elif rerun_type == 'more_mesh':
         termination_flags = TF1_POOL_ERROR
@@ -872,8 +872,9 @@ def logic_rerun(grid, rerun_type):
     elif ((rerun_type == 'dedt_energy_eqn') or
           (rerun_type == 'LBV_wind+dedt_energy_eqn')):
         termination_flags = TF1_POOL_ERROR    
-    elif ((rerun_type == 'dedt_hepulse') or
-          (rerun_type == 'LBV_wind+dedt_hepulse')):
+    elif ((rerun_type == 'dedt_hepulse')
+#          or (rerun_type == 'LBV_wind+dedt_hepulse')
+         ):
         termination_flags = TF1_POOL_ERROR
     elif rerun_type == 'LBV_wind':
         N_runs = len(grid)

--- a/bin/posydon-run-pipeline
+++ b/bin/posydon-run-pipeline
@@ -688,18 +688,18 @@ def copy_ini_file(grid_type, rerun_metallicity, rerun_type, destination,
     elif rerun_type == "dedt_hepulse":
         replace_text = "seth_dedt_hepulse-0274be9895480cae3aa2a4d14b056a2447d5921b"
     elif rerun_type == 'LBV_wind':
-        replace_text = "matthias_LBV_wind-e7db85fe578587383c335f168e3054c1eaaca895"
+        replace_text = "matthias_LBV_wind-0cebead888f29eb56800516900f5ceb24e523d82"
     elif rerun_type == 'LBV_wind+thermohaline_mixing':
-        replace_text = "matthias_LBV_wind-e7db85fe578587383c335f168e3054c1eaaca895"
+        replace_text = "matthias_LBV_wind-0cebead888f29eb56800516900f5ceb24e523d82"
     elif rerun_type == 'LBV_wind+HeMB_MLTp_mesh':
         raise ValueError(f'Not yet supported rerun type {rerun_type}!')
-        replace_text = "matthias_LBV_wind-e7db85fe578587383c335f168e3054c1eaaca895" #TODO: update to new MESA-INLIST branch/commit
+        replace_text = "matthias_LBV_wind-0cebead888f29eb56800516900f5ceb24e523d82" #TODO: update to new MESA-INLIST branch/commit
     elif rerun_type == 'LBV_wind+dedt_energy_eqn':
         raise ValueError(f'Not yet supported rerun type {rerun_type}!')
-        replace_text = "matthias_LBV_wind-e7db85fe578587383c335f168e3054c1eaaca895" #TODO: update to new MESA-INLIST branch/commit
+        replace_text = "matthias_LBV_wind-0cebead888f29eb56800516900f5ceb24e523d82" #TODO: update to new MESA-INLIST branch/commit
     elif rerun_type == 'LBV_wind+dedt_hepulse':
         raise ValueError(f'Not yet supported rerun type {rerun_type}!')
-        replace_text = "matthias_LBV_wind-e7db85fe578587383c335f168e3054c1eaaca895" #TODO: update to new MESA-INLIST branch/commit
+        replace_text = "matthias_LBV_wind-0cebead888f29eb56800516900f5ceb24e523d82" #TODO: update to new MESA-INLIST branch/commit
     elif rerun_type == 'other': # e.g. 'envelope_mass_limit', 'fe_core_infall_limit'
         # this rerun uses the default inlist commit
         return
@@ -878,23 +878,41 @@ def logic_rerun(grid, rerun_type):
     elif rerun_type == 'LBV_wind':
         N_runs = len(grid)
         runs_to_rerun = []
+        hot_wind_full_on_T = 1.2e4 # inlist value
         for i in range(N_runs):
             if grid[i].history1 is not None:
                 s1_L = 10**grid[i].history1['log_L']
                 s1_R = 10**grid[i].history1['log_R']
                 s1_HD_limit = (1.0e-5 * s1_R * np.sqrt(s1_L))
                 lbv_1 = np.logical_and(s1_L > 6.0e5, s1_HD_limit > 1.0)
+                s1_Teff = 10**grid[i].history1['log_Teff']
+                s1_Yc = grid[i].history1['center_he4']
+                s1_he_shell_mass = grid[i].history1['he_core_mass'] -\
+                                   grid[i].history1['co_core_mass']
+                tpagb_1 = np.logical_and(s1_Teff <= hot_wind_full_on_T,\
+                                         s1_Yc <= 1e-6)
+                tpagb_1 = np.logical_and(tpagb_1, s1_he_shell_mass <= 1e-1)
             else:
                 lbv_1 = np.array([False])
+                tpagb_1 = np.array([False])
             if grid[i].history2 is not None:
                 s2_L = 10**grid[i].history2['log_L']
                 s2_R = 10**grid[i].history2['log_R']
                 s2_HD_limit = (1.0e-5 * s2_R * np.sqrt(s2_L))
                 lbv_2 = np.logical_and(s2_L > 6.0e5, s2_HD_limit > 1.0)
+                s2_Teff = 10**grid[i].history2['log_Teff']
+                s2_Yc = grid[i].history2['center_he4']
+                s2_he_shell_mass = grid[i].history2['he_core_mass'] -\
+                                   grid[i].history2['co_core_mass']
+                tpagb_2 = np.logical_and(s2_Teff <= hot_wind_full_on_T,\
+                                         s2_Yc <= 1e-6)
+                tpagb_2 = np.logical_and(tpagb_2, s2_he_shell_mass <= 1e-1)
             else:
                 lbv_2 = np.array([False])
+                tpagb_2 = np.array([False])
             if np.max(np.logical_or(lbv_1, lbv_2)) == True:
-                runs_to_rerun += [i]
+                if np.max(np.logical_or(tpagb_1, tpagb_2)) == False:
+                    runs_to_rerun += [i]
         runs_to_rerun = np.array(runs_to_rerun)
     elif rerun_type == 'envelope_mass_limit': # maybe 'fe_core_infall_limit' as well?
         runs_to_rerun = None # implement logic

--- a/bin/posydon-run-pipeline
+++ b/bin/posydon-run-pipeline
@@ -688,18 +688,18 @@ def copy_ini_file(grid_type, rerun_metallicity, rerun_type, destination,
     elif rerun_type == "dedt_hepulse":
         replace_text = "seth_dedt_hepulse-0274be9895480cae3aa2a4d14b056a2447d5921b"
     elif rerun_type == 'LBV_wind':
-        replace_text = "matthias_LBV_wind-95c817ef9512b6b3a69962b748e5008e5f9fc0da"
+        replace_text = "matthias_LBV_wind-e7db85fe578587383c335f168e3054c1eaaca895"
     elif rerun_type == 'LBV_wind+thermohaline_mixing':
-        replace_text = "matthias_LBV_wind-95c817ef9512b6b3a69962b748e5008e5f9fc0da"
+        replace_text = "matthias_LBV_wind-e7db85fe578587383c335f168e3054c1eaaca895"
     elif rerun_type == 'LBV_wind+HeMB_MLTp_mesh':
         raise ValueError(f'Not yet supported rerun type {rerun_type}!')
-        replace_text = "matthias_LBV_wind-95c817ef9512b6b3a69962b748e5008e5f9fc0da" #TODO: update to new MESA-INLIST branch/commit
+        replace_text = "matthias_LBV_wind-e7db85fe578587383c335f168e3054c1eaaca895" #TODO: update to new MESA-INLIST branch/commit
     elif rerun_type == 'LBV_wind+dedt_energy_eqn':
         raise ValueError(f'Not yet supported rerun type {rerun_type}!')
-        replace_text = "matthias_LBV_wind-95c817ef9512b6b3a69962b748e5008e5f9fc0da" #TODO: update to new MESA-INLIST branch/commit
+        replace_text = "matthias_LBV_wind-e7db85fe578587383c335f168e3054c1eaaca895" #TODO: update to new MESA-INLIST branch/commit
     elif rerun_type == 'LBV_wind+dedt_hepulse':
         raise ValueError(f'Not yet supported rerun type {rerun_type}!')
-        replace_text = "matthias_LBV_wind-95c817ef9512b6b3a69962b748e5008e5f9fc0da" #TODO: update to new MESA-INLIST branch/commit
+        replace_text = "matthias_LBV_wind-e7db85fe578587383c335f168e3054c1eaaca895" #TODO: update to new MESA-INLIST branch/commit
     elif rerun_type == 'other': # e.g. 'envelope_mass_limit', 'fe_core_infall_limit'
         # this rerun uses the default inlist commit
         return

--- a/bin/posydon-run-pipeline
+++ b/bin/posydon-run-pipeline
@@ -687,6 +687,19 @@ def copy_ini_file(grid_type, rerun_metallicity, rerun_type, destination,
         replace_text = "seth_dedt_energy_eqn-f1803afe400ed16a4fad47b0bad6abbf0965cae1"
     elif rerun_type == "dedt_hepulse":
         replace_text = "seth_dedt_hepulse-0274be9895480cae3aa2a4d14b056a2447d5921b"
+    elif rerun_type == "LBV_wind":
+        replace_text = "matthias_LBV_wind-95c817ef9512b6b3a69962b748e5008e5f9fc0da"
+    elif rerun_type == "LBV_wind+thermohaline_mixing":
+        replace_text = "matthias_LBV_wind-95c817ef9512b6b3a69962b748e5008e5f9fc0da"
+    elif rerun_type == "LBV_wind+HeMB_MLTp_mesh":
+        raise ValueError(f'Not yet supported rerun type {rerun_type}!')
+        replace_text = "matthias_LBV_wind-95c817ef9512b6b3a69962b748e5008e5f9fc0da" #TODO: update to new MESA-INLIST branch/commit
+    elif rerun_type == "LBV_wind+dedt_energy_eqn":
+        raise ValueError(f'Not yet supported rerun type {rerun_type}!')
+        replace_text = "matthias_LBV_wind-95c817ef9512b6b3a69962b748e5008e5f9fc0da" #TODO: update to new MESA-INLIST branch/commit
+    elif rerun_type == "LBV_wind+dedt_hepulse":
+        raise ValueError(f'Not yet supported rerun type {rerun_type}!')
+        replace_text = "matthias_LBV_wind-95c817ef9512b6b3a69962b748e5008e5f9fc0da" #TODO: update to new MESA-INLIST branch/commit
     elif rerun_type == 'other': # e.g. 'envelope_mass_limit', 'fe_core_infall_limit'
         # this rerun uses the default inlist commit
         return
@@ -806,10 +819,12 @@ def logic_rerun(grid, rerun_type):
             if np.max(np.logical_or(tpagb_1, tpagb_2)) == True:
                 runs_to_rerun += [i]
         runs_to_rerun = np.array(runs_to_rerun)
-    elif rerun_type == 'thermohaline_mixing':
+    elif ((rerun_type == 'thermohaline_mixing') or
+          (rerun_type == "LBV_wind+thermohaline_mixing")):
         termination_flags = TF1_POOL_ERROR
         new_mesa_flag = {'thermohaline_coeff' : 17.5}
-    elif rerun_type == 'HeMB_MLTp_mesh':
+    elif ((rerun_type == 'HeMB_MLTp_mesh') or
+          (rerun_type == "LBV_wind+HeMB_MLTp_mesh")):
         termination_flags = TF1_POOL_ERROR
     elif rerun_type == 'more_mesh':
         termination_flags = TF1_POOL_ERROR
@@ -854,10 +869,33 @@ def logic_rerun(grid, rerun_type):
             if np.isnan(iniY) or iniY<0.96:
                 runs_to_rerun += [i]
         runs_to_rerun = np.array(runs_to_rerun)
-    elif rerun_type == 'dedt_energy_eqn':
+    elif ((rerun_type == 'dedt_energy_eqn') or
+          (rerun_type == "LBV_wind+dedt_energy_eqn")):
         termination_flags = TF1_POOL_ERROR    
-    elif rerun_type == 'dedt_hepulse':
+    elif ((rerun_type == 'dedt_hepulse') or
+          (rerun_type == "LBV_wind+dedt_hepulse")):
         termination_flags = TF1_POOL_ERROR
+    elif rerun_type == "LBV_wind":
+        N_runs = len(grid)
+        runs_to_rerun = []
+        for i in range(N_runs):
+            if grid[i].history1 is not None:
+                s1_L = 10**grid[i].history1['log_L']
+                s1_R = 10**grid[i].history1['log_R']
+                s1_HD_limit = (1e-5 * s1_R * np.sqrt(s1_L))
+                lbv_1 = s1_HD_limit > 1.0
+            else:
+                lbv_1 = np.array([False])
+            if grid[i].history2 is not None:
+                s2_L = 10**grid[i].history2['log_L']
+                s2_R = 10**grid[i].history2['log_R']
+                s2_HD_limit = (1e-5 * s2_R * np.sqrt(s2_L))
+                lbv_2 = s2_HD_limit > 1.0
+            else:
+                lbv_2 = np.array([False])
+            if np.max(np.logical_or(lbv_1, lbv_2)) == True:
+                runs_to_rerun += [i]
+        runs_to_rerun = np.array(runs_to_rerun)
     elif rerun_type == 'envelope_mass_limit': # maybe 'fe_core_infall_limit' as well?
         runs_to_rerun = None # implement logic
     else:

--- a/bin/posydon-run-pipeline
+++ b/bin/posydon-run-pipeline
@@ -688,18 +688,18 @@ def copy_ini_file(grid_type, rerun_metallicity, rerun_type, destination,
     elif rerun_type == "dedt_hepulse":
         replace_text = "seth_dedt_hepulse-0274be9895480cae3aa2a4d14b056a2447d5921b"
     elif rerun_type == 'LBV_wind':
-        replace_text = "matthias_LBV_wind-112a8dcb96c11373e0e08c544ea8b71fb35aebf6"
+        replace_text = "matthias_LBV_wind-051343856f50dc5518abdf28904d62df4caacaff"
     elif rerun_type == 'LBV_wind+thermohaline_mixing':
-        replace_text = "matthias_LBV_wind-112a8dcb96c11373e0e08c544ea8b71fb35aebf6"
+        replace_text = "matthias_LBV_wind-051343856f50dc5518abdf28904d62df4caacaff"
     elif rerun_type == 'LBV_wind+HeMB_MLTp_mesh':
         raise ValueError(f'Not yet supported rerun type {rerun_type}!')
-        replace_text = "matthias_LBV_wind-112a8dcb96c11373e0e08c544ea8b71fb35aebf6" #TODO: update to new MESA-INLIST branch/commit
+        replace_text = "matthias_LBV_wind-051343856f50dc5518abdf28904d62df4caacaff" #TODO: update to new MESA-INLIST branch/commit
     elif rerun_type == 'LBV_wind+dedt_energy_eqn':
         raise ValueError(f'Not yet supported rerun type {rerun_type}!')
-        replace_text = "matthias_LBV_wind-112a8dcb96c11373e0e08c544ea8b71fb35aebf6" #TODO: update to new MESA-INLIST branch/commit
+        replace_text = "matthias_LBV_wind-051343856f50dc5518abdf28904d62df4caacaff" #TODO: update to new MESA-INLIST branch/commit
     elif rerun_type == 'LBV_wind+dedt_hepulse':
         raise ValueError(f'Not yet supported rerun type {rerun_type}!')
-        replace_text = "matthias_LBV_wind-112a8dcb96c11373e0e08c544ea8b71fb35aebf6" #TODO: update to new MESA-INLIST branch/commit
+        replace_text = "matthias_LBV_wind-051343856f50dc5518abdf28904d62df4caacaff" #TODO: update to new MESA-INLIST branch/commit
     elif rerun_type == 'other': # e.g. 'envelope_mass_limit', 'fe_core_infall_limit'
         # this rerun uses the default inlist commit
         return
@@ -887,7 +887,7 @@ def logic_rerun(grid, rerun_type):
                 lbv_1 = np.logical_and(s1_L > 6.0e5, s1_HD_limit > 1.0)
                 # exclude (stripped) He stars
                 s1_X_surf = grid[i].history1['surface_h1']
-                lbv_1 = np.logical_and(lbv_1, s1_X_surf >= 0.4)
+                lbv_1 = np.logical_and(lbv_1, s1_X_surf >= 0.1)
                 # exclude stars going through TPAGB
                 s1_Teff = 10**grid[i].history1['log_Teff']
                 s1_Yc = grid[i].history1['center_he4']
@@ -906,7 +906,7 @@ def logic_rerun(grid, rerun_type):
                 lbv_2 = np.logical_and(s2_L > 6.0e5, s2_HD_limit > 1.0)
                 # exclude (stripped) He stars
                 s2_X_surf = grid[i].history2['surface_h1']
-                lbv_2 = np.logical_and(lbv_2, s2_X_surf >= 0.4)
+                lbv_2 = np.logical_and(lbv_2, s2_X_surf >= 0.1)
                 # exclude stars going through TPAGB
                 s2_Teff = 10**grid[i].history2['log_Teff']
                 s2_Yc = grid[i].history2['center_he4']

--- a/bin/posydon-run-pipeline
+++ b/bin/posydon-run-pipeline
@@ -687,17 +687,17 @@ def copy_ini_file(grid_type, rerun_metallicity, rerun_type, destination,
         replace_text = "seth_dedt_energy_eqn-f1803afe400ed16a4fad47b0bad6abbf0965cae1"
     elif rerun_type == "dedt_hepulse":
         replace_text = "seth_dedt_hepulse-0274be9895480cae3aa2a4d14b056a2447d5921b"
-    elif rerun_type == "LBV_wind":
+    elif rerun_type == 'LBV_wind':
         replace_text = "matthias_LBV_wind-95c817ef9512b6b3a69962b748e5008e5f9fc0da"
-    elif rerun_type == "LBV_wind+thermohaline_mixing":
+    elif rerun_type == 'LBV_wind+thermohaline_mixing':
         replace_text = "matthias_LBV_wind-95c817ef9512b6b3a69962b748e5008e5f9fc0da"
-    elif rerun_type == "LBV_wind+HeMB_MLTp_mesh":
+    elif rerun_type == 'LBV_wind+HeMB_MLTp_mesh':
         raise ValueError(f'Not yet supported rerun type {rerun_type}!')
         replace_text = "matthias_LBV_wind-95c817ef9512b6b3a69962b748e5008e5f9fc0da" #TODO: update to new MESA-INLIST branch/commit
-    elif rerun_type == "LBV_wind+dedt_energy_eqn":
+    elif rerun_type == 'LBV_wind+dedt_energy_eqn':
         raise ValueError(f'Not yet supported rerun type {rerun_type}!')
         replace_text = "matthias_LBV_wind-95c817ef9512b6b3a69962b748e5008e5f9fc0da" #TODO: update to new MESA-INLIST branch/commit
-    elif rerun_type == "LBV_wind+dedt_hepulse":
+    elif rerun_type == 'LBV_wind+dedt_hepulse':
         raise ValueError(f'Not yet supported rerun type {rerun_type}!')
         replace_text = "matthias_LBV_wind-95c817ef9512b6b3a69962b748e5008e5f9fc0da" #TODO: update to new MESA-INLIST branch/commit
     elif rerun_type == 'other': # e.g. 'envelope_mass_limit', 'fe_core_infall_limit'
@@ -820,11 +820,11 @@ def logic_rerun(grid, rerun_type):
                 runs_to_rerun += [i]
         runs_to_rerun = np.array(runs_to_rerun)
     elif ((rerun_type == 'thermohaline_mixing') or
-          (rerun_type == "LBV_wind+thermohaline_mixing")):
+          (rerun_type == 'LBV_wind+thermohaline_mixing')):
         termination_flags = TF1_POOL_ERROR
         new_mesa_flag = {'thermohaline_coeff' : 17.5}
     elif ((rerun_type == 'HeMB_MLTp_mesh') or
-          (rerun_type == "LBV_wind+HeMB_MLTp_mesh")):
+          (rerun_type == 'LBV_wind+HeMB_MLTp_mesh')):
         termination_flags = TF1_POOL_ERROR
     elif rerun_type == 'more_mesh':
         termination_flags = TF1_POOL_ERROR
@@ -870,27 +870,27 @@ def logic_rerun(grid, rerun_type):
                 runs_to_rerun += [i]
         runs_to_rerun = np.array(runs_to_rerun)
     elif ((rerun_type == 'dedt_energy_eqn') or
-          (rerun_type == "LBV_wind+dedt_energy_eqn")):
+          (rerun_type == 'LBV_wind+dedt_energy_eqn')):
         termination_flags = TF1_POOL_ERROR    
     elif ((rerun_type == 'dedt_hepulse') or
-          (rerun_type == "LBV_wind+dedt_hepulse")):
+          (rerun_type == 'LBV_wind+dedt_hepulse')):
         termination_flags = TF1_POOL_ERROR
-    elif rerun_type == "LBV_wind":
+    elif rerun_type == 'LBV_wind':
         N_runs = len(grid)
         runs_to_rerun = []
         for i in range(N_runs):
             if grid[i].history1 is not None:
                 s1_L = 10**grid[i].history1['log_L']
                 s1_R = 10**grid[i].history1['log_R']
-                s1_HD_limit = (1e-5 * s1_R * np.sqrt(s1_L))
-                lbv_1 = s1_HD_limit > 1.0
+                s1_HD_limit = (1.0e-5 * s1_R * np.sqrt(s1_L))
+                lbv_1 = np.logical_and(s1_L > 6.0e5, s1_HD_limit > 1.0)
             else:
                 lbv_1 = np.array([False])
             if grid[i].history2 is not None:
                 s2_L = 10**grid[i].history2['log_L']
                 s2_R = 10**grid[i].history2['log_R']
-                s2_HD_limit = (1e-5 * s2_R * np.sqrt(s2_L))
-                lbv_2 = s2_HD_limit > 1.0
+                s2_HD_limit = (1.0e-5 * s2_R * np.sqrt(s2_L))
+                lbv_2 = np.logical_and(s2_L > 6.0e5, s2_HD_limit > 1.0)
             else:
                 lbv_2 = np.array([False])
             if np.max(np.logical_or(lbv_1, lbv_2)) == True:

--- a/bin/posydon-run-pipeline
+++ b/bin/posydon-run-pipeline
@@ -688,18 +688,18 @@ def copy_ini_file(grid_type, rerun_metallicity, rerun_type, destination,
     elif rerun_type == "dedt_hepulse":
         replace_text = "seth_dedt_hepulse-0274be9895480cae3aa2a4d14b056a2447d5921b"
     elif rerun_type == 'LBV_wind':
-        replace_text = "matthias_LBV_wind-0cebead888f29eb56800516900f5ceb24e523d82"
+        replace_text = "matthias_LBV_wind-112a8dcb96c11373e0e08c544ea8b71fb35aebf6"
     elif rerun_type == 'LBV_wind+thermohaline_mixing':
-        replace_text = "matthias_LBV_wind-0cebead888f29eb56800516900f5ceb24e523d82"
+        replace_text = "matthias_LBV_wind-112a8dcb96c11373e0e08c544ea8b71fb35aebf6"
     elif rerun_type == 'LBV_wind+HeMB_MLTp_mesh':
         raise ValueError(f'Not yet supported rerun type {rerun_type}!')
-        replace_text = "matthias_LBV_wind-0cebead888f29eb56800516900f5ceb24e523d82" #TODO: update to new MESA-INLIST branch/commit
+        replace_text = "matthias_LBV_wind-112a8dcb96c11373e0e08c544ea8b71fb35aebf6" #TODO: update to new MESA-INLIST branch/commit
     elif rerun_type == 'LBV_wind+dedt_energy_eqn':
         raise ValueError(f'Not yet supported rerun type {rerun_type}!')
-        replace_text = "matthias_LBV_wind-0cebead888f29eb56800516900f5ceb24e523d82" #TODO: update to new MESA-INLIST branch/commit
+        replace_text = "matthias_LBV_wind-112a8dcb96c11373e0e08c544ea8b71fb35aebf6" #TODO: update to new MESA-INLIST branch/commit
     elif rerun_type == 'LBV_wind+dedt_hepulse':
         raise ValueError(f'Not yet supported rerun type {rerun_type}!')
-        replace_text = "matthias_LBV_wind-0cebead888f29eb56800516900f5ceb24e523d82" #TODO: update to new MESA-INLIST branch/commit
+        replace_text = "matthias_LBV_wind-112a8dcb96c11373e0e08c544ea8b71fb35aebf6" #TODO: update to new MESA-INLIST branch/commit
     elif rerun_type == 'other': # e.g. 'envelope_mass_limit', 'fe_core_infall_limit'
         # this rerun uses the default inlist commit
         return
@@ -885,6 +885,10 @@ def logic_rerun(grid, rerun_type):
                 s1_R = 10**grid[i].history1['log_R']
                 s1_HD_limit = (1.0e-5 * s1_R * np.sqrt(s1_L))
                 lbv_1 = np.logical_and(s1_L > 6.0e5, s1_HD_limit > 1.0)
+                # exclude (stripped) He stars
+                s1_X_surf = grid[i].history1['surface_h1']
+                lbv_1 = np.logical_and(lbv_1, s1_X_surf >= 0.4)
+                # exclude stars going through TPAGB
                 s1_Teff = 10**grid[i].history1['log_Teff']
                 s1_Yc = grid[i].history1['center_he4']
                 s1_he_shell_mass = grid[i].history1['he_core_mass'] -\
@@ -900,6 +904,10 @@ def logic_rerun(grid, rerun_type):
                 s2_R = 10**grid[i].history2['log_R']
                 s2_HD_limit = (1.0e-5 * s2_R * np.sqrt(s2_L))
                 lbv_2 = np.logical_and(s2_L > 6.0e5, s2_HD_limit > 1.0)
+                # exclude (stripped) He stars
+                s2_X_surf = grid[i].history2['surface_h1']
+                lbv_2 = np.logical_and(lbv_2, s2_X_surf >= 0.4)
+                # exclude stars going through TPAGB
                 s2_Teff = 10**grid[i].history2['log_Teff']
                 s2_Yc = grid[i].history2['center_he4']
                 s2_he_shell_mass = grid[i].history2['he_core_mass'] -\

--- a/docs/_source/components-overview/post_processing/pipeline/pipeline_steps.rst
+++ b/docs/_source/components-overview/post_processing/pipeline/pipeline_steps.rst
@@ -201,10 +201,11 @@ type of the rerun specifying the logic and changes, and the cluster name.
     opacity_max            caution         it uses a fixed maximum opacity of 0.5 (this is only a last option change to get more stability)
     TPAGBwind              default in v3+  it enables the MESA inlist commit, which changes the wind during the TPAGB phase
     thermohaline_mixing    default in v3+  it uses thermohaline mixing in the inlist
-    HeMB_MLTp_mesh         workaround      it turns off magnetic braking for He stars; it uses less extreme parameters of the MLT++; it changes some more input values to change the resulation close to the surface
+    HeMB_MLTp_mesh         caution         it turns off magnetic braking for He stars; it uses less extreme parameters of the MLT++ (this can cause significant changes in the radius evolution of stars); it changes some more input values to change the resulation close to the surface
     more_mesh              workaround      it modifies the remeshing and allows for more cells in MESA
     conv_bdy_weight        caution         it disabled the convective_bdy_weight where this caused segmentation faults (this avoids a bug in the old MESA version r11701)
     dedt_energy_eqn        caution         it enables MESA's dedt-form of the energy equation for numerical stability during rapid (superthermal) mass transfer
-    dedt_hepulse           caution         it enables MESA's dedt-form of the energy equation for rapid mass transfer. At stripped HeZAMS, several MLT++ changes, v_flag and lnPgas_flag set to .true., and convective_bdy_weight disabled to help with stripped He star superadiabatic envelopes, pulsations, and WD cooling. 
+    dedt_hepulse           caution         it enables MESA's dedt-form of the energy equation for rapid mass transfer; at stripped HeZAMS, several MLT++ changes, v_flag and lnPgas_flag set to .true., and convective_bdy_weight disabled to help with stripped He star superadiabatic envelopes, pulsations, and WD cooling
+    LBV_wind               default in v3+  it turns on LBV winds when crossing the Humphreys-Davidson limit as intended (due to a bug this was only applied after a retry); additionally, there are reruns `LBV_wind+thermohaline_mixing`, `LBV_wind+HeMB_MLTp_mesh`, `LBV_wind+dedt_energy_eqn`, `LBV_wind+dedt_hepulse`, which combine the two rerun types
     =====================  ==============  ===========
 


### PR DESCRIPTION
- [x] add logic to identify stars crossing Humphreys-Davidson limit
- [x] add inlist hashes for `LBV_wind` and `LBV_wind+thermohaline_mixing`
- [x] add inlist hashes for `LBV_wind+dedt_energy_eqn`; uncomment `LBV_wind+HeMB_MLTp_mesh`, and `LBV_wind+dedt_hepulse`
- [x] update docs
- tested on CO-HMS gird on yggdrasil:
   - as expected: the number of reruns increase towards lower metallicity
   - as expected: we get a few more reruns, when exporting them from the ORIGINAL data sets (this covers some runs, which spend short time in the LBV regime, which got removed by the down sampling in the LITE version)
   - as expected: exporting from different rerun levels results in different bunches of reruns
   - unexpected: there is no clear trend, which rerun level creates the most reruns; I think, we need to export from all levels and get a union of the `grid.csv` files; but even then I'm not sure, whether we cover all in the grids, where some MESA runs got skipped to speed up the grid recreation