### PR TITLE
Upgrade setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+# following PEP 621: https://peps.python.org/pep-0621
+# details: https://packaging.python.org/en/latest/guides/writing-pyproject-toml
+
 [build-system]
 requires = ["setuptools >= 76.0.0", "versioneer"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,95 @@
+[build-system]
+requires = ["setuptools >= 76.0.0", "versioneer"]
+build-backend = "setuptools.build_meta"
+
+[project]
+dynamic = [
+  "description",
+  "license",
+  "version",
+  "requires-python",
+  "classifiers",
+  "dependencies",
+  "optional-dependencies",
+]
+name = "posydon"
+#description = "POSYDON the Next Generation of Population Synthesis"
+authors = [
+  {name = "POSYDON Collaboration", email = "posydon.team@gmail.com"},
+]
+maintainers = [
+  {name = "POSYDON Collaboration", email = "posydon.team@gmail.com"},
+]
+#license = 'GPLv3+'
+#version = "2.0.0.dev"
+#requires-python = ">=3.11, <3.12"
+readme = "README.md"
+keywords = [
+  "POSYDON",
+  "Astronomy",
+  "Binary Stars",
+  "Population Synthesis",
+  "MESA",
+]
+#classifiers = [
+#  'Development Status :: 4 - Beta',
+#  'Intended Audience :: Science/Research',
+#  'Intended Audience :: End Users/Desktop',
+#  'Topic :: Scientific/Engineering',
+#  'Topic :: Scientific/Engineering :: Astronomy',
+#  'Topic :: Scientific/Engineering :: Physics',
+#  'Programming Language :: Python',
+#  'Programming Language :: Python :: 3.11',
+#  'Operating System :: POSIX',
+#  'Operating System :: Unix',
+#  'Operating System :: MacOS',
+#  'Natural Language :: English',
+#  'License :: OSI Approved :: GNU General Public License v3 (GPLv3+)',
+#]
+#dependencies = [
+#  'numpy < 2.0.0, >= 1.24.2',
+#  'scipy <= 1.14.1, >= 1.10.1',
+#  'iminuit <= 2.30.1, >= 2.21.3',
+#  'configparser <= 7.1.0, >= 5.3.0',
+#  'astropy <= 6.1.6, >= 5.2.2',
+#  'pandas <= 2.2.3, >= 2.0.0',
+#  'scikit-learn == 1.2.2',
+#  'matplotlib <= 3.9.2, >= 3.9.0',
+#  'matplotlib-label-lines <= 0.7.0, >= 0.5.2',
+#  'h5py <= 3.12.1, >= 3.8.0',
+#  'psutil <= 6.1.0, >= 5.9.4',
+#  'tqdm <= 4.67.0, >= 4.65.0',
+#  'tables <= 3.10.1, >= 3.8.0',
+#  'progressbar2 <= 4.5.0, >= 4.2.0',
+#  'hurry.filesize <= 0.9, >= 0.9',
+#  'python-dotenv <= 1.0.1, >= 1.0.0',
+#]
+
+#[project.optional-dependencies]
+#doc = [
+#  'ipython',
+#  'sphinx >= 8.2.2',
+#  'numpydoc',
+#  'sphinx_rtd_theme',
+#  'sphinxcontrib_programoutput',
+#  'PSphinxTheme',
+#  'nbsphinx',
+#  'pandoc'
+#]
+#vis = [
+#  'PyQt5 <= 5.15.11, >= 5.15.9'
+#]
+#ml = [
+#  'tensorflow >= 2.13.0'
+#]
+#hpc = [
+#  'mpi4py >= 3.0.3'
+#]
+
+[project.urls]
+Homepage = "https://posydon.org"
+Documentation = "https://posydon.org/POSYDON"
+Repository = "https://github.com/POSYDON-code/POSYDON.git"
+Issues = "https://github.com/POSYDON-code/POSYDON/issues"
+Changelog = "https://github.com/POSYDON-code/POSYDON/releases"
+

--- a/setup.py
+++ b/setup.py
@@ -48,13 +48,13 @@ with open("README.md", "rb") as f:
 
 
 # DEPENDENCIES
+setup_requires = [
+    'setuptools >= 76.0.0',
+]
 if 'test' in sys.argv:
-    setup_requires = [
-        'setuptools',
+    setup_requires += [
         'pytest-runner',
     ]
-else:
-    setup_requires = []
 
 
 # These pretty common requirement are commented out. Various syntax types
@@ -149,18 +149,17 @@ setup(
     use_2to3=False,
     classifiers=[
         "Development Status :: 4 - Beta",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3.11",
         "Intended Audience :: Science/Research",
         "Intended Audience :: End Users/Desktop",
-        "Intended Audience :: Science/Research",
-        "Natural Language :: English",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Astronomy",
         "Topic :: Scientific/Engineering :: Physics",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3.11",
         "Operating System :: POSIX",
         "Operating System :: Unix",
         "Operating System :: MacOS",
+        "Natural Language :: English",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3+)",
     ],
 )


### PR DESCRIPTION
The new standard [PEP 621](https://peps.python.org/pep-0621) requires a different file than `setup.py`.

- [x] create `pyproject.toml`
  - fill info
  - try to load as much as possible dynamically from `setup.py` to be backward compatible
- [x] some small cleanup in `setup.py`