### PR TITLE
Update publish-to-anaconda.yml

### DIFF
--- a/.github/workflows/publish-to-anaconda.yml
+++ b/.github/workflows/publish-to-anaconda.yml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: publish-to-conda
-      uses: scottcoughlin2014/publish_conda_package_action@v1.0.0
+      uses: POSYDON-code/publish_to_anaconda@v1.0.1
       with:
         CondaDir: 'conda'
         Platforms: 'noarch'


### PR DESCRIPTION
Point towards POSYDON-code/ version of the publish-to-anaconda action.