### PR TITLE
Add accreted_He_Shell_H_burning stars to flow

### DIFF
--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -54,6 +54,7 @@ LIST_ACCEPTABLE_STATES_FOR_postMS = [
     "H-rich_Core_C_burning",
     "H-rich_Central_C_depletion",
     "H-rich_non_burning",
+    "accreted_He_Shell_H_burning",
     "accreted_He_non_burning"]
 
 LIST_ACCEPTABLE_STATES_FOR_HeStar = [
@@ -75,6 +76,7 @@ STAR_STATES_H_RICH = [
     'H-rich_Central_C_depletion',
     'H-rich_non_burning',
     'accreted_He_Core_H_burning',
+    'accreted_He_Shell_H_burning',
     'accreted_He_non_burning'
 ]
 

--- a/posydon/binary_evol/flow_chart.py
+++ b/posydon/binary_evol/flow_chart.py
@@ -30,6 +30,7 @@ STAR_STATES_ALL = [
     'H-rich_Central_C_depletion',
     'H-rich_non_burning',
     'accreted_He_Core_H_burning',
+    'accreted_He_Shell_H_burning',
     'accreted_He_non_burning',
     'accreted_He_Core_He_burning',
     'stripped_He_Core_He_burning',
@@ -63,7 +64,8 @@ STAR_STATES_HE_RICH = STAR_STATES_NORMALSTAR.copy()
                                          'H-rich_Shell_He_burning',
                                          'H-rich_Core_C_burning',
                                          'H-rich_Central_C_depletion',
-                                         'accreted_He_Core_H_burning']]
+                                         'accreted_He_Core_H_burning',
+                                         'accreted_He_Shell_H_burning']]
 
 STAR_STATES_C_DEPLETION = [st for st in STAR_STATES_ALL if "C_depletion" in st]
 
@@ -90,6 +92,7 @@ STAR_STATES_CC = [
     'stripped_He_non_burning',
     'H-rich_non_burning',
     'H-rich_Shell_H_burning',
+    'accreted_He_Shell_H_burning',
     'accreted_He_non_burning'
     ]
 


### PR DESCRIPTION
This PR addresses Issue #487 where binaries that have accreted_He_Shell_H_burning stars are undefined in the flow. This PR adds this star state to the flow and detached step.

The binary that was failing in the issue now runs fine and the history df looks like this:
<img width="731" alt="Screen Shot 2025-02-27 at 11 34 04 AM" src="https://github.com/user-attachments/assets/b4c5dd96-377b-487f-a9cc-d7bbad91d94a" />
