### PR TITLE
Change bbox to `standard`

### DIFF
--- a/posydon/visualization/posydon.mplstyle
+++ b/posydon/visualization/posydon.mplstyle
@@ -17,7 +17,7 @@ figure.dpi 		: 300
 xtick.minor.visible     : True
 ytick.minor.visible     : True
 
-savefig.bbox		:  standard  # tight
+savefig.bbox		: standard  # tight
 savefig.pad_inches	: 0.1 # Padding when bbox is tight.
 savefig.dpi		: 300
 savefig.format		: pdf

--- a/posydon/visualization/posydon.mplstyle
+++ b/posydon/visualization/posydon.mplstyle
@@ -17,7 +17,7 @@ figure.dpi 		: 300
 xtick.minor.visible     : True
 ytick.minor.visible     : True
 
-savefig.bbox		: tight # standard
+savefig.bbox		:  standard  # tight
 savefig.pad_inches	: 0.1 # Padding when bbox is tight.
 savefig.dpi		: 300
 savefig.format		: pdf


### PR DESCRIPTION
When saving figures, matplotlib was set to use `bbox : tight` in the `posydon.mplstyle`.
This changes the size of the resulting figure, despite setting your own or using the default POSYDON dimensions.

Setting it back to `standard` should respect the set figure size. 

The best way to keep the same figure size would be to use `constrained_layout`, but this is incompatible with custom white space between figures.