### PR TITLE
enforce 100% test coverage

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -36,4 +36,4 @@ jobs:
         export PATH_TO_POSYDON=./
         export PATH_TO_POSYDON_DATA=./
         export MESA_DIR=./
-        python -m pytest posydon/unit_tests/ --cov=posydon.utils --cov-branch --cov-report term-missing
+        python -m pytest posydon/unit_tests/ --cov=posydon.utils --cov-branch --cov-report term-missing --cov-fail-under=100


### PR DESCRIPTION
adding a piece to enforce minimum coverage of 100% of specified code when running the tests. if the coverage is below 100%, pytest will exit and the github action will fail. 

100% coverage means that every line of code of posydon.utils (as specified in `--cov=posydon.utils`) is run at least once in the test suite execution. 