### PR TITLE
update profile interpolation for consistency with paper

### DIFF
--- a/posydon/interpolation/profile_interpolation.py
+++ b/posydon/interpolation/profile_interpolation.py
@@ -662,7 +662,6 @@ class Composition:
                     hbounds,nonflat_a = calc_bevel_bounds(h_prof)
                     valid_hbounds,valid_nonflat_a = calc_bevel_bounds(valid_h_prof)
                     pbounds,nonflat_p = calc_bevel_bounds(plus_prof)
-                    print(pbounds)
                     valid_pbounds,valid_nonflat_p = calc_bevel_bounds(valid_plus_prof)
                     nonflat = np.intersect1d(nonflat_a,nonflat_p)
                     valid_nonflat = np.intersect1d(valid_nonflat_a,valid_nonflat_p)

--- a/posydon/interpolation/profile_interpolation.py
+++ b/posydon/interpolation/profile_interpolation.py
@@ -350,8 +350,10 @@ class Density:
         Args:
             initial (array-like) : log-space initial conditions for training data.
             profiles (array-like) : final density profiles for training data. 
+            mt (array-like) : mass transfer classes corresponding to training set binaries. 
             valid_initial (array-like) : log-space initial conditions for validation data.
             valid_profiles (array-like) : final density profiles for validation data.
+            valid_mt (array-like): mass transfer classes corresponding to validation set binaries. 
             IF_interpolator (string) : path to .pkl file for IF interpolator for central density, final mass values
             n_comp (int) : number of PCA components. 
             hms_s2 (Boolean) : option to do profiles of star 2 in HMS-HMS grid

--- a/posydon/interpolation/profile_interpolation.py
+++ b/posydon/interpolation/profile_interpolation.py
@@ -161,10 +161,11 @@ class CompileData:
             
 class ProfileInterpolator:
     
-    def __init__(self,seed_value):
+    def __init__(self,seed_value=None):
         """Interfaces with other classes, trains models and predicts profiles.
         Args:
-            seed_value (int) : random seed to ensure consistent results
+            seed_value (None or int) : random seed to ensure consistent results
+                                       default value for Teng+24 is 1234
         """
         if seed_value is not None:
             os.environ['PYTHONHASHSEED']=str(seed_value)

--- a/posydon/interpolation/profile_interpolation.py
+++ b/posydon/interpolation/profile_interpolation.py
@@ -140,11 +140,13 @@ class CompileData:
                           (grid.final_values['S1_surf_avg_omega'][ind]/ \
                            grid.final_values['S1_surf_avg_omega_div_omega_crit'][ind])
         
-        if not pd.isna(grid.final_values['S1_surf_avg_omega_div_omega_crit'][ind]):
-            return scalars, profiles
+            if not pd.isna(grid.final_values['S1_surf_avg_omega_div_omega_crit'][ind]):
+                return scalars, profiles
+            else:
+                Pwarn("nan in final values, binary will not be"
+                      "included in file","IncompletenessWarning")
         else:
-            Pwarn("nan in final values, binary will not be"
-                  "included in file","IncompletenessWarning")
+            return scalars, profiles
 
     def save(self, filename):
         """Save extracted profile data.

--- a/posydon/interpolation/profile_interpolation.py
+++ b/posydon/interpolation/profile_interpolation.py
@@ -143,7 +143,8 @@ class CompileData:
         if not np.isnan(grid.final_values['S1_surf_avg_omega_div_omega_crit'][ind]):
             return scalars, profiles
         else:
-            Pwarn("nan in final values","InappropriateValueWarning")
+            Pwarn("nan in final values, binary will not be"
+                  "included in file","InappropriateValueWarning")
 
     def save(self, filename):
         """Save extracted profile data.
@@ -223,7 +224,7 @@ class ProfileInterpolator:
             width (int) : width of neural network for principal component weights
             depthn (int) : depth of neural network for normalizing value
             widthn (int) : width of neural network for normalizing value
-            lr (float) : learning rate
+            lr (float) : learning rate for neural network training
         Returns:
             self.comp.loss_history (array-like) : training and validation loss history for composition profiles
             self.dens.loss_history (array-like) : training and validation loss history for density profiles

--- a/posydon/interpolation/profile_interpolation.py
+++ b/posydon/interpolation/profile_interpolation.py
@@ -115,12 +115,12 @@ class CompileData:
         # grab input values, final star 1 state, final star 1 mass
         total_mass = df["mass"].iloc[-1]
         
-        scalars = {"m1":grid.initial_values["star_1_mass"][ind],
-                   "m2":grid.initial_values["star_2_mass"][ind],
-                   "p":grid.initial_values["period_days"][ind],
-                   "MT_class":grid.final_values["interpolation_class"][ind],
-                   "star_state":grid.final_values[state_key][ind],
-                   "total_mass":total_mass}
+        scalars = {"m1":[grid.initial_values["star_1_mass"][ind]],
+                   "m2":[grid.initial_values["star_2_mass"][ind]],
+                   "p":[grid.initial_values["period_days"][ind]],
+                   "MT_class":[grid.final_values["interpolation_class"][ind]],
+                   "star_state":[grid.final_values[state_key][ind]],
+                   "total_mass":[total_mass]}
 
         # grab output vectors, interpolate to normalize
         profiles=np.zeros([1+len(self.names),200])

--- a/posydon/interpolation/profile_interpolation.py
+++ b/posydon/interpolation/profile_interpolation.py
@@ -495,8 +495,7 @@ class Density:
         pred_mass = self.interp.test_interpolator(inputs)[:,m_ind]
             
         # reconstruct profile
-        norm_prof = self.pca.inverse_transform(pca_weights_pred*self.scaling)
-        density_profiles = norm_prof*(max_rho[:,np.newaxis]-min_rho[:,np.newaxis]) \
+        density_profiles = pred_profiles*(max_rho[:,np.newaxis]-min_rho[:,np.newaxis]) \
                            + min_rho[:,np.newaxis]
         
         # construct mass enclosed profile coordinates

--- a/posydon/interpolation/profile_interpolation.py
+++ b/posydon/interpolation/profile_interpolation.py
@@ -143,8 +143,8 @@ class CompileData:
         if not pd.isna(grid.final_values['S1_surf_avg_omega_div_omega_crit'][ind]):
             return scalars, profiles
         else:
-            Pwarn("nan in final values, binary will not be"
-                  "included in file","InappropriateValueWarning")
+            Pwarn("nan in final values, binary will not be"dd 
+                  "included in file","IncompletenessWarning")
 
     def save(self, filename):
         """Save extracted profile data.

--- a/posydon/interpolation/profile_interpolation.py
+++ b/posydon/interpolation/profile_interpolation.py
@@ -140,7 +140,7 @@ class CompileData:
                           (grid.final_values['S1_surf_avg_omega'][ind]/ \
                            grid.final_values['S1_surf_avg_omega_div_omega_crit'][ind])
         
-        if not np.isnan(grid.final_values['S1_surf_avg_omega_div_omega_crit'][ind]):
+        if not pd.isna(grid.final_values['S1_surf_avg_omega_div_omega_crit'][ind]):
             return scalars, profiles
         else:
             Pwarn("nan in final values, binary will not be"

--- a/posydon/interpolation/profile_interpolation.py
+++ b/posydon/interpolation/profile_interpolation.py
@@ -669,7 +669,8 @@ class Composition:
                     model.add(layers.Dense(width,input_dim=width,activation="relu"))
                 model.add(layers.Dense(outs,input_dim=10,activation="sigmoid"))
 
-                model.compile(optimizers.Adam(clipnorm=1,learning_rate=learning_rate),loss=losses.MeanSquaredError())
+                model.compile(optimizers.Adam(clipnorm=1,learning_rate=learning_rate),
+                              loss=losses.MeanSquaredError())
                 callback = tf.keras.callbacks.EarlyStopping(monitor='loss', patience=training_patience)
                         
                 history = model.fit(inputs[nonflat],bounds[nonflat],
@@ -704,8 +705,15 @@ class Composition:
             He = np.ones(200)*np.nan
             
         elif star_state == "stripped_He_non_burning":
-            He = np.ones(200)*surface_He # non-burning stars have a flat He profile
-        
+            if surface_He == center_He:
+                He = np.ones(200)*surface_He # non-burning stars have a flat He profile
+            else:
+                Pwarn(f"Non-burning helium star unexpectedly does not have a flat profile. "
+                      "The average of the surface and center helium fraction values "
+                      "will be used to create a flat profile.",
+                      "InappropriateValueWarning")
+                He = np.ones(200)*np.mean([surface_He,center_He])
+            
         elif 'stripped_He_C' in star_state:
             # predicting profile shape parameters 
             b = self.bounds_models[star_state](tf.convert_to_tensor([initial])).numpy()[0]

--- a/posydon/interpolation/profile_interpolation.py
+++ b/posydon/interpolation/profile_interpolation.py
@@ -143,7 +143,7 @@ class CompileData:
         if not pd.isna(grid.final_values['S1_surf_avg_omega_div_omega_crit'][ind]):
             return scalars, profiles
         else:
-            Pwarn("nan in final values, binary will not be"dd 
+            Pwarn("nan in final values, binary will not be"
                   "included in file","IncompletenessWarning")
 
     def save(self, filename):

--- a/posydon/interpolation/profile_interpolation.py
+++ b/posydon/interpolation/profile_interpolation.py
@@ -237,8 +237,8 @@ class ProfileInterpolator:
                                                   Returned second if both models are trained. 
             
         """      
-        self.train_comp==train_comp
-        self.train_density==train_density
+        self.train_comp=train_comp
+        self.train_density=train_density
         
         if train_comp==True:
             # instantiate and train composition (H and He mass fraction) profiles model

--- a/posydon/interpolation/profile_interpolation.py
+++ b/posydon/interpolation/profile_interpolation.py
@@ -279,7 +279,7 @@ class ProfileInterpolator:
     def predict(self,inputs):
         """Predict density, H mass fraction, and He mass fraction profiles from inputs.
         Args:
-            inputs (array-like) : linear-space initial conditions of N binaries to predict, shape (N,3).
+            inputs (array-like) : positive linear-space initial conditions of N binaries to predict, shape (N,3).
             density (Boolean) : option to train Density model
             comp (Boolean) : option to train Composition model
         Returns:
@@ -457,7 +457,7 @@ class Density:
     def predict(self,inputs):
         """Predicts profile for n sets of given inputs, in array of shape (n,3).
         Args: 
-            inputs (array-like) : linear-space initial conditions of N binaries to predict, shape (N,3).
+            inputs (array-like) : positive linear-space initial conditions of N binaries to predict, shape (N,3).
         Returns:
             mass_coords (array-like) : linear-scale mass enclosed profile coordinates.
             density_profiles (array_like) : log-scale density profile coordinates.
@@ -597,7 +597,7 @@ class Composition:
                     bounds.append(np.array([diff[0]+1,diff[-1]+1])/200)
                     nonflat.append(i)
                 else:
-                    bounds.append([np.nan,np.nan])
+                    bounds.append(np.array([np.nan,np.nan]))
             return np.array(bounds), nonflat
         
         for state in ['stripped_He_Core_He_burning',
@@ -801,7 +801,7 @@ class Composition:
     def predict(self,inputs):
         """Predict H mass fraction profiles from inputs.
         Args:
-            inputs (array-like) : linear-space initial conditions of N binaries to predict, shape (N,3).
+            inputs (array-like) : positive linear-space initial conditions of N binaries to predict, shape (N,3).
         Returns:
             mass_coords (array-like) : linear-scale mass enclosed profile coordinates.
             h_profiles (array_like) : H mass fraction profile coordinates.

--- a/posydon/interpolation/profile_interpolation.py
+++ b/posydon/interpolation/profile_interpolation.py
@@ -465,6 +465,8 @@ class Density:
             mass_coords (array-like) : linear-scale mass enclosed profile coordinates.
             density_profiles (array_like) : log-scale density profile coordinates.
         """
+        pred_profiles = np.zeros([len(inputs),200])
+        
         # predict MT class
         pred_mt = self.interp.test_classifiers(inputs)['interpolation_class']
         for mt in self.mt.unique():

--- a/posydon/interpolation/profile_interpolation.py
+++ b/posydon/interpolation/profile_interpolation.py
@@ -705,14 +705,13 @@ class Composition:
             He = np.ones(200)*np.nan
             
         elif star_state == "stripped_He_non_burning":
-            if surface_He == center_He:
-                He = np.ones(200)*surface_He # non-burning stars have a flat He profile
-            else:
-                Pwarn(f"Non-burning helium star unexpectedly does not have a flat profile. "
-                      "The average of the surface and center helium fraction values "
+            if surface_He != center_He:
+                Pwarn("Non-burning helium star unexpectedly does not have a flat profile. "
+                      "The difference in value between the surface and center helium "
+                      f"fraction values is {center_He-surface_He}. Their average "
                       "will be used to create a flat profile.",
                       "InappropriateValueWarning")
-                He = np.ones(200)*np.mean([surface_He,center_He])
+            He = np.ones(200)*np.mean([surface_He,center_He]) # non-burning stars have a flat He profile
             
         elif 'stripped_He_C' in star_state:
             # predicting profile shape parameters 

--- a/posydon/interpolation/profile_interpolation.py
+++ b/posydon/interpolation/profile_interpolation.py
@@ -274,6 +274,7 @@ class ProfileInterpolator:
                 return self.comp.loss_history
             else:
                 PWarn("No models selected for training","IncompletenessWarning")
+                return
     
     def predict(self,inputs):
         """Predict density, H mass fraction, and He mass fraction profiles from inputs.


### PR DESCRIPTION
- [x] update method in CompileData to use pd.concat() instead of append()
- [x] update assignment of total mass to being based on mass profile to avoid inconsistency with final values total mass
- [x] fix definition of omega profile
- [x] added posydon warning for nans in the final values (check with Camille)
- [x] add ability to set random seed to standardize results
- [x] add arguments for customizing neural network size, learning rate
- [x] simplify PCA step
- [x] make models for each MT class in a grid
- [x] add code for customizing neural network size
- [x] log vs linear -- make sure this is consistent with IF interpolator
- [x] update composition method
- [x] separate composition and density training
- [x] address comments from Matthias
