### PR TITLE
typo correction: period_change_stabe_MT -> period_change_stable_MT

### DIFF
--- a/posydon/binary_evol/CE/step_CEE.py
+++ b/posydon/binary_evol/CE/step_CEE.py
@@ -636,13 +636,13 @@ class StepCEE(object):
                 # An assumed stable mass transfer case after postCEE with
                 # fully non-conservative MT and mass lost from the vicinity
                 # of the accretor:
-                orbital_period_f = cf.period_change_stabe_MT(
+                orbital_period_f = cf.period_change_stable_MT(
                     orbital_period_postCEE, Mdon_i=mc1_i, Mdon_f=mc1_f,
                     Macc_i=mc2_i, alpha=0.0, beta=1.0)
                 if double_CE:
                     # a reverse stable MT assumed to be happening
                     # at the same time
-                    orbital_period_f = cf.period_change_stabe_MT(
+                    orbital_period_f = cf.period_change_stable_MT(
                         orbital_period_f, Mdon_i=mc2_i, Mdon_f=mc2_f,
                         Macc_i=mc1_i, alpha=0.0, beta=1.0)
                 if verbose:
@@ -656,13 +656,13 @@ class StepCEE(object):
                     "core_not_replaced_windloss"]:
                 # An assumed wind loss after postCEE with mass lost
                 # from the vicinity of the donor
-                orbital_period_f = cf.period_change_stabe_MT(
+                orbital_period_f = cf.period_change_stable_MT(
                     orbital_period_postCEE, Mdon_i=mc1_i, Mdon_f=mc1_f,
                     Macc_i=mc2_i, alpha=1.0, beta=0.0)
                 if double_CE:
                     # a wind mass loss from the 2nd star assumed to be
                     # happening at the same time
-                    orbital_period_f = cf.period_change_stabe_MT(
+                    orbital_period_f = cf.period_change_stable_MT(
                         orbital_period_f, Mdon_i=mc2_i, Mdon_f=mc2_f,
                         Macc_i=mc1_i, alpha=1.0, beta=0.0)
                 if verbose:

--- a/posydon/unit_tests/utils/test_common_functions.py
+++ b/posydon/unit_tests/utils/test_common_functions.py
@@ -104,7 +104,7 @@ class TestElements:
                     'linear_interpolation_between_two_cells', 'newton', 'np',\
                     'orbital_period_from_separation',\
                     'orbital_separation_from_period', 'os', 'pd',\
-                    'period_change_stabe_MT', 'period_evol_wind_loss',\
+                    'period_change_stable_MT', 'period_evol_wind_loss',\
                     'profile_recomb_energy', 'quad',\
                     'read_histogram_from_file', 'rejection_sampler',\
                     'roche_lobe_radius', 'rotate', 'rzams',\
@@ -282,8 +282,8 @@ class TestElements:
     def test_instance_separation_evol_wind_loss(self):
         assert isroutine(totest.separation_evol_wind_loss)
 
-    def test_instance_period_change_stabe_MT(self):
-        assert isroutine(totest.period_change_stabe_MT)
+    def test_instance_period_change_stable_MT(self):
+        assert isroutine(totest.period_change_stable_MT)
 
     def test_instance_linear_interpolation_between_two_cells(self):
         assert isroutine(totest.linear_interpolation_between_two_cells)
@@ -1806,28 +1806,28 @@ class TestFunctions:
         for (M1, Mi, M2, ai, r) in tests:
             assert totest.separation_evol_wind_loss(M1, Mi, M2, ai) == r
 
-    def test_period_change_stabe_MT(self):
+    def test_period_change_stable_MT(self):
         # missing argument
         with raises(TypeError, match="missing 4 required positional "\
                                      +"arguments: 'period_i', 'Mdon_i', "\
                                      +"'Mdon_f', and 'Macc_i'"):
-            totest.period_change_stabe_MT()
+            totest.period_change_stable_MT()
         # bad input
         with raises(TypeError) as error_info:
-            totest.period_change_stabe_MT(None, None, None, None)
+            totest.period_change_stable_MT(None, None, None, None)
         assert error_info.value.args[0] == "unsupported operand type(s) for "\
                                            + "-: 'NoneType' and 'NoneType'"
         tests = [(-1.0, 0.0), (2.0, 0.0), (0.0, -1.0), (0.0, 2.0)]
         for (a, b) in tests:
             with raises(ValueError) as error_info:
-                totest.period_change_stabe_MT(0.5, 0.5, 0.5, 0.5, alpha=a,\
+                totest.period_change_stable_MT(0.5, 0.5, 0.5, 0.5, alpha=a,\
                                               beta=b)
-            assert error_info.value.args[0] == "In period_change_stabe_MT, "\
+            assert error_info.value.args[0] == "In period_change_stable_MT, "\
                                                + "mass transfer efficiencies,"\
                                                + f" alpha, beta: {a}, {b} "\
                                                + "are not in the [0-1] range."
         with raises(ValueError, match="Donor gains mass from 0.5 to 1.5"):
-            totest.period_change_stabe_MT(0.5, 0.5, 1.5, 0.5)
+            totest.period_change_stable_MT(0.5, 0.5, 1.5, 0.5)
         # examples:
         tests = [(0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.5),\
                  (1.5, 0.5, 0.5, 0.5, 0.0, 0.0, 1.5),\
@@ -1863,7 +1863,7 @@ class TestFunctions:
                  (0.5, 1.0, 0.5, 1.0, 0.0, 1.0,\
                   approx(1.58670336106, abs=6e-12))]
         for (Pi, Mdi, Mdf, Mai, a, b, r) in tests:
-            assert totest.period_change_stabe_MT(Pi, Mdi, Mdf, Mai, alpha=a,\
+            assert totest.period_change_stable_MT(Pi, Mdi, Mdf, Mai, alpha=a,\
                                                  beta=b) == r
 
     def test_linear_interpolation_between_two_cells(self, capsys):

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -2069,8 +2069,8 @@ def separation_evol_wind_loss(M_current, M_init, Mcomp, A_init):
     return 10.0**log10A
 
 
-def period_change_stabe_MT(period_i, Mdon_i, Mdon_f, Macc_i,
-                           alpha=0.0, beta=0.0):
+def period_change_stable_MT(period_i, Mdon_i, Mdon_f, Macc_i,
+                            alpha=0.0, beta=0.0):
     """Change the binary period after a semi-detached stable MT phase.
 
     Calculated in Sorensen, Fragos et al.  2017A&A...597A..12S.
@@ -2107,7 +2107,7 @@ def period_change_stabe_MT(period_i, Mdon_i, Mdon_f, Macc_i,
                                                                  Mdon_f))
     Macc_f = Macc_i + (1.-beta)*(1.-alpha)*DM_don
     if alpha < 0.0 or beta < 0.0 or alpha > 1.0 or beta > 1.0:
-        raise ValueError("In period_change_stabe_MT, mass transfer "
+        raise ValueError("In period_change_stable_MT, mass transfer "
                          "efficiencies, alpha, beta: {}, {} are not in the "
                          "[0-1] range.".format(alpha, beta))
     if beta != 1.0:      # Eq. 7 of Sorensen+Fragos et al. 2017


### PR DESCRIPTION
- [x] Correcting the typo in the function name `period_change_stabe_MT`, see issue #461 