### PR TITLE
update star states in step_SN

### DIFF
--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -418,11 +418,13 @@ class StepSN(object):
             # collapse star
             self.collapse_star(star=binary.star_1)
             self._reset_other_star_properties(star=binary.star_2)
+            binary.update_star_states()
 
         elif binary.event == "CC2":
             # collapse star
             self.collapse_star(star=binary.star_2)
             self._reset_other_star_properties(star=binary.star_1)
+            binary.update_star_states()
         else:
             raise ValueError("Something went wrong: "
                              "invalid call of supernova step!")


### PR DESCRIPTION
This PR addresses Issue #345 and Issue #413 by updating the binary stellar states after core collapse in step_SN.
Here is an example of a binary where the stellar state was not updated previously:
<img width="635" alt="Screen Shot 2024-10-16 at 12 34 39 PM" src="https://github.com/user-attachments/assets/1a5c92eb-5931-458a-86a1-5b45045c0114">
And now with the fix:
<img width="667" alt="Screen Shot 2024-10-16 at 12 35 00 PM" src="https://github.com/user-attachments/assets/98d4b2a0-33ce-4cbb-8bc6-e5afe850845b">
This appears to fix all mislabeling of SN remnants in a small test population of binaries, I am running a larger population to be sure.