### PR TITLE
chi_eff NaN replace by 0

### DIFF
--- a/posydon/popsyn/transient_select_funcs.py
+++ b/posydon/popsyn/transient_select_funcs.py
@@ -147,17 +147,20 @@ def chi_eff(m_1, m_2, a_1, a_2, tilt_1, tilt_2):
         
     '''
     if pd.isna(a_1).any():
-        Pwarn("a_1 contains NaN, replacing with 0.0", 'ReplaceValueWarning')
+        Pwarn("a_1 contains undefined values, replacing them with 0.0",
+              'ReplaceValueWarning')
         a_1[pd.isna(a_1)] = 0.0
     if np.isnan(a_2).any():
-        Pwarn("a_2 contains NaN, replacing with 0.0", 'ReplaceValueWarning')
+        Pwarn("a_2 contains undefined values, replacing them with 0.0",
+              'ReplaceValueWarning')
         a_2[pd.isna(a_2)] = 0.0
     if np.isnan(tilt_1).any():
-        Pwarn("tilt_1 contains NaN, replacing with 0.0", 'ReplaceValueWarning')
-        
+        Pwarn("tilt_1 contains undefined values, replacing them with 0.0",
+              'ReplaceValueWarning')
         tilt_1[pd.isna(tilt_1)] = 0.0
     if np.isnan(tilt_2).any():
-        Pwarn("tilt_2 contains NaN, replacing with 0.0", 'ReplaceValueWarning')
+        Pwarn("tilt_2 contains undefined values, replacing them with 0.0",
+              'ReplaceValueWarning')
         tilt_2[pd.isna(tilt_2)] = 0.
     return (m_1*a_1*np.cos(tilt_1)+m_2*a_2*np.cos(tilt_2))/(m_1+m_2)
 

--- a/posydon/popsyn/transient_select_funcs.py
+++ b/posydon/popsyn/transient_select_funcs.py
@@ -123,7 +123,29 @@ def GRB_selection(history_chunk, oneline_chunk, formation_channels_chunk=None, S
 
 
 def chi_eff(m_1, m_2, a_1, a_2, tilt_1, tilt_2):
-    '''Calculate the effective spin of two masses.'''
+    '''Calculate the effective spin of two masses.
+    
+    Parameters
+    ----------
+    m_1 : np.ndarray
+        The mass of the first BH.
+    m_2 : np.ndarray
+        The mass of the second BH.
+    a_1 : np.ndarray
+        The spin of the first BH.
+    a_2 : np.ndarray
+        The spin of the second BH.
+    tilt_1 : np.ndarray
+        The tilt of the first BH.
+    tilt_2 : np.ndarray
+        The tilt of the second BH.
+    
+    Returns
+    -------
+    np.ndarray
+        The effective spin of the BHs.
+        
+    '''
     if np.isnan(a_1).any():
         Pwarn("a_1 contains NaN, replacing with 0.0", 'ReplaceValueWarning')
         a_1 = np.nan_to_num(a_1, nan=0.0)
@@ -136,7 +158,7 @@ def chi_eff(m_1, m_2, a_1, a_2, tilt_1, tilt_2):
     if np.isnan(tilt_2).any():
         Pwarn("tilt_2 contains NaN, replacing with 0.0", 'ReplaceValueWarning')
         tilt_2 = np.nan_to_num(tilt_2, nan=0.0)
-    return (m_1*a_1*np.cos(tilt_1)+m_2*a_2*np.cos(tilt_2))/(m_1+m_2)
+    return np.ndarray((m_1*a_1*np.cos(tilt_1)+m_2*a_2*np.cos(tilt_2))/(m_1+m_2))
 
 def m_chirp(m_1, m_2):
     '''Calculate the chirp mass of two masses.'''

--- a/posydon/popsyn/transient_select_funcs.py
+++ b/posydon/popsyn/transient_select_funcs.py
@@ -158,7 +158,7 @@ def chi_eff(m_1, m_2, a_1, a_2, tilt_1, tilt_2):
     if np.isnan(tilt_2).any():
         Pwarn("tilt_2 contains NaN, replacing with 0.0", 'ReplaceValueWarning')
         tilt_2 = np.nan_to_num(tilt_2, nan=0.0)
-    return np.ndarray((m_1*a_1*np.cos(tilt_1)+m_2*a_2*np.cos(tilt_2))/(m_1+m_2))
+    return (m_1*a_1*np.cos(tilt_1)+m_2*a_2*np.cos(tilt_2))/(m_1+m_2)
 
 def m_chirp(m_1, m_2):
     '''Calculate the chirp mass of two masses.'''

--- a/posydon/popsyn/transient_select_funcs.py
+++ b/posydon/popsyn/transient_select_funcs.py
@@ -4,9 +4,9 @@ import posydon.popsyn.selection_effects as selection_effects
 from posydon.config import PATH_TO_POSYDON_DATA
 import os
 from tqdm import tqdm
-
-
 import warnings
+from posydon.utils.posydonwarning import Pwarn
+
 # This is to suppress the performance warnings from pandas
 # These warnings are not important for the user
 # We should alter the code to remove these warnings, but for now we suppress them
@@ -124,6 +124,18 @@ def GRB_selection(history_chunk, oneline_chunk, formation_channels_chunk=None, S
 
 def chi_eff(m_1, m_2, a_1, a_2, tilt_1, tilt_2):
     '''Calculate the effective spin of two masses.'''
+    if np.isnan(a_1).any():
+        Pwarn("a_1 contains NaN, replacing with 0.0", 'ReplaceValueWarning')
+        a_1 = np.nan_to_num(a_1, nan=0.0)
+    if np.isnan(a_2).any():
+        Pwarn("a_2 contains NaN, replacing with 0.0", 'ReplaceValueWarning')
+        a_2 = np.nan_to_num(a_2, nan=0.0)
+    if np.isnan(tilt_1).any():
+        Pwarn("tilt_1 contains NaN, replacing with 0.0", 'ReplaceValueWarning')
+        tilt_1 = np.nan_to_num(tilt_1, nan=0.0)
+    if np.isnan(tilt_2).any():
+        Pwarn("tilt_2 contains NaN, replacing with 0.0", 'ReplaceValueWarning')
+        tilt_2 = np.nan_to_num(tilt_2, nan=0.0)
     return (m_1*a_1*np.cos(tilt_1)+m_2*a_2*np.cos(tilt_2))/(m_1+m_2)
 
 def m_chirp(m_1, m_2):

--- a/posydon/popsyn/transient_select_funcs.py
+++ b/posydon/popsyn/transient_select_funcs.py
@@ -150,15 +150,15 @@ def chi_eff(m_1, m_2, a_1, a_2, tilt_1, tilt_2):
         Pwarn("a_1 contains undefined values, replacing them with 0.0",
               'ReplaceValueWarning')
         a_1[pd.isna(a_1)] = 0.0
-    if np.isnan(a_2).any():
+    if pd.isna(a_2).any():
         Pwarn("a_2 contains undefined values, replacing them with 0.0",
               'ReplaceValueWarning')
         a_2[pd.isna(a_2)] = 0.0
-    if np.isnan(tilt_1).any():
+    if pd.isna(tilt_1).any():
         Pwarn("tilt_1 contains undefined values, replacing them with 0.0",
               'ReplaceValueWarning')
         tilt_1[pd.isna(tilt_1)] = 0.0
-    if np.isnan(tilt_2).any():
+    if pd.isna(tilt_2).any():
         Pwarn("tilt_2 contains undefined values, replacing them with 0.0",
               'ReplaceValueWarning')
         tilt_2[pd.isna(tilt_2)] = 0.

--- a/posydon/popsyn/transient_select_funcs.py
+++ b/posydon/popsyn/transient_select_funcs.py
@@ -146,18 +146,19 @@ def chi_eff(m_1, m_2, a_1, a_2, tilt_1, tilt_2):
         The effective spin of the BHs.
         
     '''
-    if np.isnan(a_1).any():
+    if pd.isna(a_1).any():
         Pwarn("a_1 contains NaN, replacing with 0.0", 'ReplaceValueWarning')
-        a_1 = np.nan_to_num(a_1, nan=0.0)
+        a_1[pd.isna(a_1)] = 0.0
     if np.isnan(a_2).any():
         Pwarn("a_2 contains NaN, replacing with 0.0", 'ReplaceValueWarning')
-        a_2 = np.nan_to_num(a_2, nan=0.0)
+        a_2[pd.isna(a_2)] = 0.0
     if np.isnan(tilt_1).any():
         Pwarn("tilt_1 contains NaN, replacing with 0.0", 'ReplaceValueWarning')
-        tilt_1 = np.nan_to_num(tilt_1, nan=0.0)
+        
+        tilt_1[pd.isna(tilt_1)] = 0.0
     if np.isnan(tilt_2).any():
         Pwarn("tilt_2 contains NaN, replacing with 0.0", 'ReplaceValueWarning')
-        tilt_2 = np.nan_to_num(tilt_2, nan=0.0)
+        tilt_2[pd.isna(tilt_2)] = 0.
     return (m_1*a_1*np.cos(tilt_1)+m_2*a_2*np.cos(tilt_2))/(m_1+m_2)
 
 def m_chirp(m_1, m_2):


### PR DESCRIPTION
Might close #319. But it has two parts:

1. NaN's in a nearest neighbour run, which might be cause by a negative spin. Unclear how we should proceed with this.
2. NaN's in a initial-final run. These are most likely caused be a mismatch between the interpolation class and CO type. We can't really fix these without fixing the classifier. This allows the `chi_eff` calculation to still work while there are NaN values in the spins.

When values are replaced, a warning is raised.