### PR TITLE
add missing binaries to UNDEFINED_STATES in flow chart

### DIFF
--- a/posydon/binary_evol/flow_chart.py
+++ b/posydon/binary_evol/flow_chart.py
@@ -137,7 +137,9 @@ UNDEFINED_STATES = [
     ('NS', 'H-rich_Core_H_burning', 'disrupted', 'CC2'),
     ('NS', 'H-rich_Core_H_burning', 'detached', 'CC2'),
     ('BH', 'H-rich_Core_H_burning', 'disrupted', 'CC2'),
-    ('BH', 'H-rich_Core_H_burning', 'detached', 'CC2')
+    ('BH', 'H-rich_Core_H_burning', 'detached', 'CC2'),
+    ('WD', 'H-rich_Core_H_burning', 'disrupted', 'CC2'),
+    ('WD', 'H-rich_Core_H_burning', 'detached', 'CC2')
 ]
 
 # dynamically construct the flow chart

--- a/posydon/binary_evol/flow_chart.py
+++ b/posydon/binary_evol/flow_chart.py
@@ -133,14 +133,10 @@ BINARY_EVENTS_OF_SN_OR_AFTER_DETACHED = BINARY_EVENTS_ALL.copy()
 
 ## a list of known total binary states that can occur, 
 ## but are not in the flow chart and will not be added to POSYDON
-UNDEFINED_STATES = [
-    ('NS', 'H-rich_Core_H_burning', 'disrupted', 'CC2'),
-    ('NS', 'H-rich_Core_H_burning', 'detached', 'CC2'),
-    ('BH', 'H-rich_Core_H_burning', 'disrupted', 'CC2'),
-    ('BH', 'H-rich_Core_H_burning', 'detached', 'CC2'),
-    ('WD', 'H-rich_Core_H_burning', 'disrupted', 'CC2'),
-    ('WD', 'H-rich_Core_H_burning', 'detached', 'CC2')
-]
+UNDEFINED_STATES = []
+for s1 in STAR_STATES_CO:
+    for b in ['disrupted', 'detached']:
+        UNDEFINED_STATES.append((s1, 'H-rich_Core_H_burning', b, 'CC2'))
 
 # dynamically construct the flow chart
 POSYDON_FLOW_CHART = {}

--- a/posydon/binary_evol/flow_chart.py
+++ b/posydon/binary_evol/flow_chart.py
@@ -135,7 +135,9 @@ BINARY_EVENTS_OF_SN_OR_AFTER_DETACHED = BINARY_EVENTS_ALL.copy()
 ## but are not in the flow chart and will not be added to POSYDON
 UNDEFINED_STATES = [
     ('NS', 'H-rich_Core_H_burning', 'disrupted', 'CC2'),
-    ('NS', 'H-rich_Core_H_burning', 'detached', 'CC2')
+    ('NS', 'H-rich_Core_H_burning', 'detached', 'CC2'),
+    ('BH', 'H-rich_Core_H_burning', 'disrupted', 'CC2'),
+    ('BH', 'H-rich_Core_H_burning', 'detached', 'CC2')
 ]
 
 # dynamically construct the flow chart


### PR DESCRIPTION
This addresses Issue #488 for binaries failing with this state: ('BH', 'H-rich_Core_H_burning', 'detached', 'CC2').
This is the same issue that was fixed in PR #468 , just for binaries with primary BHs rather than NSs.
I have added these missing states to the flow chart.