### PR TITLE
Update meta.yaml to 2.0.0.pre1

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "posydon" %}
-{% set version = "2.0.0-pre1" %}
+{% set version = "2.0.0.pre1" %}
 
 package:
   name: "{{ name|lower }}"


### PR DESCRIPTION
Conda does not support '-' in the version naming.