### PR TITLE
Ensure python version 3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,7 @@ setup(
     install_requires=install_requires,
     tests_require=tests_require,
     extras_require=extras_require,
-    python_requires=">3.10, <3.12",
+    python_requires=">=3.11, <3.12",
     use_2to3=False,
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
- [x] change >3.10 to >=3.11
- [x] tests:
  - In a new python 3.10 environment I now get the error: `ERROR: Package 'posydon' requires a different Python: 3.10.16 not in '<3.12,>=3.11'`
  - In a python 3.11 environment the installation still works.