### PR TITLE
allow double He-rich star binaries in RLO to merge

### DIFF
--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -85,22 +85,36 @@ class MergedStep(IsolatedStep):
 
 
     def __call__(self,binary):
+
         merged_star_properties = self.merged_star_properties
+
         if self.verbose:
             print("Before Merger", binary.star_1.state,binary.star_2.state,binary.state, binary.event)
             print("M1 , M2, he_core_mass1, he_core_mass2: ", binary.star_1.mass,binary.star_2.mass, binary.star_1.he_core_mass, binary.star_2.he_core_mass)
             print("star_1.center_he4, star_2.center_he4, star_1.surface_he4, star_2.surface_he4: ",  binary.star_1.center_he4,binary.star_2.center_he4, binary.star_1.surface_he4,binary.star_2.surface_he4)
+        
         if binary.state == "merged":
             if binary.event == 'oMerging1':
-                binary.star_1,binary.star_2 = merged_star_properties(binary.star_1,binary.star_2)
+                binary.star_1, binary.star_2 = merged_star_properties(binary.star_1, binary.star_2)
             elif binary.event == 'oMerging2':
-                binary.star_2,binary.star_1 = merged_star_properties(binary.star_2,binary.star_1)
+                binary.star_2, binary.star_1 = merged_star_properties(binary.star_2, binary.star_1)
             else:
-                raise FlowError("binary.state='merged' but binary.event != 'oMerging1/2'")
+                raise ValueError("binary.state='merged' but binary.event != 'oMerging1/2'")
+
+        ## assume that binaries in RLO with two He-rich stars always merge   
+        elif binary.star_1.state in STAR_STATES_HE_RICH and binary.star_2.state in STAR_STATES_HE_RICH:
+            binary.state = "merged"
+            if binary.event == 'oRLO1':
+                binary.star_1, binary.star_2 = merged_star_properties(binary.star_1, binary.star_2)
+            elif binary.event == 'oRLO2':
+                binary.star_2, binary.star_1 = merged_star_properties(binary.star_2, binary.star_1)
+            else:
+                raise ValueError("step_merged initiated for He stars but RLO not initiated")
         else:
-            raise FlowError("step_merging initiated but binary.state != 'merged'")
+            raise ValueError("step_merged initiated but binary is not in valid merging state!")
 
         binary.event = None
+
         if self.verbose:
             print("After Merger", binary.star_1.state,binary.star_2.state,binary.state, binary.event)
             print("M_merged , he_core_mass merged: ", binary.star_1.mass, binary.star_1.he_core_mass)

--- a/posydon/binary_evol/flow_chart.py
+++ b/posydon/binary_evol/flow_chart.py
@@ -182,6 +182,12 @@ for s1 in STAR_STATES_HE_RICH:
         POSYDON_FLOW_CHART[(s1, s2, 'detached', "redirect_from_CO_HeMS_RLO")] = 'step_detached'
         POSYDON_FLOW_CHART[(s2, s1, 'detached', "redirect_from_CO_HeMS_RLO")] = 'step_detached'
 
+## He-rich star roche-lobe overflow onto another He-rich star
+## assume these systems always merge 
+for s1 in STAR_STATES_HE_RICH:
+    for s2 in STAR_STATES_HE_RICH:
+        POSYDON_FLOW_CHART[(s1, s2, 'RLO1', "oRLO1")] = 'step_merged'
+        POSYDON_FLOW_CHART[(s2, s1, 'RLO2', "oRLO2")] = 'step_merged'
 
 # Binaries that go to common envelope
 


### PR DESCRIPTION
Previously, binaries in RLO with two He-rich stars were failing, as we do no have treatment/grids for these systems in POSYDON.
This PR allows these binaries to merge and sends them to step_merged, as @astroJeff and team discussed at the last dev meeting.

Here is an example of the new evolution for such a binary:

<img width="753" alt="Screen Shot 2024-10-15 at 3 58 59 PM" src="https://github.com/user-attachments/assets/b4705335-868a-45a9-a2bc-ab9022375c3f">

For more context, refer to  Issue #388 and the discussion in [this Slack thread](url).
