### PR TITLE
Relax number formating for mesa inputs

### DIFF
--- a/bin/posydon-run-grid
+++ b/bin/posydon-run-grid
@@ -262,7 +262,8 @@ def create_binary_inlists(binary_controls, binary_job,
             inlist_grid_points.write("&binary_controls\n")
             for k, v in binary_controls.items():
                 if (type(v) == float) and (not v.is_integer()):
-                    inlist_grid_points.write("\t{0} = {1:.10f}d0\n".format(k, v))
+                    inlist_grid_points.write("\t{0} = ".format(k)+"{0:.10e}\n"\
+                                             .format(v).replace('e','d'))
                 elif (type(v) == float) and (v.is_integer()):
                     inlist_grid_points.write("\t{0} = {1}\n".format(k, int(v)))
                 elif type(v) == bool:
@@ -279,7 +280,8 @@ def create_binary_inlists(binary_controls, binary_job,
             inlist_grid_points.write("&binary_job\n")
             for k, v in binary_job.items():
                 if (type(v) == float) and (not v.is_integer()):
-                    inlist_grid_points.write("\t{0} = {1:.10f}d0\n".format(k, v))
+                    inlist_grid_points.write("\t{0} = ".format(k)+"{0:.10e}\n"\
+                                             .format(v).replace('e','d'))
                 elif (type(v) == float) and (v.is_integer()):
                     inlist_grid_points.write("\t{0} = {1}\n".format(k, int(v)))
                 elif type(v) == bool:
@@ -300,7 +302,8 @@ def create_binary_inlists(binary_controls, binary_job,
             inlist_grid_points.write("&controls\n")
             for k, v in star1_binary_controls.items():
                 if (type(v) == float) and (not v.is_integer()):
-                    inlist_grid_points.write("\t{0} = {1:.10f}d0\n".format(k, v))
+                    inlist_grid_points.write("\t{0} = ".format(k)+"{0:.10e}\n"\
+                                             .format(v).replace('e','d'))
                 elif (type(v) == float) and (v.is_integer()):
                     inlist_grid_points.write("\t{0} = {1}\n".format(k, int(v)))
                 elif type(v) == bool:
@@ -321,7 +324,8 @@ def create_binary_inlists(binary_controls, binary_job,
             inlist_grid_points.write("&controls\n")
             for k, v in star2_binary_controls.items():
                 if (type(v) == float) and (not v.is_integer()):
-                    inlist_grid_points.write("\t{0} = {1:.10f}d0\n".format(k, v))
+                    inlist_grid_points.write("\t{0} = ".format(k)+"{0:.10e}\n"\
+                                             .format(v).replace('e','d'))
                 elif (type(v) == float) and (v.is_integer()):
                     inlist_grid_points.write("\t{0} = {1}\n".format(k, int(v)))
                 elif type(v) == bool:
@@ -342,7 +346,8 @@ def create_binary_inlists(binary_controls, binary_job,
             inlist_grid_points.write("&star_job\n")
             for k, v in star1_binary_job.items():
                 if (type(v) == float) and (not v.is_integer()):
-                    inlist_grid_points.write("\t{0} = {1:.10f}d0\n".format(k, v))
+                    inlist_grid_points.write("\t{0} = ".format(k)+"{0:.10e}\n"\
+                                             .format(v).replace('e','d'))
                 elif (type(v) == float) and (v.is_integer()):
                     inlist_grid_points.write("\t{0} = {1}\n".format(k, int(v)))
                 elif type(v) == bool:
@@ -363,7 +368,8 @@ def create_binary_inlists(binary_controls, binary_job,
             inlist_grid_points.write("&star_job\n")
             for k, v in star2_binary_job.items():
                 if (type(v) == float) and (not v.is_integer()):
-                    inlist_grid_points.write("\t{0} = {1:.10f}d0\n".format(k, v))
+                    inlist_grid_points.write("\t{0} = ".format(k)+"{0:.10e}\n"\
+                                             .format(v).replace('e','d'))
                 elif (type(v) == float) and (v.is_integer()):
                     inlist_grid_points.write("\t{0} = {1}\n".format(k, int(v)))
                 elif type(v) == bool:
@@ -416,17 +422,17 @@ def create_star_formation(mass, work_dir, star_inlist_project, initial_z=None, n
         Pwarn('Replace '+filename, "OverwriteWarning")
     with open(filename, 'w') as inlist_grid_points:
         inlist_grid_points.write("&controls\n")
-        inlist_grid_points.write("initial_mass = {0:.10e}\n"\
+        inlist_grid_points.write("initial_mass = "+"{0:.10e}\n"\
                                  .format(mass).replace('e','d'))
         if initial_z is not None:
-            inlist_grid_points.write("initial_z = {0:.10e}\n"\
+            inlist_grid_points.write("initial_z = "+"{0:.10e}\n"\
                                      .format(initial_z).replace('e','d'))
-            inlist_grid_points.write("Zbase = {0:.10e}\n"\
+            inlist_grid_points.write("Zbase = "+"{0:.10e}\n"\
                                      .format(initial_z).replace('e','d'))
         inlist_grid_points.write("/ ! end of star_controls namelist\n")
         inlist_grid_points.write("&star_job\n")
         if new_Z:
-            inlist_grid_points.write("new_Z = {0:.10e}\n"\
+            inlist_grid_points.write("new_Z = "+"{0:.10e}\n"\
                                      .format(initial_z).replace('e','d'))
         inlist_grid_points.write("/ ! end of star_job namelist\n")
         inlist_grid_points.close()

--- a/bin/posydon-run-grid
+++ b/bin/posydon-run-grid
@@ -416,14 +416,18 @@ def create_star_formation(mass, work_dir, star_inlist_project, initial_z=None, n
         Pwarn('Replace '+filename, "OverwriteWarning")
     with open(filename, 'w') as inlist_grid_points:
         inlist_grid_points.write("&controls\n")
-        inlist_grid_points.write("initial_mass = {0:.10f}d0\n".format(mass))
+        inlist_grid_points.write("initial_mass = {0:.10e}\n"\
+                                 .format(mass).replace('e','d'))
         if initial_z is not None:
-            inlist_grid_points.write("initial_z = {0:.10f}d0\n".format(initial_z))
-            inlist_grid_points.write("Zbase = {0:.10f}d0\n".format(initial_z))
+            inlist_grid_points.write("initial_z = {0:.10e}\n"\
+                                     .format(initial_z).replace('e','d'))
+            inlist_grid_points.write("Zbase = {0:.10e}\n"\
+                                     .format(initial_z).replace('e','d'))
         inlist_grid_points.write("/ ! end of star_controls namelist\n")
         inlist_grid_points.write("&star_job\n")
         if new_Z:
-            inlist_grid_points.write("new_Z = {0:.10f}d0\n".format(initial_z))
+            inlist_grid_points.write("new_Z = {0:.10e}\n"\
+                                     .format(initial_z).replace('e','d'))
         inlist_grid_points.write("/ ! end of star_job namelist\n")
         inlist_grid_points.close()
 


### PR DESCRIPTION
Currently, when running grids we format all the floats as floats with a precision of 10 digits and append the `d0` to make it FORTRAN readable.
This cause problems for floats <1e-10, see issue #398 

- [x] instead of using float outputs, using exponential output and replace the `e` by a `d`, thus we can now transport any float to the required FORTRAN format.

P.S.: I kept the precession of 10 digits, hence this now become effective digits, e.g. 123.456789012345 no longer converts to `123.4567890123d0`, but to `1.2345678901d+02`