### PR TITLE
add more dump_rate info to docs

### DIFF
--- a/docs/_source/components-overview/pop_syn/population_params.rst
+++ b/docs/_source/components-overview/pop_syn/population_params.rst
@@ -652,7 +652,7 @@ It also contains which sampling distributions to use for the initial conditions 
 
   * - ``dump_rate``
     - | Batch save after evolving N binaries.
-    - | To facilitate I/O performance, this should be higher than 500 for populations of 100.000 binaries or more.
+    - | To facilitate I/O performance, this should be at least 500 for populations of 100.000 binaries or more.
     - ``2000``
 
   * - ``temp_directory``

--- a/docs/_source/components-overview/pop_syn/population_params.rst
+++ b/docs/_source/components-overview/pop_syn/population_params.rst
@@ -652,7 +652,7 @@ It also contains which sampling distributions to use for the initial conditions 
 
   * - ``dump_rate``
     - | Batch save after evolving N binaries.
-    - | To facilitate I/O performance, this should not be set below 500 for populations of 100.000 binaries or more. 
+    - | To facilitate I/O performance, this should be higher than 500 for populations of 100.000 binaries or more.
     - ``2000``
 
   * - ``temp_directory``

--- a/docs/_source/components-overview/pop_syn/population_params.rst
+++ b/docs/_source/components-overview/pop_syn/population_params.rst
@@ -652,6 +652,7 @@ It also contains which sampling distributions to use for the initial conditions 
 
   * - ``dump_rate``
     - | Batch save after evolving N binaries.
+    - | To facilitate I/O performance, this should not be set below 500 for populations of 100.000 binaries or more. 
     - ``2000``
 
   * - ``temp_directory``

--- a/docs/_source/troubleshooting-faqs/code-questions.rst
+++ b/docs/_source/troubleshooting-faqs/code-questions.rst
@@ -46,7 +46,7 @@ Frequently Asked Questions
     
     The memory usage of the 8000 :code:`dump_rate` run is stable at around 6GB, while the 10.000 :code:`dump_rate` run is stable at around 6.8GB.
 
-    In general, the :code:`dump_rate` should not be set below 500 for populations of 100.000 binaries or more.
+    In general, the :code:`dump_rate` should be at least 500 for populations of 100.000 binaries or more.
     Setting a very low :code:`dump_rate` for larger populations can potentially introduce I/O issues during the reading, writing, and merging of output files.
 
 

--- a/docs/_source/troubleshooting-faqs/code-questions.rst
+++ b/docs/_source/troubleshooting-faqs/code-questions.rst
@@ -46,6 +46,9 @@ Frequently Asked Questions
     
     The memory usage of the 8000 :code:`dump_rate` run is stable at around 6GB, while the 10.000 :code:`dump_rate` run is stable at around 6.8GB.
 
+    In general, the :code:`dump_rate` should not be set below 500 for populations of 100.000 binaries or more.
+    Setting a very low :code:`dump_rate` for larger populations can potentially introduce I/O issues during the reading, writing, and merging of output files.
+
 
 4. **What should the walltime and job array size be for my population synthesis run?**
 

--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -281,6 +281,7 @@
   # set maximum ram per cpu before batch saving (GB)
   dump_rate = 2000
   # batch save after evolving N binaries
+  # this should not be set below 500 for populations of 100,000 binaries or more
   temp_directory = 'batches'
   # folder for keeping batch files
   tqdm = False
@@ -298,7 +299,6 @@
   history_verbose = False
   # if True, record extra functional steps in the output DataFrames
   # (These steps represent internal workings of POSYDON rather than physical phases of evolution)
-  # Random Number Generation
   entropy = None
   # `None` uses system entropy (recommended)
   number_of_binaries = 10

--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -281,7 +281,7 @@
   # set maximum ram per cpu before batch saving (GB)
   dump_rate = 2000
   # batch save after evolving N binaries
-  # this should not be set below 500 for populations of 100,000 binaries or more
+  # this should be at least 500 for populations of 100,000 binaries or more
   temp_directory = 'batches'
   # folder for keeping batch files
   tqdm = False


### PR DESCRIPTION
I have added more explicit information to the docs and default `.ini` file about the `dump_rate` settings to help users avoid Issue #478.
