### PR TITLE
Fix RLO warnings in detached step

### DIFF
--- a/posydon/binary_evol/CE/step_CEE.py
+++ b/posydon/binary_evol/CE/step_CEE.py
@@ -540,8 +540,8 @@ class StepCEE(object):
 
         # now we check if the roche Lobe of any of the cores that spiralled-in
         # will be filled if reached this final separation
-        RL1 = cf.roche_lobe_radius(mc1_i/mc2_i, separation_postCEE/const.Rsun)
-        RL2 = cf.roche_lobe_radius(mc2_i/mc1_i, separation_postCEE/const.Rsun)
+        RL1 = cf.roche_lobe_radius(mc1_i, mc2_i, separation_postCEE/const.Rsun)
+        RL2 = cf.roche_lobe_radius(mc2_i, mc1_i, separation_postCEE/const.Rsun)
 
         if verbose:
             print("donor radius / core radius / RL1:", radius1, rc1_i, RL1)
@@ -836,8 +836,8 @@ class StepCEE(object):
 
                 else:
 
-                    separation_for_inner_RLO1 = rc1_i / cf.roche_lobe_radius(mc1_i/mc2_i, a_orb=1)
-                    separation_for_inner_RLO2 = rc2_i / cf.roche_lobe_radius(mc2_i/mc1_i, a_orb=1)
+                    separation_for_inner_RLO1 = rc1_i / cf.roche_lobe_radius(mc1_i, mc2_i, a_orb=1)
+                    separation_for_inner_RLO2 = rc2_i / cf.roche_lobe_radius(mc2_i, mc1_i, a_orb=1)
 
                     separation_before_merger = max( separation_for_inner_RLO1, separation_for_inner_RLO2 ) * const.Rsun
 

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -20,7 +20,6 @@ from scipy.integrate import solve_ivp
 from scipy.interpolate import PchipInterpolator
 from scipy.optimize import minimize
 from scipy.optimize import root
-import warnings
 
 from posydon.utils.data_download import PATH_TO_POSYDON_DATA
 from posydon.binary_evol.binarystar import BINARYPROPERTIES
@@ -1215,23 +1214,10 @@ class detached_step:
             pri_mass = interp1d_pri["mass"](t - t_offset_pri)
             sec_mass = interp1d_sec["mass"](t - t_offset_sec)
 
-            if isinstance(y[0], np.ndarray):
-                warnings.warn("Trying to compute RL radius for binary with zero separation")
-                sep = np.nan
-                ecc = np.nan                
-            else:
-                sep = y[0]
-                ecc = y[1]
-
-            if pri_mass <=0:
-                warnings.warn("Trying to compute RL radius for binary with nonexistent companion")
-                pri_mass = np.nan
-
-            if sec_mass <=0:
-                warnings.warn("Trying to compute RL radius for binary with nonexistent companion")
-                sec_mass = np.nan
+            sep = y[0]
+            ecc = y[1]
            
-            RL = roche_lobe_radius(sec_mass/pri_mass, (1 - ecc) * sep)
+            RL = roche_lobe_radius(sec_mass, pri_mass, (1 - ecc) * sep)
             
             # 95% filling of the RL is enough to assume beginning of RLO,
             # as we do in CO-HMS_RLO grid
@@ -1261,24 +1247,11 @@ class detached_step:
             """
             pri_mass = interp1d_pri["mass"](t - t_offset_pri)
             sec_mass = interp1d_sec["mass"](t - t_offset_sec)
-
-            if isinstance(y[0], np.ndarray):
-                warnings.warn("Trying to compute RL radius for binary with zero separation")
-                sep = np.nan
-                ecc = np.nan                
-            else:
-                sep = y[0]
-                ecc = y[1]
-
-            if pri_mass <=0:
-                warnings.warn("Trying to compute RL radius for binary with nonexistent companion")
-                pri_mass = np.nan
-
-            if sec_mass <=0:
-                warnings.warn("Trying to compute RL radius for binary with nonexistent companion")
-                sec_mass = np.nan
+            
+            sep = y[0]
+            ecc = y[1]
            
-            RL = roche_lobe_radius(pri_mass/sec_mass, (1 - ecc) * sep)
+            RL = roche_lobe_radius(pri_mass, sec_mass, (1 - ecc) * sep)
             
             return interp1d_pri["R"](t - t_offset_pri) - 0.95*RL
 
@@ -1306,24 +1279,11 @@ class detached_step:
             """
             pri_mass = interp1d_pri["mass"](t - t_offset_pri)
             sec_mass = interp1d_sec["mass"](t - t_offset_sec)
-
-            if isinstance(y[0], np.ndarray):
-                warnings.warn("Trying to compute RL radius for binary with zero separation")
-                sep = np.nan
-                ecc = np.nan                
-            else:
-                sep = y[0]
-                ecc = y[1]
-
-            if pri_mass <=0:
-                warnings.warn("Trying to compute RL radius for binary with nonexistent companion")
-                pri_mass = np.nan
-
-            if sec_mass <=0:
-                warnings.warn("Trying to compute RL radius for binary with nonexistent companion")
-                sec_mass = np.nan
+            
+            sep = y[0]
+            ecc = y[1]
            
-            RL = roche_lobe_radius(sec_mass/pri_mass, (1 - ecc) * sep)
+            RL = roche_lobe_radius(sec_mass, pri_mass, (1 - ecc) * sep)
 
             return (interp1d_sec["R"](t - t_offset_sec) - RL) / RL
 
@@ -1352,23 +1312,10 @@ class detached_step:
             pri_mass = interp1d_pri["mass"](t - t_offset_pri)
             sec_mass = interp1d_sec["mass"](t - t_offset_sec)
 
-            if isinstance(y[0], np.ndarray):
-                warnings.warn("Trying to compute RL radius for binary with zero separation")
-                sep = np.nan
-                ecc = np.nan                
-            else:
-                sep = y[0]
-                ecc = y[1]
-
-            if pri_mass <=0:
-                warnings.warn("Trying to compute RL radius for binary with nonexistent companion")
-                pri_mass = np.nan
-
-            if sec_mass <=0:
-                warnings.warn("Trying to compute RL radius for binary with nonexistent companion")
-                sec_mass = np.nan
+            sep = y[0]
+            ecc = y[1]
            
-            RL = roche_lobe_radius(pri_mass/sec_mass, (1 - ecc) * sep)
+            RL = roche_lobe_radius(pri_mass, sec_mass, (1 - ecc) * sep)
 
             return (interp1d_pri["R"](t - t_offset_pri) - RL) / RL
 

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -20,6 +20,7 @@ from scipy.integrate import solve_ivp
 from scipy.interpolate import PchipInterpolator
 from scipy.optimize import minimize
 from scipy.optimize import root
+import warnings
 
 from posydon.utils.data_download import PATH_TO_POSYDON_DATA
 from posydon.binary_evol.binarystar import BINARYPROPERTIES
@@ -1210,11 +1211,27 @@ class detached_step:
                 solar radii.
 
             """
-            sep = y[0]
-            ecc = y[1]
-            RL = roche_lobe_radius(interp1d_sec["mass"](t - t_offset_sec)
-                                   / interp1d_pri["mass"](t - t_offset_pri),
-                                   (1 - ecc) * sep)
+            pri_mass = interp1d_pri["mass"](t - t_offset_pri)
+            sec_mass = interp1d_sec["mass"](t - t_offset_sec)
+
+            if isinstance(y[0], np.ndarray):
+                warnings.warn("Trying to compute RL radius for binary with zero separation", "EvolutionWarning")
+                sep = np.nan
+                ecc = np.nan                
+            else:
+                sep = y[0]
+                ecc = y[1]
+
+            if pri_mass <=0:
+                warnings.warn("Trying to compute RL radius for binary with nonexistent companion", "EvolutionWarning")
+                pri_mass = np.nan
+
+            if sec_mass <=0:
+                warnings.warn("Trying to compute RL radius for binary with nonexistent companion", "EvolutionWarning")
+                sec_mass = np.nan
+           
+            RL = roche_lobe_radius(sec_mass/pri_mass, (1 - ecc) * sep)
+            
             # 95% filling of the RL is enough to assume beginning of RLO,
             # as we do in CO-HMS_RLO grid
             return interp1d_sec["R"](t - t_offset_sec) - 0.95*RL
@@ -1241,11 +1258,27 @@ class detached_step:
                 solar radii.
 
             """
-            sep = y[0]
-            ecc = y[1]
-            RL = roche_lobe_radius(interp1d_pri["mass"](t - t_offset_pri)
-                                   / interp1d_sec["mass"](t - t_offset_sec),
-                                   (1 - ecc) * sep)
+            pri_mass = interp1d_pri["mass"](t - t_offset_pri)
+            sec_mass = interp1d_sec["mass"](t - t_offset_sec)
+
+            if isinstance(y[0], np.ndarray):
+                warnings.warn("Trying to compute RL radius for binary with zero separation", "EvolutionWarning")
+                sep = np.nan
+                ecc = np.nan                
+            else:
+                sep = y[0]
+                ecc = y[1]
+
+            if pri_mass <=0:
+                warnings.warn("Trying to compute RL radius for binary with nonexistent companion", "EvolutionWarning")
+                pri_mass = np.nan
+
+            if sec_mass <=0:
+                warnings.warn("Trying to compute RL radius for binary with nonexistent companion", "EvolutionWarning")
+                sec_mass = np.nan
+           
+            RL = roche_lobe_radius(pri_mass/sec_mass, (1 - ecc) * sep)
+            
             return interp1d_pri["R"](t - t_offset_pri) - 0.95*RL
 
         @event(True, 1)
@@ -1270,11 +1303,27 @@ class detached_step:
                 radius.
 
             """
-            sep = y[0]
-            ecc = y[1]
-            RL = roche_lobe_radius(interp1d_sec["mass"](t - t_offset_sec)
-                                   / interp1d_pri["mass"](t - t_offset_pri),
-                                   (1 - ecc) * sep)
+            pri_mass = interp1d_pri["mass"](t - t_offset_pri)
+            sec_mass = interp1d_sec["mass"](t - t_offset_sec)
+
+            if isinstance(y[0], np.ndarray):
+                warnings.warn("Trying to compute RL radius for binary with zero separation", "EvolutionWarning")
+                sep = np.nan
+                ecc = np.nan                
+            else:
+                sep = y[0]
+                ecc = y[1]
+
+            if pri_mass <=0:
+                warnings.warn("Trying to compute RL radius for binary with nonexistent companion", "EvolutionWarning")
+                pri_mass = np.nan
+
+            if sec_mass <=0:
+                warnings.warn("Trying to compute RL radius for binary with nonexistent companion", "EvolutionWarning")
+                sec_mass = np.nan
+           
+            RL = roche_lobe_radius(sec_mass/pri_mass, (1 - ecc) * sep)
+
             return (interp1d_sec["R"](t - t_offset_sec) - RL) / RL
 
         @event(True, 1)
@@ -1299,11 +1348,27 @@ class detached_step:
                 radius.
 
             """
-            sep = y[0]
-            ecc = y[1]
-            RL = roche_lobe_radius(interp1d_pri["mass"](t - t_offset_pri)
-                                   / interp1d_sec["mass"](t - t_offset_sec),
-                                   (1 - ecc) * sep)
+            pri_mass = interp1d_pri["mass"](t - t_offset_pri)
+            sec_mass = interp1d_sec["mass"](t - t_offset_sec)
+
+            if isinstance(y[0], np.ndarray):
+                warnings.warn("Trying to compute RL radius for binary with zero separation", "EvolutionWarning")
+                sep = np.nan
+                ecc = np.nan                
+            else:
+                sep = y[0]
+                ecc = y[1]
+
+            if pri_mass <=0:
+                warnings.warn("Trying to compute RL radius for binary with nonexistent companion", "EvolutionWarning")
+                pri_mass = np.nan
+
+            if sec_mass <=0:
+                warnings.warn("Trying to compute RL radius for binary with nonexistent companion", "EvolutionWarning")
+                sec_mass = np.nan
+           
+            RL = roche_lobe_radius(pri_mass/sec_mass, (1 - ecc) * sep)
+
             return (interp1d_pri["R"](t - t_offset_pri) - RL) / RL
 
         @event(True, -1)

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -1215,7 +1215,7 @@ class detached_step:
             sec_mass = interp1d_sec["mass"](t - t_offset_sec)
 
             if isinstance(y[0], np.ndarray):
-                warnings.warn("Trying to compute RL radius for binary with zero separation", "EvolutionWarning")
+                warnings.warn("Trying to compute RL radius for binary with zero separation")
                 sep = np.nan
                 ecc = np.nan                
             else:
@@ -1223,11 +1223,11 @@ class detached_step:
                 ecc = y[1]
 
             if pri_mass <=0:
-                warnings.warn("Trying to compute RL radius for binary with nonexistent companion", "EvolutionWarning")
+                warnings.warn("Trying to compute RL radius for binary with nonexistent companion")
                 pri_mass = np.nan
 
             if sec_mass <=0:
-                warnings.warn("Trying to compute RL radius for binary with nonexistent companion", "EvolutionWarning")
+                warnings.warn("Trying to compute RL radius for binary with nonexistent companion")
                 sec_mass = np.nan
            
             RL = roche_lobe_radius(sec_mass/pri_mass, (1 - ecc) * sep)
@@ -1262,7 +1262,7 @@ class detached_step:
             sec_mass = interp1d_sec["mass"](t - t_offset_sec)
 
             if isinstance(y[0], np.ndarray):
-                warnings.warn("Trying to compute RL radius for binary with zero separation", "EvolutionWarning")
+                warnings.warn("Trying to compute RL radius for binary with zero separation")
                 sep = np.nan
                 ecc = np.nan                
             else:
@@ -1270,11 +1270,11 @@ class detached_step:
                 ecc = y[1]
 
             if pri_mass <=0:
-                warnings.warn("Trying to compute RL radius for binary with nonexistent companion", "EvolutionWarning")
+                warnings.warn("Trying to compute RL radius for binary with nonexistent companion")
                 pri_mass = np.nan
 
             if sec_mass <=0:
-                warnings.warn("Trying to compute RL radius for binary with nonexistent companion", "EvolutionWarning")
+                warnings.warn("Trying to compute RL radius for binary with nonexistent companion")
                 sec_mass = np.nan
            
             RL = roche_lobe_radius(pri_mass/sec_mass, (1 - ecc) * sep)
@@ -1307,7 +1307,7 @@ class detached_step:
             sec_mass = interp1d_sec["mass"](t - t_offset_sec)
 
             if isinstance(y[0], np.ndarray):
-                warnings.warn("Trying to compute RL radius for binary with zero separation", "EvolutionWarning")
+                warnings.warn("Trying to compute RL radius for binary with zero separation")
                 sep = np.nan
                 ecc = np.nan                
             else:
@@ -1315,11 +1315,11 @@ class detached_step:
                 ecc = y[1]
 
             if pri_mass <=0:
-                warnings.warn("Trying to compute RL radius for binary with nonexistent companion", "EvolutionWarning")
+                warnings.warn("Trying to compute RL radius for binary with nonexistent companion")
                 pri_mass = np.nan
 
             if sec_mass <=0:
-                warnings.warn("Trying to compute RL radius for binary with nonexistent companion", "EvolutionWarning")
+                warnings.warn("Trying to compute RL radius for binary with nonexistent companion")
                 sec_mass = np.nan
            
             RL = roche_lobe_radius(sec_mass/pri_mass, (1 - ecc) * sep)
@@ -1352,7 +1352,7 @@ class detached_step:
             sec_mass = interp1d_sec["mass"](t - t_offset_sec)
 
             if isinstance(y[0], np.ndarray):
-                warnings.warn("Trying to compute RL radius for binary with zero separation", "EvolutionWarning")
+                warnings.warn("Trying to compute RL radius for binary with zero separation")
                 sep = np.nan
                 ecc = np.nan                
             else:
@@ -1360,11 +1360,11 @@ class detached_step:
                 ecc = y[1]
 
             if pri_mass <=0:
-                warnings.warn("Trying to compute RL radius for binary with nonexistent companion", "EvolutionWarning")
+                warnings.warn("Trying to compute RL radius for binary with nonexistent companion")
                 pri_mass = np.nan
 
             if sec_mass <=0:
-                warnings.warn("Trying to compute RL radius for binary with nonexistent companion", "EvolutionWarning")
+                warnings.warn("Trying to compute RL radius for binary with nonexistent companion")
                 sec_mass = np.nan
            
             RL = roche_lobe_radius(pri_mass/sec_mass, (1 - ecc) * sep)

--- a/posydon/binary_evol/DT/step_isolated.py
+++ b/posydon/binary_evol/DT/step_isolated.py
@@ -7,28 +7,10 @@ __authors__ = [
     "Konstantinos Kovlakas <Konstantinos.Kovlakas@unige.ch>"
 ]
 
-
-import os
 import numpy as np
-from scipy.integrate import solve_ivp
-from scipy.interpolate import PchipInterpolator
-from scipy.optimize import minimize
-from scipy.optimize import root
 
 from posydon.utils.data_download import PATH_TO_POSYDON_DATA
-from posydon.binary_evol.binarystar import BINARYPROPERTIES
-from posydon.binary_evol.singlestar import STARPROPERTIES
-from posydon.interpolation.data_scaling import DataScaler
-from posydon.utils.common_functions import (
-    bondi_hoyle,
-    orbital_period_from_separation,
-    orbital_separation_from_period,
-    roche_lobe_radius,
-    check_state_of_star,
-    PchipInterpolator2
-)
-from posydon.binary_evol.flow_chart import (STAR_STATES_CC)
-import posydon.utils.constants as const
+from posydon.utils.common_functions import orbital_separation_from_period
 from posydon.binary_evol.DT.step_detached import detached_step
 from posydon.utils.posydonerror import FlowError
 

--- a/posydon/tests/binary_evol/CE/test_CEE.py
+++ b/posydon/tests/binary_evol/CE/test_CEE.py
@@ -51,9 +51,8 @@ class TestCommonEnvelope(unittest.TestCase):
         giantstar = SingleStar(**PROPERTIES_STAR1)
         compstar = SingleStar(**PROPERTIES_STAR2)
 
-        q = giantstar.mass / compstar.mass
         orbital_separation_for_RLOF = 10**giantstar.log_R / cf.roche_lobe_radius(
-            q, a_orb=1)
+            giantstar.mass, compstar.mass, a_orb=1)
         orbital_period_for_RLOF = cf.orbital_period_from_separation(
             orbital_separation_for_RLOF, giantstar.mass, compstar.mass)
         PROPERTIES_BINARY = {
@@ -113,9 +112,8 @@ class TestCommonEnvelope(unittest.TestCase):
         }
         compstar = SingleStar(**PROPERTIES_STAR2)
 
-        q = giantstar_withprofile.mass / compstar.mass
         orbital_separation_for_RLOF = 10**giantstar_withprofile.log_R / cf.roche_lobe_radius(
-            q, a_orb=1)
+            giantstar_withprofile.mass, compstar.mass, a_orb=1)
         orbital_period_for_RLOF = cf.orbital_period_from_separation(
             orbital_separation_for_RLOF, giantstar_withprofile.mass,
             compstar.mass)
@@ -180,9 +178,8 @@ class TestCommonEnvelope(unittest.TestCase):
         }
         compstar = SingleStar(**PROPERTIES_STAR2)
 
-        q = giantstar_withprofile.mass / compstar.mass
         orbital_separation_for_RLOF = 10**giantstar_withprofile.log_R / cf.roche_lobe_radius(
-            q, a_orb=1)
+            giantstar_withprofile.mass, compstar.mass, a_orb=1)
         orbital_period_for_RLOF = cf.orbital_period_from_separation(
             orbital_separation_for_RLOF, giantstar_withprofile.mass,
             compstar.mass)
@@ -243,9 +240,8 @@ class TestCommonEnvelope(unittest.TestCase):
         }
         compstar = SingleStar(**PROPERTIES_STAR2)
 
-        q = giantstar_withprofile.mass / compstar.mass
         orbital_separation_for_RLOF = 10**giantstar_withprofile.log_R / cf.roche_lobe_radius(
-            q, a_orb=1)
+            giantstar_withprofile.mass, compstar.mass, a_orb=1)
         orbital_period_for_RLOF = cf.orbital_period_from_separation(
             orbital_separation_for_RLOF, giantstar_withprofile.mass,
             compstar.mass)
@@ -309,9 +305,8 @@ class TestCommonEnvelope(unittest.TestCase):
         }
         compstar = SingleStar(**PROPERTIES_STAR2)
 
-        q = giantstar_withprofile.mass / compstar.mass
         orbital_separation_for_RLOF = 10**giantstar_withprofile.log_R / cf.roche_lobe_radius(
-            q, a_orb=1)
+            giantstar_withprofile.mass, compstar.mass, a_orb=1)
         orbital_period_for_RLOF = cf.orbital_period_from_separation(
             orbital_separation_for_RLOF, giantstar_withprofile.mass,
             compstar.mass)
@@ -367,9 +362,8 @@ class TestCommonEnvelope(unittest.TestCase):
         }
         compstar = SingleStar(**PROPERTIES_STAR2)
 
-        q = giantstar_withprofile.mass / compstar.mass
         orbital_separation_for_RLOF = 10**giantstar_withprofile.log_R / cf.roche_lobe_radius(
-            q, a_orb=1)
+            giantstar_withprofile.mass, compstar.mass, a_orb=1)
         orbital_period_for_RLOF = cf.orbital_period_from_separation(
             orbital_separation_for_RLOF, giantstar_withprofile.mass,
             compstar.mass)
@@ -390,7 +384,7 @@ class TestCommonEnvelope(unittest.TestCase):
         #self.assertTrue(binary_withprofile.event == 'redirect',
         #                "CEE test 6 failed")
         self.assertTrue((10**giantstar_withprofile.log_R - cf.roche_lobe_radius(
-            giantstar_withprofile.mass / compstar.mass,
+            giantstar_withprofile.mass, compstar.mass,
             a_orb=cf.orbital_separation_from_period(
                 binary_withprofile.orbital_period, giantstar_withprofile.mass,
                 compstar.mass))), "CEE test 6 failed")
@@ -437,9 +431,8 @@ class TestCommonEnvelope(unittest.TestCase):
         }
         compstar = SingleStar(**PROPERTIES_STAR2)
 
-        q = giantstar_withprofile.mass / compstar.mass
         orbital_separation_for_RLOF = 10**giantstar_withprofile.log_R / cf.roche_lobe_radius(
-            q, a_orb=1)
+            giantstar_withprofile.mass, compstar.mass, a_orb=1)
         orbital_period_for_RLOF = cf.orbital_period_from_separation(
             orbital_separation_for_RLOF, giantstar_withprofile.mass,
             compstar.mass)
@@ -461,7 +454,7 @@ class TestCommonEnvelope(unittest.TestCase):
         #self.assertTrue(binary_withprofile.event == 'redirect',
         #                "CEE test 7 failed")
         self.assertTrue((10**giantstar_withprofile.log_R - cf.roche_lobe_radius(
-            giantstar_withprofile.mass / compstar.mass,
+            giantstar_withprofile.mass, compstar.mass,
             a_orb=cf.orbital_separation_from_period(
                 binary_withprofile.orbital_period, giantstar_withprofile.mass,
                 compstar.mass))), "CEE test 7 failed")
@@ -504,9 +497,8 @@ class TestCommonEnvelope(unittest.TestCase):
         }  #radius = 10km
         compstar = SingleStar(**PROPERTIES_STAR2)
 
-        q = giantstar_withprofile.mass / compstar.mass
         orbital_separation_for_RLOF = 10**giantstar_withprofile.log_R / cf.roche_lobe_radius(
-            q, a_orb=1)
+            giantstar_withprofile.mass, compstar.mass, a_orb=1)
         orbital_period_for_RLOF = cf.orbital_period_from_separation(
             orbital_separation_for_RLOF, giantstar_withprofile.mass,
             compstar.mass)
@@ -569,9 +561,8 @@ class TestCommonEnvelope(unittest.TestCase):
         }  #radius = 10km
         compstar = SingleStar(**PROPERTIES_STAR2)
 
-        q = giantstar_withprofile.mass / compstar.mass
         orbital_separation_for_RLOF = 10**giantstar_withprofile.log_R / cf.roche_lobe_radius(
-            q, a_orb=1)
+            giantstar_withprofile.mass, compstar.mass, a_orb=1)
         orbital_period_for_RLOF = cf.orbital_period_from_separation(
             orbital_separation_for_RLOF, giantstar_withprofile.mass,
             compstar.mass)
@@ -638,9 +629,8 @@ class TestCommonEnvelope(unittest.TestCase):
         }  #radius = 10km
         compstar = SingleStar(**PROPERTIES_STAR2)
 
-        q = giantstar_withprofile.mass / compstar.mass
         orbital_separation_for_RLOF = 10**giantstar_withprofile.log_R / cf.roche_lobe_radius(
-            q, a_orb=1)
+            giantstar_withprofile.mass, compstar.mass, a_orb=1)
         orbital_period_for_RLOF = cf.orbital_period_from_separation(
             orbital_separation_for_RLOF, giantstar_withprofile.mass,
             compstar.mass)

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -207,15 +207,15 @@ RL -> Roche lobe radius in similar units as a_orb
 '''
 
 
-def roche_lobe_radius(q, a_orb=1):
+def roche_lobe_radius(m1, m2, a_orb=1):
     """Approximate the Roche lobe radius from [1]_.
 
     Parameters
     ----------
-    q : float
-        Dimensionless mass ratio = MRL/Mcomp, where
-        MRL is the mass of the star we calculate the RL and
-        Mcomp is the mass of its companion star.
+    m1 : float
+        the mass of the star for which we calculate the Roche lobe
+    m2: float
+        the mass of the companion star
     a_orb : float
         Orbital separation. The return value will have the same unit.
 
@@ -228,6 +228,20 @@ def roche_lobe_radius(q, a_orb=1):
     .. [1] Eggleton, P. P. 1983, ApJ, 268, 368
 
     """
+
+    if isinstance(a_orb, np.ndarray):
+        Pwarn("Trying to compute RL radius for binary with no separation", "EvolutionWarning")
+        a_orb = np.nan
+                          
+    if m1 <=0:
+        Pwarn("Trying to compute RL radius for binary with nonexistent companion", "EvolutionWarning")
+        m1 = np.nan
+
+    if m2 <=0:
+        Pwarn("Trying to compute RL radius for binary with nonexistent companion", "EvolutionWarning")
+        m2 = np.nan
+
+    q = m1/m2
     RL = a_orb * (0.49 * q**(2. / 3.)) / (
         0.6 * q**(2. / 3.) + np.log(1 + q**(1. / 3))
     )

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -195,52 +195,54 @@ def rzams(m, z=0.02, Zsun=0.02):
     return r
 
 
-'''
-
-
-Receives:
-q ->
-a_orb ->
-
-Returns:
-RL -> Roche lobe radius in similar units as a_orb
-'''
-
-
 def roche_lobe_radius(m1, m2, a_orb=1):
     """Approximate the Roche lobe radius from [1]_.
 
     Parameters
     ----------
-    m1 : float
+    m1 : float, array of floats
         the mass of the star for which we calculate the Roche lobe
-    m2: float
+    m2 : float, array of floats
         the mass of the companion star
-    a_orb : float
+    a_orb : float, array of floats
         Orbital separation. The return value will have the same unit.
 
     Returns
     -------
-    float
+    float, array of floats
         Roche lobe radius in similar units as a_orb
     References
     ----------
     .. [1] Eggleton, P. P. 1983, ApJ, 268, 368
 
     """
-
-    if isinstance(a_orb, np.ndarray):
+    
+    ## catching if a_orb is an empty array or is an array with invalid separation values
+    if isinstance(a_orb, np.ndarray) and (not np.any(a_orb) or np.any(a_orb <=0)):
+        Pwarn("Trying to compute RL radius for binary with no separation", "EvolutionWarning")
+        a_orb = np.full_like(a_orb, np.nan)
+    ## catching if a_orb is a float with invalid separation value
+    elif a_orb <=0: 
         Pwarn("Trying to compute RL radius for binary with no separation", "EvolutionWarning")
         a_orb = np.nan
-                          
-    if m1 <=0:
-        Pwarn("Trying to compute RL radius for binary with nonexistent companion", "EvolutionWarning")
-        m1 = np.nan
 
-    if m2 <=0:
-        Pwarn("Trying to compute RL radius for binary with nonexistent companion", "EvolutionWarning")
+
+    if isinstance(m1, np.ndarray) and (not np.any(m1) or np.any(m1 <=0)):                    
+        Pwarn("Trying to compute RL radius for nonexistent object", "EvolutionWarning")
+        m1 = np.full_like(m1, np.nan)
+    elif m1 <=0:
+        Pwarn("Trying to compute RL radius for nonexistent object", "EvolutionWarning")
+        m1 = np.nan
+    
+
+    if isinstance(m2, np.ndarray) and (not np.any(m2) or np.any(m2 <=0)):                    
+        Pwarn("Trying to compute RL radius for nonexistent companion", "EvolutionWarning")
+        m2 = np.full_like(m2, np.nan)
+    elif m2 <=0:
+        Pwarn("Trying to compute RL radius for nonexistent companion", "EvolutionWarning")
         m2 = np.nan
 
+    
     q = m1/m2
     RL = a_orb * (0.49 * q**(2. / 3.)) / (
         0.6 * q**(2. / 3.) + np.log(1 + q**(1. / 3))

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -200,16 +200,16 @@ def roche_lobe_radius(m1, m2, a_orb=1):
 
     Parameters
     ----------
-    m1 : float, array of floats
+    m1 : float, ndarray of floats
         the mass of the star for which we calculate the Roche lobe
-    m2 : float, array of floats
+    m2 : float, ndarray of floats
         the mass of the companion star
-    a_orb : float, array of floats
+    a_orb : float, ndarray of floats
         Orbital separation. The return value will have the same unit.
 
     Returns
     -------
-    float, array of floats
+    float, ndarray of floats
         Roche lobe radius in similar units as a_orb
     References
     ----------
@@ -218,26 +218,40 @@ def roche_lobe_radius(m1, m2, a_orb=1):
     """
     
     ## catching if a_orb is an empty array or is an array with invalid separation values
-    if isinstance(a_orb, np.ndarray) and (not np.any(a_orb) or np.any(a_orb <=0)):
-        Pwarn("Trying to compute RL radius for binary with no separation", "EvolutionWarning")
-        a_orb = np.full_like(a_orb, np.nan)
+    if isinstance(a_orb, np.ndarray):
+        ## if array is empty (or all zeros), fill with NaN values
+        if a_orb.size == 0:
+            Pwarn("Trying to compute RL radius for binary with invalid separation", "EvolutionWarning")
+            a_orb = np.full_like(a_orb, np.nan, dtype=np.float64)
+        ## if array contains invalid values, replace with NaN 
+        elif np.any(a_orb < 0):
+            Pwarn("Trying to compute RL radius for binary with invalid separation", "EvolutionWarning")
+            a_orb[a_orb < 0] = np.nan
     ## catching if a_orb is a float with invalid separation value
     elif a_orb <=0: 
-        Pwarn("Trying to compute RL radius for binary with no separation", "EvolutionWarning")
+        Pwarn("Trying to compute RL radius for binary with invalid separation", "EvolutionWarning")
         a_orb = np.nan
 
 
-    if isinstance(m1, np.ndarray) and (not np.any(m1) or np.any(m1 <=0)):                    
-        Pwarn("Trying to compute RL radius for nonexistent object", "EvolutionWarning")
-        m1 = np.full_like(m1, np.nan)
+    if isinstance(m1, np.ndarray):
+        if m1.size == 0:                  
+            Pwarn("Trying to compute RL radius for nonexistent object", "EvolutionWarning")
+            m1 = np.full_like(m1, np.nan, dtype=np.float64)
+        elif np.any(m1 <= 0):
+            Pwarn("Trying to compute RL radius for nonexistent object", "EvolutionWarning")
+            m1[m1 <= 0] = np.nan
     elif m1 <=0:
         Pwarn("Trying to compute RL radius for nonexistent object", "EvolutionWarning")
         m1 = np.nan
     
 
-    if isinstance(m2, np.ndarray) and (not np.any(m2) or np.any(m2 <=0)):                    
-        Pwarn("Trying to compute RL radius for nonexistent companion", "EvolutionWarning")
-        m2 = np.full_like(m2, np.nan)
+    if isinstance(m2, np.ndarray):
+        if m2.size == 0:                  
+            Pwarn("Trying to compute RL radius for nonexistent companion", "EvolutionWarning")
+            m2 = np.full_like(m2, np.nan, dtype=np.float64)
+        elif np.any(m2 <= 0):
+            Pwarn("Trying to compute RL radius for nonexistent companion", "EvolutionWarning")
+            m2[m2 <= 0] = np.nan
     elif m2 <=0:
         Pwarn("Trying to compute RL radius for nonexistent companion", "EvolutionWarning")
         m2 = np.nan

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -13,6 +13,7 @@ __authors__ = [
     "Scott Coughlin <scottcoughlin2014@u.northwestern.edu>",
     "Kyle Akira Rocha <kylerocha2024@u.northwestern.edu>",
     "Matthias Kruckow <Matthias.Kruckow@unige.ch>",
+    "Camille Liotine <cliotine@u.northwestern.edu>",
 ]
 
 
@@ -222,7 +223,7 @@ def roche_lobe_radius(m1, m2, a_orb=1):
         ## if array is empty, fill with NaN values
         if a_orb.size == 0:
             Pwarn("Trying to compute RL radius for binary with invalid separation", "EvolutionWarning")
-            a_orb = np.full_like(a_orb, np.nan, dtype=np.float64)
+            a_orb = np.full_like(a_orb.shape, np.nan, dtype=np.float64)
         ## if array contains invalid values, replace with NaN 
         elif np.any(a_orb < 0):
             Pwarn("Trying to compute RL radius for binary with invalid separation", "EvolutionWarning")
@@ -236,7 +237,7 @@ def roche_lobe_radius(m1, m2, a_orb=1):
     if isinstance(m1, np.ndarray):
         if m1.size == 0:                  
             Pwarn("Trying to compute RL radius for nonexistent object", "EvolutionWarning")
-            m1 = np.full_like(m1, np.nan, dtype=np.float64)
+            m1 = np.full_like(m1.shape, np.nan, dtype=np.float64)
         elif np.any(m1 <= 0):
             Pwarn("Trying to compute RL radius for nonexistent object", "EvolutionWarning")
             m1[m1 <= 0] = np.nan
@@ -248,7 +249,7 @@ def roche_lobe_radius(m1, m2, a_orb=1):
     if isinstance(m2, np.ndarray):
         if m2.size == 0:                  
             Pwarn("Trying to compute RL radius for nonexistent companion", "EvolutionWarning")
-            m2 = np.full_like(m2, np.nan, dtype=np.float64)
+            m2 = np.full_like(m2.shape, np.nan, dtype=np.float64)
         elif np.any(m2 <= 0):
             Pwarn("Trying to compute RL radius for nonexistent companion", "EvolutionWarning")
             m2[m2 <= 0] = np.nan

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -217,13 +217,12 @@ def roche_lobe_radius(m1, m2, a_orb=1):
     .. [1] Eggleton, P. P. 1983, ApJ, 268, 368
 
     """
-    
     ## catching if a_orb is an empty array or is an array with invalid separation values
     if isinstance(a_orb, np.ndarray):
         ## if array is empty, fill with NaN values
         if a_orb.size == 0:
             Pwarn("Trying to compute RL radius for binary with invalid separation", "EvolutionWarning")
-            a_orb = np.full_like(a_orb.shape, np.nan, dtype=np.float64)
+            a_orb = np.full([1 if s==0 else s for s in a_orb.shape], np.nan, dtype=np.float64)
         ## if array contains invalid values, replace with NaN 
         elif np.any(a_orb < 0):
             Pwarn("Trying to compute RL radius for binary with invalid separation", "EvolutionWarning")
@@ -237,7 +236,7 @@ def roche_lobe_radius(m1, m2, a_orb=1):
     if isinstance(m1, np.ndarray):
         if m1.size == 0:                  
             Pwarn("Trying to compute RL radius for nonexistent object", "EvolutionWarning")
-            m1 = np.full_like(m1.shape, np.nan, dtype=np.float64)
+            m1 = np.full([1 if s==0 else s for s in m1.shape], np.nan, dtype=np.float64)
         elif np.any(m1 <= 0):
             Pwarn("Trying to compute RL radius for nonexistent object", "EvolutionWarning")
             m1[m1 <= 0] = np.nan
@@ -249,15 +248,14 @@ def roche_lobe_radius(m1, m2, a_orb=1):
     if isinstance(m2, np.ndarray):
         if m2.size == 0:                  
             Pwarn("Trying to compute RL radius for nonexistent companion", "EvolutionWarning")
-            m2 = np.full_like(m2.shape, np.nan, dtype=np.float64)
+            m2 = np.full([1 if s==0 else s for s in m2.shape], np.nan, dtype=np.float64)
         elif np.any(m2 <= 0):
             Pwarn("Trying to compute RL radius for nonexistent companion", "EvolutionWarning")
             m2[m2 <= 0] = np.nan
     elif m2 <=0:
         Pwarn("Trying to compute RL radius for nonexistent companion", "EvolutionWarning")
         m2 = np.nan
-
-    
+   
     q = m1/m2
     RL = a_orb * (0.49 * q**(2. / 3.)) / (
         0.6 * q**(2. / 3.) + np.log(1 + q**(1. / 3))

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -219,7 +219,7 @@ def roche_lobe_radius(m1, m2, a_orb=1):
     
     ## catching if a_orb is an empty array or is an array with invalid separation values
     if isinstance(a_orb, np.ndarray):
-        ## if array is empty (or all zeros), fill with NaN values
+        ## if array is empty, fill with NaN values
         if a_orb.size == 0:
             Pwarn("Trying to compute RL radius for binary with invalid separation", "EvolutionWarning")
             a_orb = np.full_like(a_orb, np.nan, dtype=np.float64)
@@ -228,7 +228,7 @@ def roche_lobe_radius(m1, m2, a_orb=1):
             Pwarn("Trying to compute RL radius for binary with invalid separation", "EvolutionWarning")
             a_orb[a_orb < 0] = np.nan
     ## catching if a_orb is a float with invalid separation value
-    elif a_orb <=0: 
+    elif a_orb < 0: 
         Pwarn("Trying to compute RL radius for binary with invalid separation", "EvolutionWarning")
         a_orb = np.nan
 


### PR DESCRIPTION
This PR adds catching for invalid inputs to four highly used RLO functions in the detached step. With the POSYDON warnings PR, python warnings are no longer suppressed when running binary populations, and these functions are throwing a lot of python warnings (for divide-by-zero, etc.) that should not occur. Thus the error files for running populations are large without this fix.
This PR should not be accepted until the POSYDON warnings PR is accepted, so that the warnings added here can be correctly integrated into the code with the new warnings framework.