### PR TITLE
Automatic testing of installation

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest]
         python-version: ['3.11']  # can add more if we want to support
 
     steps:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -17,10 +17,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    - name: Normalize line endings on Windows
-      if: runner.os == 'Windows'
-      run: git config --global core.autocrlf false
-
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,0 +1,36 @@
+name: POSYDON Continuous Integration
+
+on:
+  pull_request:
+    branches: [main, development]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        python-version: ['3.11']  # can add more if we want to support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Normalize line endings on Windows
+      if: runner.os == 'Windows'
+      run: git config --global core.autocrlf false
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install POSYDON without extras
+      run: |
+        python -m pip install --upgrade pip
+        pip install . 
+
+    # - name: Run all tests
+    #   run: |
+    #     pytest posydon/unit_tests/

--- a/.github/workflows/install_extras.yml
+++ b/.github/workflows/install_extras.yml
@@ -10,16 +10,12 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest]
         python-version: ['3.11']  # can add more if we want to support
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-
-    - name: Normalize line endings on Windows
-      if: runner.os == 'Windows'
-      run: git config --global core.autocrlf false
 
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/.github/workflows/install_extras.yml
+++ b/.github/workflows/install_extras.yml
@@ -1,0 +1,32 @@
+name: Testing installation of extras in setup.py
+
+on:
+  schedule:
+    - cron: "0 0 * * 0"  # Runs at 00:00 (UTC) every Sunday
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        python-version: ['3.11']  # can add more if we want to support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Normalize line endings on Windows
+      if: runner.os == 'Windows'
+      run: git config --global core.autocrlf false
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install POSYDON with extras
+      run: |
+        python -m pip install --upgrade pip
+        pip install ".[doc,vis,ml,hpc]" 

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ else:
 # the correct way to do this is to make sure that they are available on
 # conda and pip for all platforms we support (see prerequisites doc page).
 install_requires = [
+    'secret-pkg',
     'numpy >= 1.24.2,<2.0.0',
     'scipy >= 1.10.1',
     'iminuit >= 2.21.3',

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,6 @@ else:
 # the correct way to do this is to make sure that they are available on
 # conda and pip for all platforms we support (see prerequisites doc page).
 install_requires = [
-    'secret-pkg',
     'numpy >= 1.24.2,<2.0.0',
     'scipy >= 1.10.1',
     'iminuit >= 2.21.3',


### PR DESCRIPTION
continuous_integration.yml: 
- is triggered for all PRs created on development or main
- tests on mac, ubuntu, windows
- runs python 3.11 (can add others)
- installs all requirements from setup.py
- I have currently commented out the option to run all tests in the unit_tests folder, but we can include that (or any combination of specific tests) later after Matthias' PR is accepted

install_extras.yml is same as above, except:
- is only triggered weekly by cronjob (takes much longer than regular installation)
- additionally installs all extras in setup.py: ml, hpc, docs, vis