### PR TITLE
Add check for valid MODELS in posydon-setup-popsyn

### DIFF
--- a/bin/posydon-setup-popsyn
+++ b/bin/posydon-setup-popsyn
@@ -10,6 +10,7 @@
 import os
 import argparse
 from posydon.popsyn.io import (binarypop_kwargs_from_ini, 
+                               simprop_kwargs_from_ini,
                                create_run_script_text,
                                create_merge_script_text)
 from posydon.config import PATH_TO_POSYDON, PATH_TO_POSYDON_DATA
@@ -17,6 +18,7 @@ from posydon.popsyn.binarypopulation import BinaryPopulation
 from posydon.popsyn.io import binarypop_kwargs_from_ini
 from posydon.utils.common_functions import convert_metallicity_to_string
 from posydon.utils.posydonwarning import Pwarn
+from posydon.grids.MODELS import MODELS
 
 
 def create_run_script(ini_file):
@@ -113,7 +115,45 @@ srun python ./merge_metallicity.py {metallicity}
         Pwarn('Replace '+filename, "OverwriteWarning")
     with open(filename, mode='w') as file:
         file.write(text)
+        
+def check_SN_MODEL_validity(ini_file):
+    '''checks if the step_SN MODEL is valid for this script
 
+    Parameters
+    ----------
+    ini_file : str
+        the path to the ini file
+    
+    Returns
+    -------
+    bool
+        True if the MODEL is valid or use_interp_values=False, False otherwise    
+    '''
+
+    simprop_kwargs = simprop_kwargs_from_ini(ini_file)
+    step_SN_MODEL = simprop_kwargs['step_SN'][1]
+    # always allow the use of non-interpolation values
+    if step_SN_MODEL['use_interp_values'] == False:
+        return True
+    # step_SN MODEL check
+    MODEL_NAME_SEL = None
+    for MODEL_NAME, MODEL in MODELS.items():
+        tmp = MODEL_NAME
+        for key, val in MODEL.items():
+            if "use_" in key or key=="ECSN":
+                # escape values, which are allowed to differ
+                continue
+            if step_SN_MODEL[key] != val:
+                tmp = None
+                break
+        if tmp is not None:
+            MODEL_NAME_SEL = tmp
+
+    if MODEL_NAME_SEL is None:
+        return False
+    else:
+        return True
+        
 
 #################
 # MAIN FUNCTION
@@ -131,6 +171,9 @@ if __name__ == '__main__':
     parser.add_argument('--mem_per_cpu', help='the memory per cpu you would like to use in SLURM format', default='7G')
     parser.add_argument('--account', help='the account you would like to use', default=None)
     args = parser.parse_args()
+
+    if not check_SN_MODEL_validity(args.ini_file):
+        raise ValueError("The step_SN MODEL is not valid for this script. Please check the MODEL in the ini file")
 
     synpop_params = binarypop_kwargs_from_ini(args.ini_file)    
     metallicities = synpop_params['metallicity']

--- a/bin/posydon-setup-popsyn
+++ b/bin/posydon-setup-popsyn
@@ -18,7 +18,7 @@ from posydon.popsyn.binarypopulation import BinaryPopulation
 from posydon.popsyn.io import binarypop_kwargs_from_ini
 from posydon.utils.common_functions import convert_metallicity_to_string
 from posydon.utils.posydonwarning import Pwarn
-from posydon.grids.MODELS import MODELS
+from posydon.grids.MODELS import get_MODEL_NAME
 
 
 def create_run_script(ini_file):
@@ -136,18 +136,7 @@ def check_SN_MODEL_validity(ini_file):
     if step_SN_MODEL['use_interp_values'] == False:
         return True
     # step_SN MODEL check
-    MODEL_NAME_SEL = None
-    for MODEL_NAME, MODEL in MODELS.items():
-        tmp = MODEL_NAME
-        for key, val in MODEL.items():
-            if "use_" in key or key=="ECSN":
-                # escape values, which are allowed to differ
-                continue
-            if step_SN_MODEL[key] != val:
-                tmp = None
-                break
-        if tmp is not None:
-            MODEL_NAME_SEL = tmp
+    MODEL_NAME_SEL = get_MODEL_NAME(step_SN_MODEL)
 
     if MODEL_NAME_SEL is None:
         return False

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -53,7 +53,7 @@ from posydon.binary_evol.SN.profile_collapse import (do_core_collapse_BH,
 from posydon.binary_evol.flow_chart import (STAR_STATES_CO, STAR_STATES_CC,
                                             STAR_STATES_C_DEPLETION)
 
-from posydon.grids.MODELS import MODELS
+from posydon.grids.MODELS import get_MODEL_NAME
 from posydon.utils.posydonerror import ModelError
 from posydon.utils.posydonwarning import Pwarn
 from posydon.utils.common_functions import set_binary_to_failed
@@ -519,23 +519,7 @@ class StepSN(object):
             # use those, else continue with or without profile.
             if self.use_interp_values:
                 # find MODEL_NAME corresponding to class variable
-                MODEL_NAME_SEL = None
-                for MODEL_NAME, MODEL in MODELS.items():
-                    tmp = MODEL_NAME
-                    for key, val in MODEL.items():
-                        if "use_" in key or key=="ECSN":
-                            # escape values, which are allowed to differ
-                            continue
-                        if getattr(self, key) != val:
-                            if self.verbose:
-                                print(tmp, 'mismatch:', key,
-                                      getattr(self, key), val)
-                            tmp = None
-                            break
-                    if tmp is not None:
-                        if self.verbose:
-                            print('matched to model:', tmp)
-                        MODEL_NAME_SEL = tmp
+                MODEL_NAME_SEL = get_MODEL_NAME(vars(self), verbose=self.verbose)
 
                 # check if selected MODEL is supported
                 if MODEL_NAME_SEL is None:

--- a/posydon/grids/MODELS.py
+++ b/posydon/grids/MODELS.py
@@ -176,3 +176,36 @@ MODELS = {
     #     "approx_at_he_depletion": False,
     # },
 }
+
+def get_MODEL_NAME(input_MODEL, verbose=False):
+    '''Find MODEL_NAME that matches input_MODEL.
+    
+    Parameters
+    ----------
+    input_MODEL : dict
+        Dictionary with the properties of the model.
+    
+    Returns
+    -------
+    MODEL_NAME_SEL : str
+        Name of the model in MODELS.py that matches input_MODEL.
+    '''
+    MODEL_NAME_SEL = None
+    for MODEL_NAME, MODEL in MODELS.items():
+        tmp = MODEL_NAME
+        for key, val in MODEL.items():
+            if "use_" in key or key=="ECSN":
+                # escape values, which are allowed to differ
+                continue
+            if input_MODEL[key] != val:
+                if verbose:
+                    print(tmp, 'mismatch:', key,
+                            input_MODEL[key], val)
+                tmp = None
+                break
+        if tmp is not None:
+            if verbose:
+                print('matched to model:', tmp)
+            MODEL_NAME_SEL = tmp
+            
+    return MODEL_NAME_SEL

--- a/posydon/grids/MODELS.py
+++ b/posydon/grids/MODELS.py
@@ -185,7 +185,9 @@ def get_MODEL_NAME(input_MODEL, verbose=False):
     ----------
     input_MODEL : dict
         Dictionary with the properties of the model.
-    
+    verbose : bool (default: False)
+        Enables additional output.
+          
     Returns
     -------
     MODEL_NAME_SEL : str

--- a/posydon/grids/MODELS.py
+++ b/posydon/grids/MODELS.py
@@ -9,6 +9,7 @@ properties of the model used by step_SN.
 
 __authors__ = [
     "Simone Bavera <Simone.Bavera@unige.ch>",
+    "Max Briel <max.briel@gmail.com>",
 ]
 
 from posydon.utils.limits_thresholds import (STATE_NS_STARMASS_UPPER_LIMIT,
@@ -176,3 +177,36 @@ MODELS = {
     #     "approx_at_he_depletion": False,
     # },
 }
+
+def get_MODEL_NAME(input_MODEL, verbose=False):
+    '''Find MODEL_NAME that matches input_MODEL.
+    
+    Parameters
+    ----------
+    input_MODEL : dict
+        Dictionary with the properties of the model.
+    
+    Returns
+    -------
+    MODEL_NAME_SEL : str
+        Name of the model in MODELS.py that matches input_MODEL.
+    '''
+    MODEL_NAME_SEL = None
+    for MODEL_NAME, MODEL in MODELS.items():
+        tmp = MODEL_NAME
+        for key, val in MODEL.items():
+            if "use_" in key or key=="ECSN":
+                # escape values, which are allowed to differ
+                continue
+            if input_MODEL[key] != val:
+                if verbose:
+                    print(tmp, 'mismatch:', key,
+                            input_MODEL[key], val)
+                tmp = None
+                break
+        if tmp is not None:
+            if verbose:
+                print('matched to model:', tmp)
+            MODEL_NAME_SEL = tmp
+            
+    return MODEL_NAME_SEL


### PR DESCRIPTION
Adds a basic check to make sure the parameters defined in the ini file for step_SN is a valid MODEL.

It only checks against the MODELS if `use_interp_values=True`.