### PR TITLE
Population() fix for large memory usage when reading files

### DIFF
--- a/posydon/interpolation/interpolation.py
+++ b/posydon/interpolation/interpolation.py
@@ -603,6 +603,9 @@ class GRIDInterpolator():
                 kvalue_low = self.grid_final_values[mass_low][key]
 
             while (kvalue_low is None or np.isnan(kvalue_low)):
+                # escape if no lower mass is available
+                if np.sum(mass_low > self.grid_mass) == 0:
+                    break
                 mass_low = np.max(self.grid_mass[mass_low > self.grid_mass])
                 try:
                     kvalue_low = self.grid_final_values[mass_low][key]
@@ -617,6 +620,9 @@ class GRIDInterpolator():
                 kvalue_high = self.grid_final_values[mass_high][key]
 
             while (kvalue_high is None or np.isnan(kvalue_high)):
+                # escape if no higher mass is available
+                if np.sum(mass_high < self.grid_mass) == 0:
+                    break
                 mass_high = np.min(self.grid_mass[mass_high < self.grid_mass])
                 try:
                     kvalue_high = self.grid_final_values[mass_high][key]

--- a/posydon/popsyn/synthetic_population.py
+++ b/posydon/popsyn/synthetic_population.py
@@ -706,9 +706,9 @@ class Oneline(DFInterface):
                 chunk = self.number_of_systems
             else:
                 chunk = key.stop - pre
-            return pd.read_hdf(
-                self.filename, key="oneline", start=pre, stop=pre + chunk
-            )            
+            indices = list(range(pre, pre + chunk))
+            return self.select(where=f'index in {indices}')
+        
         elif isinstance(key, int):
             return self.select(where=f"index == {key}")
         elif isinstance(key, list) and all(isinstance(x, int) for x in key):

--- a/posydon/popsyn/synthetic_population.py
+++ b/posydon/popsyn/synthetic_population.py
@@ -731,7 +731,7 @@ class Oneline(DFInterface):
                 raise ValueError(f"{key} is not a valid column!")
         elif isinstance(key, list) and all(isinstance(x, str) for x in key):
             if all(x in self.columns for x in key):
-                self.select(columns=key)
+                return self.select(columns=key)
             else:
                 raise ValueError(f"Not all columns in {key} are valid column names!")
         else:

--- a/posydon/popsyn/synthetic_population.py
+++ b/posydon/popsyn/synthetic_population.py
@@ -592,6 +592,7 @@ class History(DFInterface):
         ----------
         where : str, optional
             A string representing the query condition to apply to the data.
+            It is only possible to query on the index or string columns. 
         start : int, optional
             The starting index of the data to select.
         stop : int, optional
@@ -810,7 +811,8 @@ class Oneline(DFInterface):
         Parameters
         ----------
         where : str, optional
-            A condition to filter the rows of the oneline table. Default is None.
+            A condition to filter the rows of the oneline table. Default is None. 
+            It is only possible to query on the index or string columns. 
         start : int, optional
             The starting index of the subset. Default is None.
         stop : int, optional
@@ -826,7 +828,7 @@ class Oneline(DFInterface):
         Examples
         --------
         # Select rows based on a condition
-        >>> df = Oneline.select(where="S2_mass_i > 30")
+        >>> df = Oneline.select(where="event == 'ZAMS'")
 
         # Select rows from index 10 to 20
         >>> df = Oneline.select(start=10, stop=20)
@@ -1834,13 +1836,14 @@ class TransientPopulation(Population):
         """
         Select a subset of the transient population.
 
-        This method allows you to filter and extract a subset of rows from the oneline table stored in an HDF file.
+        This method allows you to filter and extract a subset of rows from the transient table stored in an HDF file.
         You can specify conditions to filter the rows, define the range of rows to select, and choose specific columns to include in the subset.
 
         Parameters
         ----------
         where : str, optional
-            A condition to filter the rows of the oneline table. Default is None.
+            A condition to filter the rows of the transient table. Default is None.
+            It is only possible to search on the index or string columns.
         start : int, optional
             The starting index of the subset. Default is None.
         stop : int, optional
@@ -1851,12 +1854,12 @@ class TransientPopulation(Population):
         Returns
         -------
         pd.DataFrame
-            The selected subset of the oneline table.
+            The selected subset of the transient table.
 
         Examples
         --------
         # Select rows based on a condition
-        >>> df = transpop.select(where="S2_mass_i > 30")
+        >>> df = transpop.select(where="S1_state == 'BH'")
 
         # Select rows from index 10 to 20
         >>> df = transpop.select(start=10, stop=20)

--- a/posydon/popsyn/synthetic_population.py
+++ b/posydon/popsyn/synthetic_population.py
@@ -227,8 +227,9 @@ class PopulationRunner:
 class DFInterface:
     """A class to handle the interface between the population file and the History and Oneline classes."""
     
-    def __init__():
-        pass
+    def __init__(self):
+        self.filename = None
+        self.chunksize = None
 
     def head(self, key, n=10):
         """Return the first n rows of the key table
@@ -292,13 +293,46 @@ class DFInterface:
         '''
         # we have to chunk the read because of memory issues
         with pd.HDFStore(self.filename, mode="r") as store:
-            iterator = store.select("history", where=where, start=start, stop=stop, columns=columns, chunksize=self.chunksize)
+            iterator = store.select(key, where=where, start=start, stop=stop, columns=columns, chunksize=self.chunksize)
             # read the data in chunks and concatenate once (faster than concat every chunk!)
             out = []
             for chunk in iterator:
                 out.append(chunk)
             out = pd.concat(out, axis=0)
         return out
+    
+    def get_repr(self, key):
+        '''Return a string representation of the key table.
+        
+        Parameters
+        ----------
+        key : str
+            The key of the table to return the string representation of.
+            
+        Returns
+        -------
+        str
+            The string representation of the key table.
+        
+        '''
+        with pd.HDFStore(self.filename, mode="r") as store:
+            return store.select(key, start=0, stop=10).__repr__()
+        
+    def get_html_repr(self, key):
+        """Return the HTML representation of the key table.
+        
+        Parameters
+        ----------
+        key : str
+            The key of the table to return the HTML representation of.
+            
+        Returns
+        -------
+        str
+            The HTML representation of the key table.
+        """
+        with pd.HDFStore(self.filename, mode="r") as store:
+            return store.select(key, start=0, stop=10)._repr_html_()
 
 
 class History(DFInterface):
@@ -528,8 +562,7 @@ class History(DFInterface):
         Returns:
             str: A string representation of the object.
         """
-        with pd.HDFStore(self.filename, mode="r") as store:
-            return store.select("history", start=0, stop=10).__repr__()
+        return super().get_repr("history")
         
     def _repr_html_(self):
         """Return the HTML representation of the history dataframe.
@@ -543,8 +576,7 @@ class History(DFInterface):
         str
             The HTML representation of the history dataframe.
         """
-        with pd.HDFStore(self.filename, mode="r") as store:
-            return store.select("history", start=0, stop=10)._repr_html_()
+        return super().get_html_repr("history")
 
     def select(self, where=None, start=None, stop=None, columns=None):
         """Select a subset of the history table based on the given conditions.
@@ -756,8 +788,7 @@ class Oneline(DFInterface):
         str
             The string representation of the oneline table.
         """
-        with pd.HDFStore(self.filename, mode="r") as store:
-            return store.select("oneline", start=0, stop=10).__repr__()
+        return super().get_repr("oneline")
 
     def _repr_html_(self):
         """
@@ -768,8 +799,7 @@ class Oneline(DFInterface):
         str
             The HTML representation of the oneline table.
         """
-        with pd.HDFStore(self.filename, mode="r") as store:
-            return store.select("oneline", start=0, stop=10)._repr_html_()
+        return super().get_html_repr("oneline")
 
     def select(self, where=None, start=None, stop=None, columns=None):
         """Select a subset of the oneline table based on the given conditions.


### PR DESCRIPTION
When using pd.read_hdf(), pandas reads in the complete Dataframe into memory in a weird way that uses much more memory than even the file is (~14GB of RAM usage for a 3GB file).
This issue originated from the choice that we made for `data_columns=False`. 

This PR does the following:
1. Create a new class `DFInterface` for interfacing with the Oneline and History dataframes in the file.
     - Contains the `select()`, `head()` and `tail()` functions that are the same for both above systems
     - More can be generalised, but I wasn't sure how to generalise a built-in function and give it an input, that is `self.__repr__`. (added) 
2. The new select function reads the file in chunks and concatenates the result. This limits the total memory usage to the given chunksize. The default parameters on my machine use about 3.6GB, but usage varies a bit.
3. The `History` and `Oneline` class now use `self.select` in the `__getitem__` function to read data from the file. (except for history[boolean_mask], I couldn't find a good way to implement this with the `self.select`)

NOTE: contains PR #385 

and should fix Issue: #353