### PR TITLE
Add default value for orbital_scheme

### DIFF
--- a/posydon/popsyn/independent_sample.py
+++ b/posydon/popsyn/independent_sample.py
@@ -17,13 +17,13 @@ from scipy.stats import truncnorm
 from posydon.utils.common_functions import rejection_sampler
 
 
-def generate_independent_samples(orbital_scheme, **kwargs):
+def generate_independent_samples(orbital_scheme='period', **kwargs):
     """Randomly generate a population of binaries at ZAMS.
 
     Parameters
     ----------
-    number_of_binaries : int
-        Number of binaries that require randomly sampled orbital separations
+    orbital_scheme : str (default: 'period')
+        The scheme to use to get either orbital periods or separations
     **kwargs : dictionary
         kwargs from BinaryPopulation class
 


### PR DESCRIPTION
We have calls of `generate_independent_samples`, e.g. in `initial_total_underlying_mass` defined in [posydon/popsyn/normalized_pop_mass.py](https://github.com/POSYDON-code/POSYDON/pull/376/files#diff-24878c8b6c024350e3382ceb551ad0f63149174220385926238221ad2d44b7fd) which don't care about the orbit and might be applied to single stars, where we don't have an orbit. Thus, there should be a default value to avoid errors on the orbit, when the user doesn't care about them and therefore didn't specified the values.

- [x] add default value for orbital_scheme to `generate_independent_samples`
- [x] update doc-string of `generate_independent_samples`