### PR TITLE
Fix log vs log10 typo

### DIFF
--- a/posydon/popsyn/star_formation_history.py
+++ b/posydon/popsyn/star_formation_history.py
@@ -242,7 +242,7 @@ def SFR_Z_fraction_at_given_redshift(
         )
         if not select_one_met:
             fSFR[:, 0] = stats.norm.cdf(np.log10(metallicity_bins[1]), mu, sigma) / norm
-            fSFR[:,-1] = norm - stats.norm.cdf(np.log(metallicity_bins[-1]), mu, sigma)/norm
+            fSFR[:,-1] = norm - stats.norm.cdf(np.log10(metallicity_bins[-1]), mu, sigma)/norm
 
     elif SFR == "Neijssel+19":
         # assume a truncated ln-normal distribution of metallicities


### PR DESCRIPTION
In the MD/MF metallicity fraction calculation, there was a typo for the outer bin in transforming the absolute metallicity into a log10 value. It was log, but should be log10!