### PR TITLE
remove failed binary states from flow chart

### DIFF
--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -105,7 +105,7 @@ class DoubleCO:
 
         if s.status == -1:
             binary.state += ' (Integration failure)'
-            raise NumericalError("Integrations failed: " + s.message)
+            raise NumericalError("Integration failed: " + s.message)
 
         elif s.status == 1:
 

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -104,8 +104,9 @@ class DoubleCO:
             t_final = [t_inspiral]
 
         if s.status == -1:
-            binary.state += ' (Integration failure)'
-            raise NumericalError("Integration failed: " + s.message)
+            failed_state = binary.state
+            set_binary_to_failed(binary)
+            raise NumericalError(f"Integration failed for {failed_state} DCO!")
 
         elif s.status == 1:
 

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -106,7 +106,7 @@ class DoubleCO:
         if s.status == -1:
             failed_state = binary.state
             set_binary_to_failed(binary)
-            raise NumericalError(f"Integration failed for {failed_state} DCO!")
+            raise NumericalError(f"Integration failed for {failed_state} DCO ({self.state1}, {self.state2}): ", s.message)
 
         elif s.status == 1:
 

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -1174,11 +1174,16 @@ class detached_step:
 
 
         if interp1d_sec is None or interp1d_pri is None:
-            # binary.event = "END"
-            binary.state += " (GridMatchingFailed)"
-            if self.verbose or self.verbose == 1:
-                print("Failed matching")
-            return
+
+            if binary.state in ['detached', 'disrupted', 'merged']:
+                binary.state += " (GridMatchingFailed)"
+                if self.verbose or self.verbose == 1:
+                    print("Failed matching")
+                return       
+            else:
+                raise ValueError("need to add new binary state to flow chart for evolution to end correctly ",
+                                "when grid matching fails: ", binary.state," (GridMatchingFailed)")           
+                   
         t0_sec = interp1d_sec["t0"]
         t0_pri = interp1d_pri["t0"]
         m01 = interp1d_sec["m0"]
@@ -1503,10 +1508,13 @@ class detached_step:
                 print("solution of ODE", s)
             if s.status == -1:
                 print("Integration failed", s.message)
-                binary.state += ' (Integration failure)'
-                # binary.event = "END"
+
+                if binary.state in ['detached']:
+                    binary.state += ' (Integration failure)'
+                else:
+                    raise ValueError("need to add new binary state to flow chart for evolution to end correctly ",
+                                "when detached integration fails: ", binary.state, " (Integration failure)")
                 return
-                # raise RuntimeError("Integration failed", s.message)
 
             if self.dt is not None and self.dt > 0:
                 t = np.arange(binary.time, s.t[-1] + self.dt/2.0, self.dt)[1:]

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -1506,15 +1506,17 @@ class detached_step:
                 print("ODE solver duration: "
                       f"{t_after_ODEsolution-t_before_ODEsolution:.6g}")
                 print("solution of ODE", s)
-            if s.status == -1:
-                print("Integration failed", s.message)
 
+            if s.status == -1:
+                if self.verbose:
+                    print("Integration failed", s.message)
+                    
                 if binary.state in ['detached']:
-                    binary.state += ' (Integration failure)'
+                    binary.state += ' (Integration failure)'                   
+                    return
                 else:
                     raise ValueError("need to add new binary state to flow chart for evolution to end correctly ",
-                                "when detached integration fails: ", binary.state, " (Integration failure)")
-                return
+                                "when detached integration fails: ", binary.state, " (Integration failure)")                
 
             if self.dt is not None and self.dt > 0:
                 t = np.arange(binary.time, s.t[-1] + self.dt/2.0, self.dt)[1:]

--- a/posydon/binary_evol/flow_chart.py
+++ b/posydon/binary_evol/flow_chart.py
@@ -229,9 +229,9 @@ for s1 in STAR_STATES_CO:
 
 
 # catch states to be ended
-for b in ['initial_RLOF',
+for b in ['initial_RLOF', 'RLO2 (OutsideGrid)'
           'detached (Integration failure)',
-          'detached (GridMatchingFailed)', 'RLO2 (OutsideGrid)']:
+          'detached (GridMatchingFailed)', 'disrupted (GridMatchingFailed)', 'merged (GridMatchingFailed)']:    
     for s1 in STAR_STATES_ALL:
         for s2 in STAR_STATES_ALL:
             for e in BINARY_EVENTS_ALL:

--- a/posydon/binary_evol/flow_chart.py
+++ b/posydon/binary_evol/flow_chart.py
@@ -229,9 +229,7 @@ for s1 in STAR_STATES_CO:
 
 
 # catch states to be ended
-for b in ['initial_RLOF', 'RLO2 (OutsideGrid)'
-          'detached (Integration failure)',
-          'detached (GridMatchingFailed)', 'disrupted (GridMatchingFailed)', 'merged (GridMatchingFailed)']:    
+for b in ['initial_RLOF']:    
     for s1 in STAR_STATES_ALL:
         for s2 in STAR_STATES_ALL:
             for e in BINARY_EVENTS_ALL:

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -77,7 +77,6 @@ saved_ini_parameters = ['metallicity',
                    'eccentricity_scheme']
 
 
-# 'event' usually 10 but 'detached (Integration failure)' can occur
 HISTORY_MIN_ITEMSIZE = {'state': 30, 'event': 25, 'step_names': 21,
                         'S1_state': 31, 'S2_state': 31,
                         'mass_transfer_case': 16,


### PR DESCRIPTION
This addresses part of Issue #388.
There are some binary states missing from the flow chart because the binary state strings are being created dynamically. This is causing some binaries to fail and throw errors.
This PR adds the missing states to the flow chart and adds checks to make sure that states exist in the flow chart before the binary state string is updated.
After looking into it, I believe this is the best workaround because it would be cumbersome and generally not good coding practice to have dynamically-matched keys for some binary states in the flow chart, unless we want to change the data structure of the entire flow chart.

One question: in the detached step, if there is an integration failure, we send it to step_end. However, in step_dco, if there is an integration failure, we raise a NumericalError. Is this the behavior we want? As someone who did not write this code it appears inconsistent to me.