### PR TITLE
PSygrid force int input

### DIFF
--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -1541,7 +1541,7 @@ class PSyGrid:
         return ret
 
     def __getitem__(self, index):
-        """Return a PSyRunView instance for the run with index `idx`."""
+        """Return a PSyRunView instance for the run with index `index`."""
         if not np.issubdtype(type(index), int):
             raise TypeError("Index {} is not of type int".format(index))
         if index not in self:

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -1542,10 +1542,10 @@ class PSyGrid:
 
     def __getitem__(self, idx):
         """Return a PSyRunView instance for the run with index `idx`."""
-        if idx not in self:
-            raise KeyError("Index {} out of bounds.".format(idx))
         if not np.issubdtype(type(idx), int):
             raise TypeError("Index {} is not of type int".format(idx))
+        if idx not in self:
+            raise KeyError("Index {} out of bounds.".format(idx))
         return PSyRunView(self, idx)
 
     def get_pandas_initial_final(self):
@@ -1566,6 +1566,8 @@ class PSyGrid:
 
     def __contains__(self, index):
         """Return True if run with index `index` is in the grid."""
+        if not np.issubdtype(type(idx), int):
+            raise TypeError("Index {} is not of type int".format(idx))
         return 0 <= index < self.n_runs
 
     def __iter__(self):

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -1545,7 +1545,7 @@ class PSyGrid:
         if not np.issubdtype(type(idx), int):
             raise TypeError("Index {} is not of type int".format(idx))
         if idx not in self:
-            raise KeyError("Index {} out of bounds.".format(idx))
+            raise IndexError("Index {} out of bounds.".format(idx))
         return PSyRunView(self, idx)
 
     def get_pandas_initial_final(self):

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -1540,13 +1540,13 @@ class PSyGrid:
 
         return ret
 
-    def __getitem__(self, idx):
+    def __getitem__(self, index):
         """Return a PSyRunView instance for the run with index `idx`."""
-        if not np.issubdtype(type(idx), int):
-            raise TypeError("Index {} is not of type int".format(idx))
-        if idx not in self:
-            raise IndexError("Index {} out of bounds.".format(idx))
-        return PSyRunView(self, idx)
+        if not np.issubdtype(type(index), int):
+            raise TypeError("Index {} is not of type int".format(index))
+        if index not in self:
+            raise IndexError("Index {} out of bounds.".format(index))
+        return PSyRunView(self, index)
 
     def get_pandas_initial_final(self):
         """Convert the initial/final values into a single Pandas dataframe."""
@@ -1566,8 +1566,8 @@ class PSyGrid:
 
     def __contains__(self, index):
         """Return True if run with index `index` is in the grid."""
-        if not np.issubdtype(type(idx), int):
-            raise TypeError("Index {} is not of type int".format(idx))
+        if not np.issubdtype(type(index), int):
+            raise TypeError("Index {} is not of type int".format(index))
         return 0 <= index < self.n_runs
 
     def __iter__(self):

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -1544,6 +1544,8 @@ class PSyGrid:
         """Return a PSyRunView instance for the run with index `idx`."""
         if idx not in self:
             raise KeyError("Index {} out of bounds.".format(idx))
+        if not np.issubdtype(type(idx), int):
+            raise TypeError("Index {} is not of type int".format(idx))
         return PSyRunView(self, idx)
 
     def get_pandas_initial_final(self):


### PR DESCRIPTION
force the user to input an integer. This includes numpy versions of int.

If this is not forces, the `initial_values` and `final_values` can be loaded with a 1 value array/list, but the `history1`, etc are not loaded with that input. As a result, `None` is returned for those and it looks like the history is empty.