### PR TITLE
Enforce `step_SN` inputs (e.g., `engine`) are strings

### DIFF
--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -262,6 +262,12 @@ class StepSN(object):
                     raise ValueError(key + " is not a valid parameter name!")
             for varname in MODEL:
                 default_value = MODEL[varname]
+
+                # Enforce that `engine` is an empty string if not properly set
+                if varname == "engine":
+                    if not isinstance(kwargs[varname], str):
+                        kwargs[varname] = ""
+                        
                 setattr(self, varname, kwargs.get(varname, default_value))
         else:
             for varname in MODEL:

--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -210,7 +210,7 @@
     # 'Sukhbold+16-engine', 'Patton&Sukhbold20-engine'
   engine = 'N20'
     # 'N20' for 'Sukhbold+16-engine',
-    # 'Patton&Sukhbold20-engine' or None for the others
+    # 'Patton&Sukhbold20-engine' or an empty string for the others
   PISN = "Marchant+19"
     # None, "Marchant+19", "Hendriks+23"
   PISN_CO_shift = 0.0


### PR DESCRIPTION
A user experienced long binary population synthesis run times due to an improper input in their `.ini` file. This modifies the supplied default `population_params_default.ini` file to specify that the `engine` property of `step_SN` should be an empty string rather than None, as setting it as None can cause binary evolution to hang.

This also places a check in `step_SN.py` to set `engine` to an empty string in case it is set as None. 

A number of other properties in the `.ini` file allow None as input. We might consider ensuring the inputs accept consistent formats. Should we include additional changes in this PR along those lines?