### PR TITLE
Revert initial RLO

### DIFF
--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -2241,6 +2241,10 @@ def join_grids(input_paths, output_path,
     if (newconfig["initial_RLO_fix"]):
         say("Determine initial RLO boundary from all grids")
         detected_initial_RLO = []
+        colnames = ["termination_flag_1", "termination_flag_2",
+                    "interpolation_class"]
+        valtoset = ["forced_initial_RLO", "forced_initial_RLO", "initial_MT"]
+        valtounset = ["reach cluster timelimit", "None", "not_converged"]
         for grid in grids:
             new_detected_initial_RLO = get_detected_initial_RLO(grid)
             for new_sys in new_detected_initial_RLO:
@@ -2294,12 +2298,6 @@ def join_grids(input_paths, output_path,
             new_final_values.append(grid.final_values[run_index])
 
             if (newconfig["initial_RLO_fix"]):
-                colnames = ["termination_flag_1", "termination_flag_2",
-                            "interpolation_class"]
-                valtoset = ["forced_initial_RLO", "forced_initial_RLO",
-                            "initial_MT"]
-                valtounset = ["reach cluster timelimit", "None",
-                              "not_converged"]
                 flag1 = new_final_values[-1]["termination_flag_1"]
                 if flag1 != "Terminate because of overflowing initial model":
                     mass1 = new_initial_values[-1]["star_1_mass"]

--- a/posydon/grids/termination_flags.py
+++ b/posydon/grids/termination_flags.py
@@ -324,6 +324,23 @@ def get_detected_initial_RLO(grid):
 
 
 def get_nearest_known_initial_RLO(mass1, mass2, known_initial_RLO):
+    """Find the nearest system of initial RLO in the known ones
+    
+    Parameters
+    ----------
+    mass1 : float
+        star_1_mass of the run to check.
+    mass2 : float
+        star_2_mass of the run to check.
+    known_initial_RLO : list of dict
+        Boundary to apply.
+    
+    Retruns
+    -------
+    dict
+        Containing the key parameters (e.g. initial masses, period) of the
+        nearest initial RLO run.
+    """
     #default values
     d2min = 1.0e+99
     nearest = {"star_1_mass": 0.0,


### PR DESCRIPTION
This is an alternative to PR #389 as suggested by @astroJeff .

- [x] Add the code to reset from `forced_initial_RLO` to `reach cluster timelimit`/`not_converged`
- [x] Further additions:
  - Update doc string
- [ ] to test

Drawback: we'll may mark successful runs as not converged. Hence, we'd need at least two iterations of the last rerun level.