### PR TITLE
Avoid massless remnants in detached binaries

### DIFF
--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -1655,6 +1655,27 @@ class StepSN(object):
             binary.mass_transfer_case = 'None'
             binary.first_SN_already_occurred = True
 
+        elif ((binary.star_1.state == 'massless_remnant') or
+              (binary.star_2.state == 'massless_remnant')):
+            # the binary should be disrupted when a massless_remnant formed
+            # update the tilt
+            if not binary.first_SN_already_occurred:
+                binary.star_1.spin_orbit_tilt_first_SN = np.nan
+                binary.star_2.spin_orbit_tilt_first_SN = np.nan
+                binary.first_SN_already_occurred = True
+            else:
+                binary.star_1.spin_orbit_tilt_second_SN = np.nan
+                binary.star_2.spin_orbit_tilt_second_SN = np.nan
+
+            binary.state = "disrupted"
+            binary.event = None
+            binary.separation = np.nan
+            binary.eccentricity = np.nan
+            binary.V_sys = np.array([0, 0, 0])
+            binary.time = binary.time_history[-1]
+            binary.orbital_period = np.nan
+            binary.mass_transfer_case = 'None'
+
         else:
 
             # The binary exist: flag_binary is True if the binary is not disrupted


### PR DESCRIPTION
We got cases in the flow, where we had a massless_remnant and a evolving star marked as detached without event. This might come from post PISN, where the binary wasn't updated correctly afterwards.

- [x] set post SN binary to disrupted in case there is a massless_remnant