### PR TITLE
Change to release on publish

### DIFF
--- a/.github/workflows/publish-to-anaconda.yml
+++ b/.github/workflows/publish-to-anaconda.yml
@@ -1,9 +1,8 @@
 name: publish_conda
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
     
 jobs:
   publish:


### PR DESCRIPTION
Make the publish_to_anaconda the same between v1.0.4 release and development.
Only publish to anaconda when a new github version is published.