### PR TITLE
Fix hepulse rerun -- point mass variable storage seg. faults

### DIFF
--- a/bin/posydon-run-pipeline
+++ b/bin/posydon-run-pipeline
@@ -702,7 +702,7 @@ def copy_ini_file(grid_type, rerun_metallicity, rerun_type, destination,
     elif rerun_type == 'LBV_wind+dedt_energy_eqn':
         replace_text = "seth_lbv_thermo_dedt-936f76f82d44b16139ff89e41e5b0f2232fd9b30"
     elif rerun_type == 'LBV_wind+dedt_hepulse':
-        replace_text = "seth_lbv_thermo_dedt_hepulse-77640b5f773825129d6e3bf29267e52c90f328a2"
+        replace_text = "seth_lbv_thermo_dedt_hepulse-2737b3bce69066751477c802a6e515183e13d303"
     elif rerun_type == 'no_age_limit':
         replace_text = "matthias_no_age_limit-a119ea9548cca9b6b7ddfe31309ced1ae40c271e"
     elif rerun_type == 'no_age_limit+thermohaline_mixing':


### PR DESCRIPTION
update SHA for hepulse rerun -- fixing seg faults that could occur when storing variables for point masses

link to MESA inlist/src branch: [rerun branch](https://github.com/POSYDON-code/POSYDON-MESA-INLISTS/tree/seth_lbv_thermo_dedt_hepulse)