### PR TITLE
Update installation-guide.rst to include note about adding conda-forge

### DIFF
--- a/docs/_source/getting-started/installation-guide.rst
+++ b/docs/_source/getting-started/installation-guide.rst
@@ -29,6 +29,12 @@ Using Anaconda (Recommended)
 
         conda activate posydon_env
 
+    As many of the required versions of packages are available on ``conda-forge`` you may need to add this channel to conda if you have not already:
+
+    .. code-block:: bash
+
+        conda config --add channels conda-forge
+
 3. **Install POSYDON**
 
     .. warning::

--- a/docs/_source/troubleshooting-faqs/installation-issues.rst
+++ b/docs/_source/troubleshooting-faqs/installation-issues.rst
@@ -10,7 +10,7 @@ Common Installation Issues
 
 1. **Failed Dependencies**:
     - **Description**: Sometimes, certain dependencies might fail to install or conflict with pre-existing ones.
-    - **Solution**: Try installing the failed dependencies separately using ``pip`` or ``conda`` before installing POSYDON. If using ``conda``, consider creating a fresh environment specifically for POSYDON.
+    - **Solution**: Try installing the failed dependencies separately using ``pip`` or ``conda`` before installing POSYDON. If using ``conda``, consider creating a fresh environment specifically for POSYDON. Additionally, some of the package versions are only available on ``conda-forge``. Please ensure that ``conda-forge`` has been added to conda as a channel using the command ``conda config --add channels conda-forge``.
 
     We try our best to keep the dependencies updated and compatible. However, if you encounter issues, please let us know!
 


### PR DESCRIPTION
I came across an issue related to installation. It turns out that many of the required packages specify versions only available on conda-forge which can cause a huge headache for unaware users. I have updated the installation documentation to include this note.