### PR TITLE
Decouple ECSN treatment from SN_MODELS

### DIFF
--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -546,9 +546,9 @@ class StepSN(object):
                 else:
                     MODEL_properties = getattr(star, MODEL_NAME_SEL)
 
-                    SN_type = check_SN_type(m_core=star.co_core_mass,
-                                            m_He_core=star.he_core_mass,
-                                            m_star=star.mass)[3]
+                    SN_type = self.check_SN_type(m_core=star.co_core_mass,
+                                                 m_He_core=star.he_core_mass,
+                                                 m_star=star.mass)[3]
                     if self.use_profiles and profile is not None:
                         alternative = "Instead use profiles."
                     elif self.use_core_masses:

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -714,6 +714,10 @@ class StepSN(object):
                     # is used to get the compact object spin
                     star.mass = m_grav
                     if m_grav >= self.max_NS_mass:
+                        if SN_type == "ECSN":
+                            Pwarn("An ECSN should not form a black hole: "
+                                  f"m_grav={m_grav}.",
+                                  "InappropriateValueWarning")
                         # see Eq. 14, Fryer, C. L., Belczynski, K., Wiktorowicz,
                         # G., Dominik, M., Kalogera, V., & Holz, D. E. (2012), ApJ, 749(1), 91.
 
@@ -845,6 +849,10 @@ class StepSN(object):
                 elif self.use_core_masses or SN_type == "ECSN":
                     star.mass = m_grav
                     if m_grav >= self.max_NS_mass:
+                        if SN_type == "ECSN":
+                            Pwarn("An ECSN should not form a black hole: "
+                                  f"m_grav={m_grav}.",
+                                  "InappropriateValueWarning")
                         # see Eq. 14, Fryer, C. L., Belczynski, K., Wiktorowicz,
                         # G., Dominik, M., Kalogera, V., & Holz, D. E. (2012), ApJ, 749(1), 91.
 

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -519,7 +519,8 @@ class StepSN(object):
                             continue
                         if getattr(self, key) != val:
                             if self.verbose:
-                                print(tmp, 'mismatch:', key, getattr(self, key), val)
+                                print(tmp, 'mismatch:', key,
+                                      getattr(self, key), val)
                             tmp = None
                             break
                     if tmp is not None:
@@ -537,16 +538,24 @@ class StepSN(object):
                     # step_disrupted.
                     # allow to continue with the collapse with profile
                     # or core masses
-                    Pwarn(f'{MODEL_NAME_SEL}: The collapsed star '
-                                     'was not interpolated! If use_profiles '
-                                     'or use_core_masses is set to True, '
-                                     'continue with the collapse.', "InterpolationWarning")
+                    Pwarn(f'{MODEL_NAME_SEL}: The collapsed star was not '
+                          'interpolated! If use_profiles or use_core_masses '
+                          'is set to True, continue with the collapse.',
+                          "InterpolationWarning")
                 else:
                     MODEL_properties = getattr(star, MODEL_NAME_SEL)
 
-                    ## Check if SN_type mismatches the CO_type in MODEL or if interpolated MODEL properties are NaN
-                    ## If either are true, interpolated values cannot be used for this SN
-                    if (check_SN_CO_match(MODEL_properties['SN_type'], MODEL_properties['state']) and
+                    if check_SN_type(m_core=star.co_core_mass,
+                                     m_He_core=star.he_core_mass,
+                                     m_star=star.mass)[3] == "ECSN":
+                        # do not use interpolated values for ECSN range
+                        pass
+
+                    ## Check if SN_type mismatches the CO_type in MODEL or if
+                    ## interpolated MODEL properties are NaN
+                    ## If either are true, interpolated values cannot be used
+                    ## for this SN
+                    elif (check_SN_CO_match(MODEL_properties['SN_type'], MODEL_properties['state']) and
                         ~np.isnan(MODEL_properties['mass'])):
 
 
@@ -581,7 +590,8 @@ class StepSN(object):
                             convert_star_to_massless_remnant(star=star)
                             # the mass is set to None
                             # but an orbital kick is still applied.
-                            # Since the mass is set to None, this will lead to a disruption
+                            # Since the mass is set to None, this will lead to
+                            # a disruption
                             # TODO: make it skip the kick caluclation
 
                         if getattr(star, 'SN_type') != 'PISN':
@@ -589,11 +599,11 @@ class StepSN(object):
                         return
 
                     else:
-                        Pwarn(f'{MODEL_NAME_SEL}: The SN_type '
-                                      'does not match the predicted CO, or the interpolated '
-                                      'values for the SN remnant are NaN. '
-                                      'If use_profiles or use_core_masses is set to True, '
-                                      'continue with the collapse.', "ApproximationWarning")
+                        Pwarn(f'{MODEL_NAME_SEL}: The SN_type does not match '
+                              'the predicted CO, or the interpolated values '
+                              'for the SN remnant are NaN. If use_profiles or '
+                              'use_core_masses is set to True, continue with '
+                              'the collapse.', "ApproximationWarning")
                         
             # Verifies the selection of core-collapse mechnism to perform
             # the collapse

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -661,7 +661,7 @@ class StepSN(object):
                     return
 
                 # check if the star was disrupted by the PISN
-                if np.isnan(m_rembar):
+                if pd.isna(m_rembar):
                     convert_star_to_massless_remnant(star=star)
                     return
 
@@ -787,7 +787,7 @@ class StepSN(object):
                     return
 
                 # check if the star was disrupted by the PISN
-                if np.isnan(m_rembar):
+                if pd.isna(m_rembar):
                     convert_star_to_massless_remnant(star=star)
                     return
 
@@ -964,7 +964,7 @@ class StepSN(object):
                 print("")
                 print("The star did NOT lose any mass because of "
                       "PPIN or PISN.")
-            elif not np.isnan(m_PISN):
+            elif not pd.isna(m_PISN):
                 print("")
                 print(
                     "The star with initial mass {:2.2f}".format(m_He_core),
@@ -1142,7 +1142,7 @@ class StepSN(object):
                 "There is no information in the evolutionary history"
                 "about STAR_STATES_CC."
             )
-        if m_core is None or np.isnan(m_core):
+        if m_core is None or pd.isna(m_core):
             # This should not happen
             raise ValueError("The CO core mass is not correct! CO core = {}".
                              format(m_core))
@@ -1752,7 +1752,7 @@ class StepSN(object):
                            and (err > tmp2 - rpre / Apost))
 
                 # SNflag3: check that epost does not exeed 1 or is nan
-                if epost >= 1.0 or np.isnan(epost):
+                if epost >= 1.0 or pd.isna(epost):
                     SNflag3 = False
                 else:
                     SNflag3 = True

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -506,7 +506,7 @@ class StepSN(object):
         # explode
         if state in STAR_STATES_CC:
 
-            SN_type == ""
+            SN_type = ""
             # if no profile is avaiable but interpolation quantities are,
             # use those, else continue with or without profile.
             if self.use_interp_values:

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -514,7 +514,8 @@ class StepSN(object):
                 for MODEL_NAME, MODEL in MODELS.items():
                     tmp = MODEL_NAME
                     for key, val in MODEL.items():
-                        if "use_" in key:
+                        if "use_" in key or key=="ECSN":
+                            # escape values, which are allowed to differ
                             continue
                         if getattr(self, key) != val:
                             if self.verbose:

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -561,6 +561,8 @@ class StepSN(object):
                     if MODEL_properties['SN_type'] == "ECSN":
                         # overwrite ECSN in SN MODEL
                         MODEL_properties['SN_type'] = SN_type
+                        Pwarn(f"ECSN in SN_MODEL replaced by {SN_type}",
+                              "ReplaceValueWarning")
 
                     if SN_type == "ECSN":
                         # do not use interpolated values for ECSN range instead

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -506,6 +506,7 @@ class StepSN(object):
         # explode
         if state in STAR_STATES_CC:
 
+            SN_type == ""
             # if no profile is avaiable but interpolation quantities are,
             # use those, else continue with or without profile.
             if self.use_interp_values:
@@ -557,8 +558,13 @@ class StepSN(object):
                     else:
                         alternative = ""
 
+                    if MODEL_properties['SN_type'] == "ECSN":
+                        # overwrite ECSN in SN MODEL
+                        MODEL_properties['SN_type'] = SN_type
+
                     if SN_type == "ECSN":
-                        # do not use interpolated values for ECSN range
+                        # do not use interpolated values for ECSN range instead
+                        # behave like use_core_masses=True
                         pass
                     ## star's SN_type mismatches one from the MODEL
                     elif SN_type != MODEL_properties['SN_type']:
@@ -701,7 +707,7 @@ class StepSN(object):
                     star.h1_mass_ej, star.he4_mass_ej = \
                         get_ejecta_element_mass_at_collapse(star,star.mass,verbose=self.verbose)
 
-                elif self.use_core_masses:
+                elif self.use_core_masses or SN_type == "ECSN":
                     # If the profile is not available the star spin
                     # is used to get the compact object spin
                     star.mass = m_grav
@@ -834,7 +840,7 @@ class StepSN(object):
                     star.h1_mass_ej, star.he4_mass_ej = \
                         get_ejecta_element_mass_at_collapse(star,star.mass,verbose=self.verbose)
 
-                elif self.use_core_masses:
+                elif self.use_core_masses or SN_type == "ECSN":
                     star.mass = m_grav
                     if m_grav >= self.max_NS_mass:
                         # see Eq. 14, Fryer, C. L., Belczynski, K., Wiktorowicz,

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -575,7 +575,7 @@ class StepSN(object):
                               "ApproximationWarning")
                     ## Check if SN_type mismatches the CO_type in MODEL
                     elif not check_SN_CO_match(MODEL_properties['SN_type'],
-                                               MODEL_properties['state'])
+                                               MODEL_properties['state']):
                         Pwarn(f"{MODEL_NAME_SEL}: The SN_type does not match "
                               "the predicted CO."+alternative,
                               "ApproximationWarning")

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -549,7 +549,7 @@ class StepSN(object):
                     SN_type = self.check_SN_type(m_core=star.co_core_mass,
                                                  m_He_core=star.he_core_mass,
                                                  m_star=star.mass)[3]
-                    if self.use_profiles and profile is not None:
+                    if self.use_profiles and star.profile is not None:
                         alternative = "Instead use profiles."
                     elif self.use_core_masses:
                         alternative = "Instead use core masses."


### PR DESCRIPTION
Currently, ECSN prescriptions are limited to be resolved in the grids, otherwise there won't be interpolators trained on them.

To circumvent this issue, it would be better to check for the interpolated core masses always and determine the NS being formed via ECSN not from the SN_MODELS.

- [x] escape the matching of ECSN when checking the SN_MODEL
- [x] check for ECSN to skip the usage of the SN interpolator values
- [x] check stuff just below or above the ECSN regime (At the moment it only throws a warning and tries to recalculate the SN properties)
- [x] tested on small pop-syn