### PR TITLE
add catch to suppress python warning in detached step

### DIFF
--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -1690,7 +1690,7 @@ class detached_step:
                         current_omega = interp1d_sec["omega"][-1]
 
                         ## add a warning catch if the current omega has an invalid value
-                        ## (otherwise python will throw a warning when taking the log)
+                        ## (otherwise python will throw an insuppressible warning when taking the log)
                         if interp1d_sec["omega"][-1] <=0:
                             Pwarn("Trying to compute log angular momentum for object with no spin", "EvolutionWarning")
                             current_omega = np.nan

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -1686,9 +1686,17 @@ class detached_step:
                                     const.msol * const.rsol ** 2)
                             
                     elif (key in ["log_total_angular_momentum"] and obj == secondary):
+
+                        current_omega = interp1d_sec["omega"][-1]
+
+                        ## add a warning catch if the current omega has an invalid value
+                        ## (otherwise python will throw a warning when taking the log)
+                        if interp1d_sec["omega"][-1] <=0:
+                            Pwarn("Trying to compute log angular momentum for object with no spin", "EvolutionWarning")
+                            current_omega = np.nan
                                                
                         current = np.log10(
-                            (interp1d_sec["omega"][-1] / const.secyer)
+                            (current_omega / const.secyer)
                                 * (interp1d_sec[
                                     self.translate["total_moment_of_inertia"]](t[-1] - t_offset_sec).item() * 
                                     (const.msol * const.rsol ** 2)))                     

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -1692,7 +1692,7 @@ class detached_step:
                         ## add a warning catch if the current omega has an invalid value
                         ## (otherwise python will throw an insuppressible warning when taking the log)
                         if interp1d_sec["omega"][-1] <=0:
-                            Pwarn("Trying to compute log angular momentum for object with no spin", "EvolutionWarning")
+                            Pwarn("Trying to compute log angular momentum for object with no spin", "InappropriateValueWarning")
                             current_omega = np.nan
                                                
                         current = np.log10(


### PR DESCRIPTION
There is one line of code in the detached step that is throwing an insuppressible python warning when running a binary population. The warnings appears for a majority of the binaries:
```
/home/cel2717/.conda/envs/posydon-source/lib/python3.11/site-packages/posydon/binary_evol/DT/step_detached.py:1698:
RuntimeWarning: invalid value encountered in log10
  current = np.log10(
```
This PR adds a catch for the value causing this problem and changes it to NaN so that we can suppress the warning with a POSYDON warning. I have run a population with the fix and it is working.