### PR TITLE
error check for undefined states in BinaryStar

### DIFF
--- a/posydon/binary_evol/DT/step_initially_single.py
+++ b/posydon/binary_evol/DT/step_initially_single.py
@@ -13,8 +13,6 @@ from posydon.binary_evol.DT.step_isolated import IsolatedStep
 
 from posydon.binary_evol.flow_chart import (
     STAR_STATES_H_RICH, STAR_STATES_HE_RICH)
-from posydon.utils.posydonerror import FlowError
-from posydon.utils.posydonerror import POSYDONError
 
 LIST_ACCEPTABLE_STATES_FOR_HMS = ["H-rich_Core_H_burning"]
 LIST_ACCEPTABLE_STATES_FOR_HeMS = ["stripped_He_Core_He_burning"]

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -14,7 +14,6 @@ from posydon.utils.data_download import PATH_TO_POSYDON_DATA
 from posydon.binary_evol.singlestar import STARPROPERTIES, convert_star_to_massless_remnant
 from posydon.utils.common_functions import check_state_of_star
 from posydon.binary_evol.DT.step_isolated import IsolatedStep
-from posydon.utils.posydonerror import FlowError
 
 from posydon.utils.posydonwarning import Pwarn
 

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -929,3 +929,39 @@ class BinaryStar:
             binary.star_2.profile = run.final_profile2
             
         return binary
+    
+    def initial_condition_message(self, ini_params=None):
+        """Generate a message with the initial conditions.
+
+        Parameters
+        ----------
+       
+        ini_params : None or iterable of str
+            If None take the initial conditions from the binary, otherwise add
+            each item of it to the message.
+
+        Returns
+        -------
+        string
+            The message with the binary initial conditions.
+        """
+    
+        if ini_params is None:
+            ini_params = ["\nFailed Binary Initial Conditions:\n",
+                    f"S1 mass: {self.star_1.mass_history[0]} \n",
+                    f"S2 mass: {self.star_2.mass_history[0]} \n",
+                    f"S1 state: {self.star_1.state_history[0]} \n",
+                    f"S2 state: {self.star_2.state_history[0]}\n",
+                    f"orbital period: {self.orbital_period_history[0] } \n",
+                    f"eccentricity: {self.eccentricity_history[0]} \n",
+                    f"binary state: {self.state_history[0] }\n",
+                    f"binary event: {self.state_history[0] }\n",
+                    f"S1 natal kick array: {self.star_1.natal_kick_array }\n",
+                    f"S2 natal kick array: {self.star_2.natal_kick_array}\n"]
+            
+        message = ""
+        for i in ini_params:
+            message += i 
+
+        return message
+

--- a/posydon/binary_evol/flow_chart.py
+++ b/posydon/binary_evol/flow_chart.py
@@ -113,6 +113,12 @@ BINARY_EVENTS_ALL = [
     'oMerging2'
 ]
 
+## a list of known total binary states that can occur, 
+## but are not in the flow chart and will not be added to POSYDON
+UNDEFINED_STATES = [
+    ('NS', 'H-rich_Core_H_burning', 'disrupted', 'CC2'),
+    ('NS', 'H-rich_Core_H_burning', 'detached', 'CC2')
+]
 
 # dynamically construct the flow chart
 POSYDON_FLOW_CHART = {}

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -54,7 +54,7 @@ from posydon.popsyn.normalized_pop_mass import initial_total_underlying_mass
 from posydon.popsyn.defaults import default_kwargs
 from posydon.popsyn.io import binarypop_kwargs_from_ini
 from posydon.utils.constants import Zsun
-from posydon.utils.posydonerror import POSYDONError,initial_condition_message
+from posydon.utils.posydonerror import POSYDONError
 from posydon.utils.posydonwarning import (Pwarn, Catch_POSYDON_Warnings)
 from posydon.utils.common_functions import set_binary_to_failed
 
@@ -331,14 +331,14 @@ class BinaryPopulation:
                     binary.traceback = traceback.format_exc()
 
                     if self.kwargs.get("error_checking_verbose", False):
-                        posydon_error.add_note(initial_condition_message(binary))
+                        posydon_error.add_note(binary.initial_condition_message())
                         traceback.print_exception(posydon_error)
 
                 except Exception as e:
                     set_binary_to_failed(binary)
                     binary.traceback = traceback.format_exc()
 
-                    e.add_note(initial_condition_message(binary))
+                    e.add_note(binary.initial_condition_message())
                     traceback.print_exception(e)
 
                 # record if there were warnings caught during the binary

--- a/posydon/unit_tests/utils/test_posydonerror.py
+++ b/posydon/unit_tests/utils/test_posydonerror.py
@@ -22,12 +22,11 @@ def artificial_object():
 class TestElements:
     # check for objects, which should be an element of the tested module
     def test_dir(self):
-        elements = ['bstar', 'FlowError', 'GridError', 'MatchingError',\
+        elements = ['FlowError', 'GridError', 'MatchingError',\
                     'ModelError', 'NumericalError', 'POSYDONError',\
-                    'sstar', '__authors__', '__builtins__', '__cached__',\
+                    '__authors__', '__builtins__', '__cached__',\
                     '__doc__', '__file__', '__loader__', '__name__',\
-                    '__package__', '__spec__', 'copy',\
-                    'initial_condition_message']
+                    '__package__', '__spec__', 'copy']
         assert dir(totest) == elements, "There might be added or removed "\
                                         + "objects without an update on the "\
                                         + "unit test."
@@ -68,28 +67,6 @@ class TestElements:
         with raises(totest.NumericalError, match="Test"):
             raise totest.NumericalError("Test")
 
-    def test_instance_initial_condition_message(self):
-        assert isroutine(totest.initial_condition_message)
-
-
-class TestFunctions:
-    # test functions
-    def test_initial_condition_message(self, BinaryStar, artificial_object):
-        with raises(TypeError, match="The binary must be a BinaryStar object"):
-            message = totest.initial_condition_message(binary=\
-                                                       artificial_object)
-        assert "Failed Binary Initial Conditions" in\
-               totest.initial_condition_message(binary=BinaryStar)
-        with raises(TypeError, match="is not iterable"):
-            message = totest.initial_condition_message(binary=BinaryStar,\
-                                                       ini_params=1)
-        with raises(TypeError, match="can only concatenate str"):
-            message = totest.initial_condition_message(binary=BinaryStar,\
-                                                       ini_params=[1,2])
-        assert totest.initial_condition_message(binary=BinaryStar, ini_params=\
-                                                ["a: 1\n", "b: 2\n"]) ==\
-               "a: 1\nb: 2\n"
-
 
 class TestPOSYDONError:
     @fixture
@@ -107,70 +84,23 @@ class TestPOSYDONError:
         # initialize an instance of the class with a message via key
         return totest.POSYDONError(message="test message with key")
 
-    @fixture
-    def POSYDONError_object(self, artificial_object):
-        # initialize an instance of the class with an artifical object in a
-        # list via key
-        return totest.POSYDONError(objects=[artificial_object])
-
-    @fixture
-    def POSYDONError_SingleStar(self, SingleStar):
-        # initialize an instance of the class with a SingleStar object
-        return totest.POSYDONError(objects=SingleStar)
-
-    @fixture
-    def POSYDONError_BinaryStar(self, BinaryStar):
-        # initialize an instance of the class with a BinaryStar object
-        return totest.POSYDONError(objects=BinaryStar)
-
-    @fixture
-    def POSYDONError_List(self, artificial_object, SingleStar, BinaryStar):
-        # initialize an instance of the class with a list of objects
-        return totest.POSYDONError(objects=[artificial_object, SingleStar,\
-                                            BinaryStar])
-
     # test the POSYDONError class
-    def test_init(self, POSYDONError, POSYDONError_position, POSYDONError_key,\
-                  POSYDONError_object, artificial_object):
+    def test_init(self, POSYDONError, POSYDONError_position, POSYDONError_key):
         assert isroutine(POSYDONError.__init__)
         # check that the instance is of correct type and all code in the
         # __init__ got executed: the elements are created and initialized
         assert isinstance(POSYDONError, totest.POSYDONError)
         # check defaults
         assert POSYDONError.message == ""
-        assert POSYDONError.objects is None
         # test a passed message via positional argument
         assert POSYDONError_position.message == "test message on position"
-        assert POSYDONError_position.objects is None
         # test a passed message via key
-        error_object = totest.POSYDONError(message="test message with key")
         assert POSYDONError_key.message == "test message with key"
-        assert POSYDONError_key.objects is None
-        # test a passed object
-        assert POSYDONError_object.message == ""
-        assert POSYDONError_object.objects == [artificial_object]
         # test requests on input parameters
         with raises(TypeError, match="message must be a string"):
             error_object = totest.POSYDONError(message=artificial_object)
-        with raises(TypeError, match="objects must be None, a list, a "\
-                                     +"SingleStar object, or a BinaryStar "\
-                                     +"object"):
-            error_object = totest.POSYDONError(objects=artificial_object)
 
-
-    def test_str(self, POSYDONError_position, POSYDONError_object,\
-                 POSYDONError_SingleStar, POSYDONError_BinaryStar,\
-                 POSYDONError_List):
+    def test_str(self, POSYDONError_position):
         assert isroutine(POSYDONError_position.__str__)
         assert str(POSYDONError_position) == "\ntest message on position"
-        # test passed objects
-        assert str(POSYDONError_object) == "\n"
-        assert "OBJECT #(<class 'posydon.binary_evol.singlestar.SingleStar'>)"\
-               in str(POSYDONError_SingleStar)
-        assert "OBJECT #(<class 'posydon.binary_evol.binarystar.BinaryStar'>)"\
-               in str(POSYDONError_BinaryStar)
-        assert "OBJECT #1" not in str(POSYDONError_List)
-        assert "OBJECT #2 (<class 'posydon.binary_evol.singlestar.SingleStar"\
-               + "'>)" in str(POSYDONError_List)
-        assert "OBJECT #3 (<class 'posydon.binary_evol.binarystar.BinaryStar"\
-               + "'>)" in str(POSYDONError_List)
+        

--- a/posydon/unit_tests/utils/test_posydonerror.py
+++ b/posydon/unit_tests/utils/test_posydonerror.py
@@ -18,16 +18,6 @@ def artificial_object():
     # create a dict as test object
     return {'Test': 'object'}
 
-@fixture
-def BinaryStar():
-    # initialize a BinaryStar instance, which is a required argument
-    return totest.BinaryStar()
-
-@fixture
-def SingleStar():
-    # initialize a SingleStar instance, which is a required argument
-    return totest.SingleStar()
-
 # define test classes collecting several test functions
 class TestElements:
     # check for objects, which should be an element of the tested module

--- a/posydon/unit_tests/utils/test_posydonerror.py
+++ b/posydon/unit_tests/utils/test_posydonerror.py
@@ -32,9 +32,9 @@ def SingleStar():
 class TestElements:
     # check for objects, which should be an element of the tested module
     def test_dir(self):
-        elements = ['BinaryStar', 'FlowError', 'GridError', 'MatchingError',\
+        elements = ['bstar', 'FlowError', 'GridError', 'MatchingError',\
                     'ModelError', 'NumericalError', 'POSYDONError',\
-                    'SingleStar', '__authors__', '__builtins__', '__cached__',\
+                    'sstar', '__authors__', '__builtins__', '__cached__',\
                     '__doc__', '__file__', '__loader__', '__name__',\
                     '__package__', '__spec__', 'copy',\
                     'initial_condition_message']

--- a/posydon/unit_tests/utils/test_posydonerror.py
+++ b/posydon/unit_tests/utils/test_posydonerror.py
@@ -26,7 +26,7 @@ class TestElements:
                     'ModelError', 'NumericalError', 'POSYDONError',\
                     '__authors__', '__builtins__', '__cached__',\
                     '__doc__', '__file__', '__loader__', '__name__',\
-                    '__package__', '__spec__', 'copy']
+                    '__package__', '__spec__']
         assert dir(totest) == elements, "There might be added or removed "\
                                         + "objects without an update on the "\
                                         + "unit test."
@@ -102,5 +102,5 @@ class TestPOSYDONError:
 
     def test_str(self, POSYDONError_position):
         assert isroutine(POSYDONError_position.__str__)
-        assert str(POSYDONError_position) == "\ntest message on position"
+        assert str(POSYDONError_position) == "test message on position"
         

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -426,7 +426,6 @@ def beaming(binary):
     else:
         rlo_mdot = 10**binary.lg_mtransfer_rate
 
-    print(rlo_mdot, mdot_edd)
     if rlo_mdot >= mdot_edd:
         if rlo_mdot > 8.5 * mdot_edd:
             # eq. 8 in King A. R., 2009, MNRAS, 393, L41-L44
@@ -600,7 +599,6 @@ def bondi_hoyle(binary, accretor, donor, idx=-1, wind_disk_criteria=True,
 
     # make it Eddington-limited
     mdot_edd = eddington_limit(binary, idx=idx)[0]
-    print(mdot_acc, mdot_edd)
     mdot_acc = np.minimum(mdot_acc, mdot_edd)
 
     return np.squeeze(mdot_acc)
@@ -2372,12 +2370,11 @@ def get_mass_radius_dm_from_profile(profile, m1_i=0.0,
         if np.abs(donor_mass[0] - m1_i) > tolerance:
             Pwarn("Donor mass from the binary class object "
                           "and the profile do not agree", "ClassificationWarning")
-            #print("mass profile/object:", (donor_mass[0]), (m1_i))
+            
         # checking if radius of profile agrees with the radius of the binary
         if np.abs(donor_radius[0] - radius1) > tolerance:
             Pwarn("Donor radius from the binary class object "
                           "and the profile do not agree", "ClassificationWarning")
-            #print("radius profile/object:", (donor_radius[0]), (radius1))
 
         # MANOS: if dm exists as a column, else calculate it from mass column
         if "dm" in profile.dtype.names:
@@ -2650,12 +2647,14 @@ def calculate_binding_energy(donor_mass, donor_radius, donor_dm,
     """
     # Sum of gravitational energy from surface to core boundary
     Grav_energy = 0.0
+
     # Sum of internal energy from surface to core boundary. This is 0 if
     # 'lambda_from_profile_gravitational' or (thermal+radiation+recombination)
     # for "lambda_from_profile_gravitational_plus_internal" or
     # (thermal+radiation) for
     # "lambda_from_profile_gravitational_plus_internal_minus_recombination"
     U_i = 0.0
+    
     # sum from surface to the core. Your core boundary is in element [ind_core]
     # in a normal MESA (and POSYDON) profile
     for i in range(ind_core):
@@ -2665,12 +2664,12 @@ def calculate_binding_energy(donor_mass, donor_radius, donor_dm,
         # integral of gravitational energy as we go deeper into the star
         Grav_energy = Grav_energy + Grav_energy_of_cell
         U_i = U_i + specific_internal_energy[i]*donor_dm[i]*const.Msun
+
     if Grav_energy > 0.0:
-        #print("Grav_energy, donor_mass, donor_dm, donor_radius",
-        #      Grav_energy, donor_mass, donor_dm, donor_radius)
         if not (Grav_energy < tolerance):
             raise ValueError("CEE problem calculating gravitational energy, "
                             "giving positive values.")
+        
     # binding energy of the enevelope equals its gravitational energy +
     # an a_th fraction of its internal energy
     Ebind_i = Grav_energy + factor_internal_energy * U_i
@@ -2738,7 +2737,6 @@ def calculate_Mejected_for_integrated_binding_energy(profile, Ebind_threshold,
 
     if donor_mass[ind_threshold]< mc1_i or  donor_radius[ind_threshold]<rc1_i:
         Pwarn("partial mass ejected is greater than the envelope mass", "EvolutionWarning")   
-        #print("M_ejected, M_envelope = ", donor_mass[0] - donor_mass[ind_threshold], donor_mass[0] - mc1_i)
         mass_threshold = mc1_i
     else:
         mass_threshold = donor_mass[ind_threshold]

--- a/posydon/utils/posydonerror.py
+++ b/posydon/utils/posydonerror.py
@@ -8,54 +8,26 @@ __authors__ = [
     "Matthias Kruckow <Matthias.Kruckow@unige.ch>",
 ]
 
-
-import copy
-
-## BinaryStar and SingleStar must be imported this way to avoid circular imports
-import posydon.binary_evol.binarystar as bstar
-import posydon.binary_evol.singlestar as sstar
-
-
 class POSYDONError(Exception):
     """General POSYDON exception class."""
 
-    def __init__(self, message="", objects=None):
+    def __init__(self, message=""):
         """General POSYDON exception.
 
         Parameters
         ----------
         message : str
             POSYDONError message.
-        objects : None or list of objects
-            A list of accompanied objects (or None if not set), that will be
-            handled differently when `str` method is used. This error can
-            only accept BinaryStar, SingleStar, or a list of each.
-
         """
         if not isinstance(message, str):
             raise TypeError("The error message must be a string.")
-        if ((objects is not None) and
-            (not isinstance(objects, (list, sstar.SingleStar, bstar.BinaryStar)))):
-            raise TypeError("The error objects must be None, a list, a "
-                            "SingleStar object, or a BinaryStar object.")
+        
         self.message = message
-        # copy the objects: we must know their state at the moment of the error
-        self.objects = copy.copy(objects)
         super().__init__(self.message)
 
     def __str__(self):
         """Create the text that accompanies this exception."""
-        result = ""
-        if self.objects is not None:
-            if isinstance(self.objects, list):
-                for i, obj in enumerate(self.objects):
-                    if isinstance(obj, (bstar.BinaryStar, sstar.SingleStar)):
-                        result += f"\n\nOBJECT #{i+1} ({type(obj)}):\n{str(obj)}"
-            elif isinstance(self.objects, (bstar.BinaryStar, sstar.SingleStar)):
-                result += f"\n\nOBJECT #({type(self.objects)}):\n{str(self.objects)}"
-            else: # pragma: no cover
-                pass
-        return result + '\n'+ super().__str__()
+        return super().__str__()
 
 # Subclasses of POSYODONError in alphabetic order
 # Before you add a new subclass check the list of python error classes at the
@@ -75,42 +47,6 @@ class ModelError(POSYDONError):
 
 class NumericalError(POSYDONError):
     """POSYDON error specific for when a binary FAILS due to limitations of numerical methods."""
-
-def initial_condition_message(binary, ini_params=None):
-    """Generate a message with the initial conditions.
-
-        Parameters
-        ----------
-        binary : BinaryStar
-            BinaryStar object to take the initial conditions from.
-        ini_params : None or iterable of str
-            If None take the initial conditions from the binary, otherwise add
-            each item of it to the message.
-
-        Returns
-        -------
-        string
-            The message with the initial conditions.
-
-    """
-    if not isinstance(binary, bstar.BinaryStar):
-        raise TypeError("The binary must be a BinaryStar object.")
-    if ini_params is None:
-        ini_params = ["\nFailed Binary Initial Conditions:\n",
-                    f"S1 mass: {binary.star_1.mass_history[0]} \n",
-                    f"S2 mass: {binary.star_2.mass_history[0]} \n",
-                    f"S1 state: {binary.star_1.state_history[0]} \n",
-                    f"S2 state: { binary.star_2.state_history[0]}\n",
-                    f"orbital period: { binary.orbital_period_history[0] } \n",
-                    f"eccentricity: { binary.eccentricity_history[0]} \n",
-                    f"binary state: { binary.state_history[0] }\n",
-                    f"binary event: { binary.state_history[0] }\n",
-                    f"S1 natal kick array: { binary.star_1.natal_kick_array }\n",
-                    f"S2 natal kick array: { binary.star_2.natal_kick_array}\n"]
-    message = ""
-    for i in ini_params:
-        message += i 
-    return message
 
 
 # There are 5 base exception classes in python: BaseException, Exception,

--- a/posydon/utils/posydonerror.py
+++ b/posydon/utils/posydonerror.py
@@ -10,8 +10,10 @@ __authors__ = [
 
 
 import copy
-from posydon.binary_evol.binarystar import BinaryStar
-from posydon.binary_evol.singlestar import SingleStar
+
+## BinaryStar and SingleStar must be imported this way to avoid circular imports
+import posydon.binary_evol.binarystar as bstar
+import posydon.binary_evol.singlestar as sstar
 
 
 class POSYDONError(Exception):
@@ -33,7 +35,7 @@ class POSYDONError(Exception):
         if not isinstance(message, str):
             raise TypeError("The error message must be a string.")
         if ((objects is not None) and
-            (not isinstance(objects, (list, SingleStar, BinaryStar)))):
+            (not isinstance(objects, (list, sstar.SingleStar, bstar.BinaryStar)))):
             raise TypeError("The error objects must be None, a list, a "
                             "SingleStar object, or a BinaryStar object.")
         self.message = message
@@ -47,9 +49,9 @@ class POSYDONError(Exception):
         if self.objects is not None:
             if isinstance(self.objects, list):
                 for i, obj in enumerate(self.objects):
-                    if isinstance(obj, (BinaryStar, SingleStar)):
+                    if isinstance(obj, (bstar.BinaryStar, sstar.SingleStar)):
                         result += f"\n\nOBJECT #{i+1} ({type(obj)}):\n{str(obj)}"
-            elif isinstance(self.objects, (BinaryStar, SingleStar)):
+            elif isinstance(self.objects, (bstar.BinaryStar, sstar.SingleStar)):
                 result += f"\n\nOBJECT #({type(self.objects)}):\n{str(self.objects)}"
             else: # pragma: no cover
                 pass
@@ -91,7 +93,7 @@ def initial_condition_message(binary, ini_params=None):
             The message with the initial conditions.
 
     """
-    if not isinstance(binary, BinaryStar):
+    if not isinstance(binary, bstar.BinaryStar):
         raise TypeError("The binary must be a BinaryStar object.")
     if ini_params is None:
         ini_params = ["\nFailed Binary Initial Conditions:\n",


### PR DESCRIPTION
This PR addresses Issue #458. It adds an error check for any binaries that enter an undefined state, and also creates a list of know undefined states in the flow that exist and don't need to be fixed, like those discussed in the issue.