### PR TITLE
Use of `PATH_*` variables

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -29,11 +29,11 @@ jobs:
 
     - name: Run all tests in posydon/unit_tests
       run: |
-        python -m pip install --upgrade pip
-        pip install .
+        # python -m pip install --upgrade pip
+        # pip install .
         pip install pytest
         pip install pytest-cov
         export PATH_TO_POSYDON=./
         export PATH_TO_POSYDON_DATA=./
         export MESA_DIR=./
-        python -m pytest posydon/unit_tests/ --cov=posydon.utils --cov-branch --cov-report term-missing --cov-fail-under=100 
+        python -m pytest posydon/unit_tests/ --cov=posydon.utils --cov=posydon.config --cov-branch --cov-report term-missing --cov-fail-under=100

--- a/bin/posydon-run-pipeline
+++ b/bin/posydon-run-pipeline
@@ -80,7 +80,7 @@ from posydon.grids.psygrid import (PSyGrid,
 from posydon.grids.post_processing import (post_process_grid,
                                            add_post_processed_quantities)
 from posydon.grids.MODELS import MODELS
-from posydon.utils.common_functions import PATH_TO_POSYDON
+from posydon.config import PATH_TO_POSYDON
 from posydon.utils.gridutils import get_new_grid_name
 from posydon.utils.posydonwarning import (Pwarn,print_stats)
 from posydon.interpolation.IF_interpolation import IFInterpolator

--- a/bin/posydon-setup-pipeline
+++ b/bin/posydon-setup-pipeline
@@ -16,7 +16,7 @@ import pandas as pd
 import numpy as np
 from pprint import pformat
 from posydon.popsyn.io import parse_inifile
-from posydon.utils.common_functions import PATH_TO_POSYDON
+from posydon.config import PATH_TO_POSYDON
 from posydon.utils.gridutils import get_new_grid_name
 from posydon.utils.posydonwarning import Pwarn
 

--- a/bin/posydon-setup-popsyn
+++ b/bin/posydon-setup-popsyn
@@ -149,9 +149,9 @@ if __name__ == '__main__':
             os.mkdir(f'{str_met}_logs')
         except:
             pass
-        create_slurm_submit(MET, args.job_array, args.partition, args.email, args.walltime, args.account, args.mem_per_cpu, PATH_TO_POSYDON, PATH_TO_POSYDON_DATA)
+        create_slurm_submit(MET, args.job_array, args.partition, args.email, args.walltime, args.account, args.mem_per_cpu, PATH_TO_POSYDON, os.path.dirname(PATH_TO_POSYDON_DATA))
         print("SLURM script created")
-        create_slurm_merge(MET, args.partition, args.email, args.merge_walltime, args.account, args.mem_per_cpu, PATH_TO_POSYDON, PATH_TO_POSYDON_DATA)
+        create_slurm_merge(MET, args.partition, args.email, args.merge_walltime, args.account, args.mem_per_cpu, PATH_TO_POSYDON, os.path.dirname(PATH_TO_POSYDON_DATA))
 
     # create submission script for all SLURM 
     filename = 'slurm_submit.sh'

--- a/posydon/binary_evol/CE/step_CEE.py
+++ b/posydon/binary_evol/CE/step_CEE.py
@@ -40,7 +40,7 @@ from posydon.utils import common_functions as cf
 from posydon.utils import constants as const
 from posydon.binary_evol.binarystar import BINARYPROPERTIES
 from posydon.binary_evol.singlestar import STARPROPERTIES
-from posydon.utils.common_functions import PATH_TO_POSYDON
+from posydon.config import PATH_TO_POSYDON
 from posydon.utils.common_functions import check_state_of_star
 from posydon.utils.common_functions import calculate_lambda_from_profile, calculate_Mejected_for_integrated_binding_energy
 from posydon.utils.posydonwarning import Pwarn

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -22,7 +22,7 @@ from scipy.interpolate import PchipInterpolator
 from scipy.optimize import minimize
 from scipy.optimize import root
 
-from posydon.utils.data_download import PATH_TO_POSYDON_DATA
+from posydon.config import PATH_TO_POSYDON_DATA
 from posydon.binary_evol.binarystar import BINARYPROPERTIES
 from posydon.binary_evol.singlestar import STARPROPERTIES
 from posydon.interpolation.interpolation import GRIDInterpolator

--- a/posydon/binary_evol/DT/step_disrupted.py
+++ b/posydon/binary_evol/DT/step_disrupted.py
@@ -8,7 +8,7 @@ __authors__ = [
 ]
 
 
-from posydon.utils.data_download import PATH_TO_POSYDON_DATA
+from posydon.config import PATH_TO_POSYDON_DATA
 from posydon.binary_evol.DT.step_isolated import IsolatedStep
 
 from posydon.binary_evol.flow_chart import (

--- a/posydon/binary_evol/DT/step_initially_single.py
+++ b/posydon/binary_evol/DT/step_initially_single.py
@@ -8,7 +8,7 @@ __authors__ = [
 ]
 
 
-from posydon.utils.data_download import PATH_TO_POSYDON_DATA
+from posydon.config import PATH_TO_POSYDON_DATA
 from posydon.binary_evol.DT.step_isolated import IsolatedStep
 
 from posydon.binary_evol.flow_chart import (

--- a/posydon/binary_evol/DT/step_isolated.py
+++ b/posydon/binary_evol/DT/step_isolated.py
@@ -9,7 +9,7 @@ __authors__ = [
 
 import numpy as np
 
-from posydon.utils.data_download import PATH_TO_POSYDON_DATA
+from posydon.config import PATH_TO_POSYDON_DATA
 from posydon.utils.common_functions import orbital_separation_from_period
 from posydon.binary_evol.DT.step_detached import detached_step
 from posydon.utils.posydonerror import FlowError

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -10,7 +10,7 @@ __authors__ = [
 
 import numpy as np
 
-from posydon.utils.data_download import PATH_TO_POSYDON_DATA
+from posydon.config import PATH_TO_POSYDON_DATA
 from posydon.binary_evol.singlestar import STARPROPERTIES, convert_star_to_massless_remnant
 from posydon.utils.common_functions import check_state_of_star
 from posydon.binary_evol.DT.step_isolated import IsolatedStep

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -237,6 +237,7 @@ class MesaGridStep:
         """Load the interpolator that has been trained on the grid."""
         # Check if interpolation files exist
         filename = os.path.join(self.path,grid_name)
+        print("looking for", filename) # debugging
         if not (os.path.exists(filename.replace('%d','0')) or
                 os.path.exists(filename.replace('_%d',''))):
             data_download()

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -201,18 +201,17 @@ class MesaGridStep:
 
             # Set the interpolation path
             if interpolation_path is None:
-                interpolation_path = (
-                    self.path + os.path.split(grid_name)[0]
-                    + '/interpolators/%s/' % self.interpolation_method)
+                interpolation_path = os.path.join(self.path,
+                    os.path.split(grid_name)[0],
+                    'interpolators/%s' % self.interpolation_method)
 
             # Set the interpolation filename
             if interpolation_filename is None:
-                interpolation_filename = (
-                    interpolation_path
-                    + os.path.split(grid_name)[1].replace('h5', 'pkl'))
+                interpolation_filename = os.path.join(interpolation_path,
+                    os.path.split(grid_name)[1].replace('h5', 'pkl'))
             else:
-                interpolation_filename = (interpolation_path
-                                          + interpolation_filename)
+                interpolation_filename = os.path.join(interpolation_path,
+                                                      interpolation_filename)
 
             self.load_Interp(interpolation_filename)
 

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -27,7 +27,8 @@ from posydon.utils.common_functions import (flip_stars,
                                             convert_metallicity_to_string,
                                             CO_radius, infer_star_state,
                                             set_binary_to_failed,)
-from posydon.utils.data_download import data_download, PATH_TO_POSYDON_DATA
+from posydon.config import PATH_TO_POSYDON_DATA
+from posydon.utils.data_download import data_download
 from posydon.grids.MODELS import MODELS
 from posydon.utils.posydonerror import FlowError, GridError
 from posydon.utils.posydonwarning import Pwarn

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -237,7 +237,6 @@ class MesaGridStep:
         """Load the interpolator that has been trained on the grid."""
         # Check if interpolation files exist
         filename = os.path.join(self.path,grid_name)
-        print("looking for", filename) # debugging
         if not (os.path.exists(filename.replace('%d','0')) or
                 os.path.exists(filename.replace('_%d',''))):
             data_download()

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -35,7 +35,8 @@ import scipy as sp
 import copy
 import pandas as pd
 
-from posydon.utils.data_download import PATH_TO_POSYDON_DATA, data_download
+from posydon.config import PATH_TO_POSYDON_DATA
+from posydon.utils.data_download import data_download
 import posydon.utils.constants as const
 from posydon.utils.common_functions import (is_number, CO_radius,
     orbital_period_from_separation, inspiral_timescale_from_separation,

--- a/posydon/config.py
+++ b/posydon/config.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 def ensure_path(name):
-    """Get the PATH set in the environment
+    """Get the 'PATH_*' variable set in the environment
     
     Parameters
     ----------

--- a/posydon/config.py
+++ b/posydon/config.py
@@ -30,4 +30,5 @@ def ensure_path(name):
 
 # POSYDON environment variables
 PATH_TO_POSYDON = ensure_path("PATH_TO_POSYDON")
-PATH_TO_POSYDON_DATA = ensure_path("PATH_TO_POSYDON_DATA")
+PATH_TO_POSYDON_DATA = os.path.join(ensure_path("PATH_TO_POSYDON_DATA"),
+                                    "POSYDON_data")

--- a/posydon/config.py
+++ b/posydon/config.py
@@ -3,6 +3,31 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+def ensure_path(name):
+    """Get the PATH set in the environment
+    
+    Parameters
+    ----------
+    name : str
+        Name of the environment variable.
+    
+    Returns
+    -------
+    str
+        Defined path or raises an error if the variable is not defined and
+        pointing to a valid path.
+    
+    """
+    if not isinstance(name, str):
+        raise TypeError("'name' has to be a string.")
+    value = os.getenv(name)
+    if value is None:
+        raise NameError(f"{name} is not defined in the environment.")
+    if not os.path.isdir(value):
+        raise NotADirectoryError(f"{value} given in {name} is an invalid "
+                                 "path.")
+    return value
+
 # POSYDON environment variables
-PATH_TO_POSYDON = os.getenv("PATH_TO_POSYDON")
-PATH_TO_POSYDON_DATA = os.getenv("PATH_TO_POSYDON_DATA")
+PATH_TO_POSYDON = ensure_path("PATH_TO_POSYDON")
+PATH_TO_POSYDON_DATA = ensure_path("PATH_TO_POSYDON_DATA")

--- a/posydon/popsyn/star_formation_history.py
+++ b/posydon/popsyn/star_formation_history.py
@@ -13,7 +13,7 @@ import os
 import numpy as np
 import scipy as sp
 from scipy import stats
-from posydon.utils.data_download import PATH_TO_POSYDON_DATA
+from posydon.config import PATH_TO_POSYDON_DATA
 from posydon.utils.constants import age_of_universe
 from posydon.utils.common_functions import (
     rejection_sampler,

--- a/posydon/popsyn/transient_select_funcs.py
+++ b/posydon/popsyn/transient_select_funcs.py
@@ -12,7 +12,7 @@ from posydon.utils.posydonwarning import Pwarn
 # We should alter the code to remove these warnings, but for now we suppress them
 warnings.simplefilter(action='ignore', category=pd.errors.PerformanceWarning)
 
-PATH_TO_PDET_GRID = os.path.join(PATH_TO_POSYDON_DATA, 'POSYDON_data/selection_effects/pdet_grid.hdf5')
+PATH_TO_PDET_GRID = os.path.join(PATH_TO_POSYDON_DATA, 'selection_effects/pdet_grid.hdf5')
 
 def GRB_selection(history_chunk, oneline_chunk, formation_channels_chunk=None, S1_S2='S1'):
     """A GRB selection function to create a transient population of LGRBs.

--- a/posydon/tests/active_learning/psy_cris/test_utils.py
+++ b/posydon/tests/active_learning/psy_cris/test_utils.py
@@ -4,7 +4,7 @@ import unittest
 import numpy as np
 import pandas as pd
 import os
-from posydon.utils.common_functions import PATH_TO_POSYDON
+from posydon.config import PATH_TO_POSYDON
 
 from posydon.active_learning.psy_cris.utils import (
     parse_inifile,

--- a/posydon/tests/binary_evol/CE/test_CEE.py
+++ b/posydon/tests/binary_evol/CE/test_CEE.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 import numpy as np
-from posydon.utils.common_functions import PATH_TO_POSYDON
+from posydon.config import PATH_TO_POSYDON
 from posydon.utils import common_functions as cf
 from posydon.binary_evol.binarystar import BinaryStar
 from posydon.binary_evol.singlestar import SingleStar

--- a/posydon/tests/binary_evol/DT/test_step_detached.py
+++ b/posydon/tests/binary_evol/DT/test_step_detached.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from posydon.utils.common_functions import PATH_TO_POSYDON
+from posydon.config import PATH_TO_POSYDON
 
 from posydon.binary_evol.DT.step_detached import detached_step
 from posydon.binary_evol.DT.step_detached import diffeq

--- a/posydon/tests/binary_evol/SN/test_profile_collapse.py
+++ b/posydon/tests/binary_evol/SN/test_profile_collapse.py
@@ -1,6 +1,6 @@
 import unittest
 import os
-from posydon.utils.common_functions import PATH_TO_POSYDON
+from posydon.config import PATH_TO_POSYDON
 from posydon.grids.psygrid import PSyGrid
 import posydon.utils.constants as const
 from posydon.binary_evol.singlestar import SingleStar

--- a/posydon/tests/binary_evol/SN/test_step_SN.py
+++ b/posydon/tests/binary_evol/SN/test_step_SN.py
@@ -1,6 +1,6 @@
 import unittest
 
-from posydon.utils.common_functions import PATH_TO_POSYDON
+from posydon.config import PATH_TO_POSYDON
 from posydon.binary_evol.SN.step_SN import StepSN
 from posydon.binary_evol.binarystar import BinaryStar
 from posydon.binary_evol.singlestar import SingleStar

--- a/posydon/tests/binary_evol/test_BinaryStar.py
+++ b/posydon/tests/binary_evol/test_BinaryStar.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 import numpy as np
-from posydon.utils.common_functions import PATH_TO_POSYDON
+from posydon.config import PATH_TO_POSYDON
 from posydon.binary_evol.singlestar import SingleStar
 from posydon.binary_evol.binarystar import BinaryStar
 from posydon.grids.psygrid import PSyGrid

--- a/posydon/tests/binary_evol/test_SingleStar.py
+++ b/posydon/tests/binary_evol/test_SingleStar.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 import numpy as np
-from posydon.utils.common_functions import PATH_TO_POSYDON
+from posydon.config import PATH_TO_POSYDON
 from posydon.binary_evol.singlestar import SingleStar
 from posydon.grids.psygrid import PSyGrid
 

--- a/posydon/tests/grids/test_psygrid.py
+++ b/posydon/tests/grids/test_psygrid.py
@@ -4,7 +4,7 @@
 # import os
 # import shutil
 # import zipfile
-# from posydon.utils.common_functions import PATH_TO_POSYDON
+# from posydon.config import PATH_TO_POSYDON
 # from posydon.grids.psygrid import PSyGrid
 #
 # 

--- a/posydon/tests/visualization/test_VHdiagram.py
+++ b/posydon/tests/visualization/test_VHdiagram.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import patch
-from posydon.utils.common_functions import PATH_TO_POSYDON
+from posydon.config import PATH_TO_POSYDON
 import os
 
 from posydon.visualization.VH_diagram.Presenter import Presenter, PresenterMode

--- a/posydon/tests/visualization/test_plot1D.py
+++ b/posydon/tests/visualization/test_plot1D.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import patch
 import os
-from posydon.utils.common_functions import PATH_TO_POSYDON
+from posydon.config import PATH_TO_POSYDON
 from posydon.grids.psygrid import PSyGrid
 
 PATH_TO_GRID = os.path.join(

--- a/posydon/tests/visualization/test_plot2D.py
+++ b/posydon/tests/visualization/test_plot2D.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import patch
-from posydon.utils.common_functions import PATH_TO_POSYDON
+from posydon.config import PATH_TO_POSYDON
 import os
 from posydon.grids.psygrid import PSyGrid
 

--- a/posydon/unit_tests/test_config.py
+++ b/posydon/unit_tests/test_config.py
@@ -46,6 +46,7 @@ class TestValues:
 
     def test_value_PATH_TO_POSYDON_DATA(self):
         assert totest.PATH_TO_POSYDON_DATA is not None
+        assert "POSYDON_data" in totest.PATH_TO_POSYDON_DATA
 
 
 class TestFunctions:

--- a/posydon/unit_tests/test_config.py
+++ b/posydon/unit_tests/test_config.py
@@ -1,0 +1,75 @@
+"""Unit tests of posydon/config.py
+"""
+
+__authors__ = [
+    "Matthias Kruckow <Matthias.Kruckow@unige.ch>"
+]
+
+# import the module which will be tested
+import posydon.config as totest
+# aliases
+os = totest.os
+
+# import other needed code for the tests, which is not already imported in the
+# module you like to test
+from pytest import raises
+from inspect import isroutine
+
+
+# define test classes collecting several test functions
+class TestElements:
+    # check for objects, which should be an element of the tested module
+    def test_dir(self):
+        elements = ['PATH_TO_POSYDON', 'PATH_TO_POSYDON_DATA', '__builtins__',\
+                    '__cached__', '__doc__', '__file__', '__loader__',\
+                    '__name__', '__package__', '__spec__', 'ensure_path',\
+                    'load_dotenv', 'os']
+        assert dir(totest) == elements, "There might be added or removed "\
+                                        + "objects without an update on the "\
+                                        + "unit test."
+
+    def test_instance_ensure_path(self):
+        assert isroutine(totest.ensure_path)
+
+    def test_instance_PATH_TO_POSYDON_DATA(self):
+        assert isinstance(totest.PATH_TO_POSYDON_DATA, (str, bytes,\
+                                                        os.PathLike))
+
+    def test_instance_PATH_TO_POSYDON(self):
+        assert isinstance(totest.PATH_TO_POSYDON, (str, bytes, os.PathLike))
+
+
+class TestValues:
+    # check that the values fit
+    def test_value_PATH_TO_POSYDON(self):
+        assert totest.PATH_TO_POSYDON is not None
+
+    def test_value_PATH_TO_POSYDON_DATA(self):
+        assert totest.PATH_TO_POSYDON_DATA is not None
+
+
+class TestFunctions:
+    # test functions
+    def test_ensure_path(self):
+        # missing argument
+        with raises(TypeError, match="missing 1 required positional "\
+                                     +"argument: 'name'"):
+            totest.ensure_path()
+        # bad input
+        with raises(TypeError, match="'name' has to be a string."):
+            totest.ensure_path(None)
+        # bad input
+        with raises(NameError, match="DOES_NOT_EXIST is not defined in the "\
+                                     +"environment."):
+            totest.ensure_path("DOES_NOT_EXIST")
+        # bad input
+        for k,i in os.environ.items():
+            # search for first item, which is no path to check the error
+            if not os.path.isdir(i):
+                with raises(NotADirectoryError, match=f"{i} given in {k} is "\
+                                                      +"an invalid path."):
+                    totest.ensure_path(k)
+                break
+        # example
+        for n in ["PATH_TO_POSYDON", "PATH_TO_POSYDON_DATA"]:
+            assert totest.ensure_path(n) == os.getenv(n)

--- a/posydon/unit_tests/utils/test_common_functions.py
+++ b/posydon/unit_tests/utils/test_common_functions.py
@@ -71,7 +71,7 @@ class TestElements:
                     'MT_CASE_BC', 'MT_CASE_C', 'MT_CASE_NONBURNING',\
                     'MT_CASE_NO_RLO', 'MT_CASE_TO_STR',\
                     'MT_CASE_UNDETERMINED', 'MT_STR_TO_CASE',\
-                    'PATH_TO_POSYDON', 'Pwarn', 'REL_LOG10_BURNING_THRESHOLD',\
+                    'Pwarn', 'REL_LOG10_BURNING_THRESHOLD',\
                     'RICHNESS_STATES', 'RL_RELATIVE_OVERFLOW_THRESHOLD',\
                     'STATE_NS_STARMASS_UPPER_LIMIT', 'STATE_UNDETERMINED',\
                     'Schwarzschild_Radius', 'THRESHOLD_CENTRAL_ABUNDANCE',\
@@ -111,9 +111,6 @@ class TestElements:
         assert dir(totest) == elements, "There might be added or removed "\
                                         + "objects without an update on the "\
                                         + "unit test."
-
-    def test_instance_PATH_TO_POSYDON(self):
-        assert isinstance(totest.PATH_TO_POSYDON, str)
 
     def test_instance_STATE_UNDETERMINED(self):
         assert isinstance(totest.STATE_UNDETERMINED, str)
@@ -320,9 +317,6 @@ class TestElements:
 
 class TestValues:
     # check that the values fit
-    def test_value_PATH_TO_POSYDON(self):
-        assert '/' in totest.PATH_TO_POSYDON
-
     def test_value_STATE_UNDETERMINED(self):
         assert totest.STATE_UNDETERMINED == "undetermined_evolutionary_state"
 

--- a/posydon/unit_tests/utils/test_data_download.py
+++ b/posydon/unit_tests/utils/test_data_download.py
@@ -7,6 +7,7 @@ __authors__ = [
 
 # import the module which will be tested
 import posydon.utils.data_download as totest
+# aliases
 os = totest.os
 
 # import other needed code for the tests, which is not already imported in the

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -32,8 +32,6 @@ from posydon.utils.limits_thresholds import (THRESHOLD_CENTRAL_ABUNDANCE,
 )
 from posydon.utils.interpolators import interp1d
 
-PATH_TO_POSYDON = os.environ.get("PATH_TO_POSYDON")
-
 
 # Constants related to inferring star states
 STATE_UNDETERMINED = "undetermined_evolutionary_state"

--- a/posydon/utils/data_download.py
+++ b/posydon/utils/data_download.py
@@ -11,12 +11,9 @@ import hashlib
 import progressbar
 import tarfile
 from tqdm import tqdm
+from posydon.config import PATH_TO_POSYDON_DATA
 
-# get path to data, if not provided use the working directory
-PATH_TO_POSYDON_DATA = os.environ.get("PATH_TO_POSYDON_DATA",'./')
 file = os.path.join(PATH_TO_POSYDON_DATA, "POSYDON_data.tar.gz")
-PATH_TO_POSYDON_DATA = os.path.join(PATH_TO_POSYDON_DATA, 'POSYDON_data/')
-
 data_url = "https://zenodo.org/record/14205146/files/POSYDON_data.tar.gz"
 original_md5 = "cf645a45b9b92c2ad01e759eb1950beb"
 

--- a/posydon/utils/data_download.py
+++ b/posydon/utils/data_download.py
@@ -13,7 +13,8 @@ import tarfile
 from tqdm import tqdm
 from posydon.config import PATH_TO_POSYDON_DATA
 
-file = os.path.join(os.path.dirname(PATH_TO_POSYDON_DATA), "POSYDON_data.tar.gz")
+file = os.path.join(os.path.dirname(PATH_TO_POSYDON_DATA),
+                    "POSYDON_data.tar.gz")
 data_url = "https://zenodo.org/record/14205146/files/POSYDON_data.tar.gz"
 original_md5 = "cf645a45b9b92c2ad01e759eb1950beb"
 
@@ -96,7 +97,8 @@ def data_download(file=file, MD5_check=True, verbose=False):
     # extract each file
     print('Extracting POSYDON data from tar file...')
     with tarfile.open(file) as tar:
-        for member in tqdm(iterable=tar.getmembers(), total=len(tar.getmembers())):
+        for member in tqdm(iterable=tar.getmembers(),
+                           total=len(tar.getmembers())):
             tar.extract(member=member, path=directory)
 
     # remove tar files after extracted

--- a/posydon/utils/data_download.py
+++ b/posydon/utils/data_download.py
@@ -53,7 +53,6 @@ def data_download(file=file, MD5_check=True, verbose=False):
             - verbose output
 
     """
-    raise FileExistsError("debugging")
     # First, make sure the path does not exist
     if os.path.exists(file):
         raise FileExistsError(f'POSYDON data already exists at {file}')

--- a/posydon/utils/data_download.py
+++ b/posydon/utils/data_download.py
@@ -53,6 +53,7 @@ def data_download(file=file, MD5_check=True, verbose=False):
             - verbose output
 
     """
+    raise FileExistsError("debugging")
     # First, make sure the path does not exist
     if os.path.exists(file):
         raise FileExistsError(f'POSYDON data already exists at {file}')

--- a/posydon/utils/data_download.py
+++ b/posydon/utils/data_download.py
@@ -13,7 +13,7 @@ import tarfile
 from tqdm import tqdm
 from posydon.config import PATH_TO_POSYDON_DATA
 
-file = os.path.join(PATH_TO_POSYDON_DATA, "POSYDON_data.tar.gz")
+file = os.path.join(PATH_TO_POSYDON_DATA, "../POSYDON_data.tar.gz")
 data_url = "https://zenodo.org/record/14205146/files/POSYDON_data.tar.gz"
 original_md5 = "cf645a45b9b92c2ad01e759eb1950beb"
 

--- a/posydon/utils/data_download.py
+++ b/posydon/utils/data_download.py
@@ -13,7 +13,7 @@ import tarfile
 from tqdm import tqdm
 from posydon.config import PATH_TO_POSYDON_DATA
 
-file = os.path.join(PATH_TO_POSYDON_DATA, "../POSYDON_data.tar.gz")
+file = os.path.join(os.path.dirname(PATH_TO_POSYDON_DATA), "POSYDON_data.tar.gz")
 data_url = "https://zenodo.org/record/14205146/files/POSYDON_data.tar.gz"
 original_md5 = "cf645a45b9b92c2ad01e759eb1950beb"
 

--- a/posydon/visualization/VH_diagram/Presenter.py
+++ b/posydon/visualization/VH_diagram/Presenter.py
@@ -13,7 +13,7 @@ from .MainWindow import MainWindow
 from .PresenterMode import PresenterMode
 
 from posydon.utils.common_functions import orbital_separation_from_period
-from posydon.utils.common_functions import PATH_TO_POSYDON
+from posydon.config import PATH_TO_POSYDON
 
 from datetime import datetime
 import os

--- a/posydon/visualization/plot_pop.py
+++ b/posydon/visualization/plot_pop.py
@@ -7,7 +7,7 @@ import os
 import numpy as np
 import matplotlib as mpl
 import pandas as pd
-from posydon.utils.common_functions import PATH_TO_POSYDON
+from posydon.config import PATH_TO_POSYDON, PATH_TO_POSYDON_DATA
 from posydon.visualization.plot_defaults import DEFAULT_LABELS
 from posydon.utils.constants import Zsun
 from posydon.grids.psygrid import PSyGrid
@@ -15,8 +15,6 @@ from posydon.utils.common_functions import convert_metallicity_to_string
 from posydon.utils.constants import Zsun
 import matplotlib.pyplot as plt
 from posydon.visualization.plot_defaults import DEFAULT_LABELS
-
-PATH_TO_POSYDON_DATA = os.environ.get("PATH_TO_POSYDON_DATA",'./')
 
 plt.style.use(os.path.join(PATH_TO_POSYDON, "posydon/visualization/posydon.mplstyle"))
 
@@ -250,7 +248,7 @@ def plot_popsyn_over_grid_slice(pop,
 
     # load grid
     met = convert_metallicity_to_string(met_Zsun)
-    grid_path = os.path.join(PATH_TO_POSYDON_DATA, f'POSYDON_data/{grid_type}/{met}_Zsun.h5')
+    grid_path = os.path.join(PATH_TO_POSYDON_DATA, f'{grid_type}/{met}_Zsun.h5')
     grid = PSyGrid(verbose=False)
     grid.load(grid_path)
 


### PR DESCRIPTION
We need a common way to deal with our path variables defined in the environment.

- [x] update `config.py`
- [x] add unit test for `config.py`
- [x] import PATHS always from `config.py`
   - include "POSYDON_data" in the python variable `PATH_TO_POSYDON_DATA` on load instead of adding it later
- [x] tested on small pop-syn