### PR TITLE
error catch for He-rich stars in RLO onto H-rich stars

### DIFF
--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -37,7 +37,7 @@ from posydon.utils.common_functions import (
 )
 from posydon.binary_evol.flow_chart import (STAR_STATES_CC, STAR_STATES_CO)
 import posydon.utils.constants as const
-from posydon.utils.posydonerror import NumericalError, MatchingError, POSYDONError, ModelError
+from posydon.utils.posydonerror import NumericalError, MatchingError, POSYDONError, FlowError
 from posydon.utils.posydonwarning import Pwarn
 
 LIST_ACCEPTABLE_STATES_FOR_HMS = ["H-rich_Core_H_burning", "accreted_He_Core_H_burning"]
@@ -1927,17 +1927,17 @@ class detached_step:
                         binary.state = "RLO1"
                         binary.event = "oRLO1"
                 
-                if (binary.star_1.state in LIST_ACCEPTABLE_STATES_FOR_HeStar 
-                    and binary.star_2.state in STAR_STATES_H_RICH 
-                    and binary.state == "RLO1"):
+                if (binary.state == "RLO1" 
+                    and binary.star_1.state in LIST_ACCEPTABLE_STATES_FOR_HeStar 
+                    and binary.star_2.state in STAR_STATES_H_RICH):
                         set_binary_to_failed(binary)
-                        raise ModelError("Evolution of He-rich stars in RLO onto H-rich stars after HMS-HMS not yet supported.") 
+                        raise FlowError("Evolution of He-rich stars in RLO onto H-rich stars after HMS-HMS not yet supported.") 
                 
-                elif (binary.star_2.state in LIST_ACCEPTABLE_STATES_FOR_HeStar 
-                    and binary.star_1.state in STAR_STATES_H_RICH 
-                    and binary.state == "RLO2"):
+                elif (binary.state == "RLO2" 
+                      and binary.star_2.state in LIST_ACCEPTABLE_STATES_FOR_HeStar 
+                      and binary.star_1.state in STAR_STATES_H_RICH):
                         set_binary_to_failed(binary)
-                        raise ModelError("Evolution of He-rich stars in RLO onto H-rich stars after HMS-HMS not yet supported.") 
+                        raise FlowError("Evolution of He-rich stars in RLO onto H-rich stars after HMS-HMS not yet supported.") 
 
 
             elif s.t_events[2]:

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -37,7 +37,7 @@ from posydon.utils.common_functions import (
 )
 from posydon.binary_evol.flow_chart import (STAR_STATES_CC, STAR_STATES_CO)
 import posydon.utils.constants as const
-from posydon.utils.posydonerror import NumericalError, MatchingError, POSYDONError
+from posydon.utils.posydonerror import NumericalError, MatchingError, POSYDONError, ModelError
 from posydon.utils.posydonwarning import Pwarn
 
 LIST_ACCEPTABLE_STATES_FOR_HMS = ["H-rich_Core_H_burning", "accreted_He_Core_H_burning"]
@@ -1926,6 +1926,19 @@ class detached_step:
                     else:
                         binary.state = "RLO1"
                         binary.event = "oRLO1"
+                
+                if (binary.star_1.state in LIST_ACCEPTABLE_STATES_FOR_HeStar 
+                    and binary.star_2.state in STAR_STATES_H_RICH 
+                    and binary.state == "RLO1"):
+                        set_binary_to_failed(binary)
+                        raise ModelError("Evolution of He-rich stars in RLO onto H-rich stars after HMS-HMS not yet supported.") 
+                
+                elif (binary.star_2.state in LIST_ACCEPTABLE_STATES_FOR_HeStar 
+                    and binary.star_1.state in STAR_STATES_H_RICH 
+                    and binary.state == "RLO2"):
+                        set_binary_to_failed(binary)
+                        raise ModelError("Evolution of He-rich stars in RLO onto H-rich stars after HMS-HMS not yet supported.") 
+
 
             elif s.t_events[2]:
                 # reached t_max of track. End of life (possible collapse) of


### PR DESCRIPTION
This PR is a temporary fix for part of Issue #418. It adds an error catch in the detached step for binaries with an He-rich star in RLO onto an H-rich star, which account for <0.5% of all binaries at solar metallicity. Ideally we would have a grid to model this subpopulation of binaries, but for now we force them to fail with a POSYDON error.

Here is an example of the output for one such binary run with this PR:
<img width="677" alt="Screen Shot 2024-10-28 at 3 06 20 PM" src="https://github.com/user-attachments/assets/45acd9e9-1fe9-48a7-8aab-4c91d523bbaf">
<img width="797" alt="Screen Shot 2024-10-28 at 3 06 41 PM" src="https://github.com/user-attachments/assets/da106f3d-365a-4071-a368-55a32426728c">
