### PR TITLE
No check for WD formation in double CE case

### DIFF
--- a/posydon/unit_tests/utils/test_common_functions.py
+++ b/posydon/unit_tests/utils/test_common_functions.py
@@ -1151,6 +1151,17 @@ class TestFunctions:
         binary.star_2.center_gamma_history=[]
         assert totest.get_binary_state_and_event_and_mt_case(binary, i=0) ==\
                ['detached', None, 'None']
+        # both stars overfill RL leading to double CE while WD condition is
+        # fulfilled as well
+        tests = [(2.0, 1.0, 'oDoubleCE1'), (1.0, 2.0, 'oDoubleCE2')]
+        for (ro1, ro2, e) in tests:
+            binary.rl_relative_overflow_1 = ro1
+            binary.rl_relative_overflow_2 = ro2
+            assert totest.get_binary_state_and_event_and_mt_case(binary,\
+                   interpolation_class='unstable_MT') == ['contact', e, 'None']
+        # stable contact leading to WD formation
+        assert totest.get_binary_state_and_event_and_mt_case(binary,\
+               interpolation_class=None) == ['contact', 'CC1', 'None']
 
     def test_get_binary_state_and_event_and_mt_case_array(self, binary,\
                                                           monkeypatch):

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -1103,8 +1103,21 @@ def get_binary_state_and_event_and_mt_case(binary, interpolation_class=None,
         if interpolation_class == 'unstable_MT':
             if rl_overflow1>=rl_overflow2:           # star 1 initiated CE
                 result = ['contact', 'oCE1', 'None']
+                # Check for double CE
+                comp_star = binary.star_2
+                if comp_star.state not in ["H-rich_Core_H_burning",
+                                           "stripped_He_Core_He_burning", "WD",
+                                           "NS", "BH"]:
+                    result[1] = "oDoubleCE1"
             else:                                   # star 2 initiated CE
                 result = ['contact', 'oCE2', 'None']
+                # Check for double CE
+                comp_star = binary.star_1
+                if comp_star.state not in ["H-rich_Core_H_burning",
+                                           "stripped_He_Core_He_burning", "WD",
+                                           "NS", "BH"]:
+                    result[1] = "oDoubleCE2"
+            return result
     elif no_rlof:                                   # no MT in any star
         result = ['detached', None, 'None']
     elif rlof1 and not rlof2:                       # only in star 1
@@ -1119,21 +1132,6 @@ def get_binary_state_and_event_and_mt_case(binary, interpolation_class=None,
             return ['RLO2', 'oCE2', mt_flag_2_str]
     else:                                           # undetermined in any star
         result = ["undefined", None, 'None']
-
-    if result[1] == "oCE1":
-        # Check for double CE
-        comp_star = binary.star_2
-        if comp_star.state not in [
-                "H-rich_Core_H_burning",
-                "stripped_He_Core_He_burning", "WD", "NS", "BH"]:
-            result[1] = "oDoubleCE1"
-    elif result[1] == "oCE2":
-        # Check for double CE
-        comp_star = binary.star_1
-        if comp_star.state not in [
-                "H-rich_Core_H_burning",
-                "stripped_He_Core_He_burning", "WD", "NS", "BH"]:
-            result[1] = "oDoubleCE2"
 
     if ("Central_C_depletion" in state1
             or "Central_He_depleted" in state1


### PR DESCRIPTION
Currently, the check for WD formation may partly overwrites the double CE case, which it shouldn't do.

- [x] Move double CE into contact detection and return afterwards to skip checks on WD formation.