### PR TITLE
Typo fixed in documenation

### DIFF
--- a/posydon/grids/post_processing.py
+++ b/posydon/grids/post_processing.py
@@ -87,8 +87,8 @@ def post_process_grid(grid, index=None, star_2_CO=True, MODELS=MODELS,
                       single_star=False, verbose=False):
     """Compute post processed quantity of any grid.
 
-    This function post process any supported grid and computes:
-    - Core collpase quantities for 5 prescritions given the fiducial POSYDON
+    This function post processes any supported grid and computes:
+    - Core collapse quantities for 5 prescriptions given the fiducial POSYDON
     assumption given in MODEL plus:
       A: direct collapse
       B: Fryer+12-rapid
@@ -98,13 +98,13 @@ def post_process_grid(grid, index=None, star_2_CO=True, MODELS=MODELS,
       for each prescrition we store the compact object state (WD/NS/BH),
       SN type (WD, ECSN, CCSN, PISN, PPISN), fallback mass fraction f_gb,
       compact object mass and spin.
-    - Core masses at he-depletion (used in Patton core collpase)
-    - Mass envelopes for common ennvelope step.
+    - Core masses at he-depletion (used in Patton core collapse)
+    - Mass envelopes for common envelope step.
 
     Parameters
     ----------
     grid : PSyGrid
-        MESA gri in PSyGrid format.
+        MESA grid in PSyGrid format.
     index : None, touple or int
         If None, loop over all indicies otherwise provide a range, e.g. [10,20]
         or a index, e.g. 42.
@@ -115,7 +115,7 @@ def post_process_grid(grid, index=None, star_2_CO=True, MODELS=MODELS,
     single_star : bool
         If `True` the PSyGrid contains single stars.
     verbose : bool
-        If `True` print on screen the results of each core collpase.
+        If `True` print the results of each core collapse on screen.
 
     Returns
     -------
@@ -124,7 +124,7 @@ def post_process_grid(grid, index=None, star_2_CO=True, MODELS=MODELS,
         processed values. This is used to ensure one to one mapping when
         appending the extra columns back to a grid.
     EXTRA_COLUMNS: dict
-        Dictionary containing all post processe quantities.
+        Dictionary containing all post processed quantities.
 
     """
     EXTRA_COLUMNS = {}
@@ -244,7 +244,7 @@ def post_process_grid(grid, index=None, star_2_CO=True, MODELS=MODELS,
                     else:
                         EXTRA_COLUMNS[f'S{j+1}_{quantity}'].append(None)
 
-        # core collpase quantities
+        # core collapse quantities
         if not single_star:
             if interpolation_class in ['no_MT', 'stable_MT',
                                        'stable_reverse_MT']:
@@ -435,7 +435,7 @@ def add_post_processed_quantities(grid, MESA_dirs_EXTRA_COLUMNS, EXTRA_COLUMNS,
     """Append post processed quantity to a grid.
 
     This function appends the quantities computed in post_process_grid to any
-    grid. Note that this function ensure you can append the quantities only if
+    grid. Note that this function ensures you can append the quantities only if
     the grid follows the order of MESA_dirs_EXTRA_COLUMNS.
 
     Parameters
@@ -447,9 +447,9 @@ def add_post_processed_quantities(grid, MESA_dirs_EXTRA_COLUMNS, EXTRA_COLUMNS,
         processed values. This is used to ensure one to one mapping when
         appending the extra columns back to a grid.
     EXTRA_COLUMNS: dict
-        Dictionary containing all post processe quantities.
+        Dictionary containing all post processed quantities.
     verbose : bool
-        If `True` print on screen the results of each core collpase.
+        If `True` print the results of each core collapse on screen.
 
     """
     # check correspondance of EXTRA_COLUMNS with grid

--- a/posydon/grids/psygrid.py
+++ b/posydon/grids/psygrid.py
@@ -26,7 +26,7 @@ d) Various options (see definition of `create` and `GRIDPROPERTIES` for more):
 
     NOTE: you can use a family of HDF5 files in case of file size restrictions.
     For example, using `mygrid.h5.%d` for the path when creating/loading grids,
-    implied that split files will be `mygrid.h5.0`, `mygrid.h5.1`, and so on.
+    implies that split files will be `mygrid.h5.0`, `mygrid.h5.1`, and so on.
     When overwriting the file, all the family is overwritten (effectively, the
     files are emptied to avoid remainder split files from previous operations.)
 
@@ -90,8 +90,8 @@ h) To include specific columns from MESA data files, set the grid properties of
    to select the exact set of columns, provide them in a tuple instead of list.
 
 
-II. READING DATA FROM GRID
---------------------------
+II. READING DATA FROM A GRID
+----------------------------
 mygrid = PSyGrid("thegrid.h5")  # opens a stored grid
 
 # Indexing...
@@ -125,7 +125,7 @@ b) In `for` loop (`iter` and `next` are supported too):
     for run in mygrid:
         print(run)
 
-c) Getting number of runs:
+c) Getting the number of runs:
 
     n_runs = len(psygrid)
 
@@ -159,8 +159,8 @@ the table is loaded from the HDF5 file temporarily. This means that:
 
     myrun.history1.star_mass + myrun.history1.star_mass
 
-loads the table two times! To reduce reading times, store in local variables
-all the tables that are going to be needed more than once:
+loads the table two times! To reduce reading times, store all the tables
+that are going to be needed more than once in local variables:
 
     myhistory1 = myrun.history1
     myhistory1.star_mass + myhistory1.star_mass

--- a/posydon/interpolation/IF_interpolation.py
+++ b/posydon/interpolation/IF_interpolation.py
@@ -1,4 +1,4 @@
-"""Module for performing initial-final inteprolation.
+"""Module for performing initial-final interpolation.
 
 We showcase the initial-final interpolator which plays a critical role in the
 evolving binary populations. To use the initial-final interpolator we first


### PR DESCRIPTION
Typos found by @elizabethteng and @sgossage while checking the v1.0.4 documentation. 

These are still present in the current code, so here's the PR to also include them in our current developement.