### PR TITLE
Initial RLO boundary limit

### DIFF
--- a/posydon/grids/termination_flags.py
+++ b/posydon/grids/termination_flags.py
@@ -36,6 +36,7 @@ from posydon.visualization.combine_TF import (
     TF1_POOL_STABLE, TF1_POOL_UNSTABLE, TF1_POOL_INITIAL_RLO, TF1_POOL_ERROR,
     TF2_POOL_NO_RLO, TF2_POOL_INITIAL_RLO
 )
+from posydon.utils.posydonwarning import Pwarn
 
 
 # variables needed for inferring star states
@@ -349,6 +350,8 @@ def get_nearest_known_initial_RLO(mass1, mass2, known_initial_RLO):
                "period_days": 0.0,
               }
     if len(known_initial_RLO)<MIN_COUNT_INITIAL_RLO_BOUNDARY:
+        Pwarn("Don't apply initial RLO boundary because of too few data points"
+              " in there.","InappropriateValueWarning")
         return nearest
     for sys in known_initial_RLO:
         #search for a known system with closest mass combination

--- a/posydon/grids/termination_flags.py
+++ b/posydon/grids/termination_flags.py
@@ -29,7 +29,8 @@ from posydon.utils.common_functions import (
     infer_star_state, cumulative_mass_transfer_flag, infer_mass_transfer_case
 )
 from posydon.utils.limits_thresholds import (
-    RL_RELATIVE_OVERFLOW_THRESHOLD, LG_MTRANSFER_RATE_THRESHOLD
+    RL_RELATIVE_OVERFLOW_THRESHOLD, LG_MTRANSFER_RATE_THRESHOLD,
+    MIN_COUNT_INITIAL_RLO_BOUNDARY
 )
 from posydon.visualization.combine_TF import (
     TF1_POOL_STABLE, TF1_POOL_UNSTABLE, TF1_POOL_INITIAL_RLO, TF1_POOL_ERROR,
@@ -324,12 +325,31 @@ def get_detected_initial_RLO(grid):
 
 
 def get_nearest_known_initial_RLO(mass1, mass2, known_initial_RLO):
+    """Find the nearest system of initial RLO in the known ones
+    
+    Parameters
+    ----------
+    mass1 : float
+        star_1_mass of the run to check.
+    mass2 : float
+        star_2_mass of the run to check.
+    known_initial_RLO : list of dict
+        Boundary to apply.
+    
+    Retruns
+    -------
+    dict
+        Containing the key parameters (e.g. initial masses, period) of the
+        nearest initial RLO run.
+    """
     #default values
     d2min = 1.0e+99
     nearest = {"star_1_mass": 0.0,
                "star_2_mass": 0.0,
                "period_days": 0.0,
               }
+    if len(known_initial_RLO)<MIN_COUNT_INITIAL_RLO_BOUNDARY:
+        return nearest
     for sys in known_initial_RLO:
         #search for a known system with closest mass combination
         #use distance^2=(delta mass1)^2+(delta mass2)^2

--- a/posydon/utils/limits_thresholds.py
+++ b/posydon/utils/limits_thresholds.py
@@ -17,6 +17,10 @@ RL_RELATIVE_OVERFLOW_THRESHOLD = 0.00  # relative overflow threshold
 # This needs to be aligned with run_binary_extras.f
 # old: LG_MTRANSFER_RATE_THRESHOLD = -12
 LG_MTRANSFER_RATE_THRESHOLD = -10      # mass-transfer rate threshold (in Lsol)
+# Numerical limit from the number of datapoints the automatically detected
+# boundary for initial RLO: the value should be ≳3 (geometrical arguments) and
+# <<1000 (well below grid size).
+MIN_COUNT_INITIAL_RLO_BOUNDARY = 5
 
 
 # CONSTANTS RELATED TO INFERRING STAR STATES

--- a/posydon/utils/limits_thresholds.py
+++ b/posydon/utils/limits_thresholds.py
@@ -20,7 +20,7 @@ LG_MTRANSFER_RATE_THRESHOLD = -10      # mass-transfer rate threshold (in Lsol)
 # Numerical limit from the number of datapoints the automatically detected
 # boundary for initial RLO: the value should be ≳3 (geometrical arguments) and
 # <<1000 (well below grid size).
-MIN_COUNT_INITIAL_RLO_BOUNDARY = 5
+MIN_COUNT_INITIAL_RLO_BOUNDARY = 20
 
 
 # CONSTANTS RELATED TO INFERRING STAR STATES


### PR DESCRIPTION
In the latest reruns we have seen that there are some issues with the automatic detection of the boundary of initial RLO, if there aren't enough successful runs to determine the boundary well. Usually, this coincides with having a very low number of initial RLO systems, too. Thus, this PR introduces a limit on the count of data points required in the initial RLO boundary.

- [x] Add new threshold
- [x] Apply threshold in `get_nearest_known_initial_RLO`
- [x] Further additions:
  - Update doc string
  - Add POSYDON warning
- [x] Testing: it works with a value of 20

Drawback: the threshold value might not be always a good choice and would need readoptions. 
There is an alternative solutions in PR #395 . This has a different drawback by solving the problem in a different way.