### PR TITLE
FAQ about slow `conda`

### DIFF
--- a/docs/_source/troubleshooting-faqs/installation-issues.rst
+++ b/docs/_source/troubleshooting-faqs/installation-issues.rst
@@ -20,7 +20,7 @@ To install the `libmamba` solver, run the following command in your environment 
 conda install conda-libmamba-solver
 ```
 
-This will install the libmamba solver, which is a drop-in replacement for the default `conda` solver.
+This will install the `libmamba` solver, which is a drop-in replacement for the default `conda` solver.
 This should speed up solving the environment and installing packages, but is not guaranteed to work in all cases.
 
 2. **Failed Dependencies**:

--- a/docs/_source/troubleshooting-faqs/installation-issues.rst
+++ b/docs/_source/troubleshooting-faqs/installation-issues.rst
@@ -13,7 +13,7 @@ Common Installation Issues
 `conda` can be very slow and sometimes gets stuck on "Verifying transaction" or "Executing transaction", especially when installing packages on a cluster.
 It creates many small files, which can be difficult for HPC clusters to solve.
 One way to speed up the installation is to use the `mamba` package manager, which is a drop-in replacement for `conda` but is much faster.
-Please proceed at your own discretion. Alternatively, you can install the `libmamba` solver to speed up the solving process for new installations in a `conda` environment.
+Please proceed at your own discretion, as this has not been fully vetted. Alternatively, you can install the `libmamba` solver to speed up the solving process for new installations in a `conda` environment.
 To install the `libmamba` solver, run the following command in your environment or `base` environment:
 
 ```bash

--- a/docs/_source/troubleshooting-faqs/installation-issues.rst
+++ b/docs/_source/troubleshooting-faqs/installation-issues.rst
@@ -14,7 +14,7 @@ Common Installation Issues
 It creates many small files, which can be difficult for HPC clusters to solve.
 One way to speed up the installation is to use the `mamba` package manager, which is a drop-in replacement for `conda` but is much faster.
 Please proceed at your own discretion, as this has not been fully vetted. Alternatively, you can install the `libmamba` solver to speed up the solving process for new installations in a `conda` environment.
-To install the `libmamba` solver, run the following command in your environment or `base` environment:
+To install the `libmamba` solver, run the following command in your `conda` environment of choice or `base` `conda` environment:
 
 ```bash
 conda install conda-libmamba-solver

--- a/docs/_source/troubleshooting-faqs/installation-issues.rst
+++ b/docs/_source/troubleshooting-faqs/installation-issues.rst
@@ -12,7 +12,7 @@ Common Installation Issues
 
 `conda` can be very slow and sometimes gets stuck on "Verifying transaction" or "Executing transaction", especially when installing packages on a cluster.
 It creates many small files, which can be difficult for HPC clusters to solve.
-One way to speed up the installation is to use the `mamba` package manager, which is a drop-in replacement for `conda` but is much faster.
+One way to speed up the installation is to use the `mamba` package manager, which is a drop-in replacement for `conda` but is much faster (`click here for more details <https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community>`_).
 Please proceed at your own discretion, as this has not been fully vetted. Alternatively, you can install the `libmamba` solver to speed up the solving process for new installations in a `conda` environment.
 To install the `libmamba` solver, run the following command in your `conda` environment of choice or `base` `conda` environment:
 

--- a/docs/_source/troubleshooting-faqs/installation-issues.rst
+++ b/docs/_source/troubleshooting-faqs/installation-issues.rst
@@ -8,26 +8,41 @@ From time to time, users might encounter issues during the installation of POSYD
 Common Installation Issues
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. **Failed Dependencies**:
+1. **Slow `conda` solving:
+
+`conda` can be very slow and sometimes gets stuck on "Verifying transaction" or "Executing transaction", especially when installing packages on a cluster.
+It creates many small files, which can become very slow on the HPC clusters.
+One way to speed up the installation is to use the `mamba` package manager, which is a drop-in replacement for `conda` but is much faster.
+Please proceed at your own discretion. Alternatively, you can install the libmamba solver to speed up the solving process for new installations in a `conda` environment.
+To install the libmamba solver, run the following command in your environment or `base` environment:
+
+```bash
+conda install conda-libmamba-solver
+```
+
+This will install the libmamba solver, which is a drop-in replacement for the default `conda` solver.
+This should speed up solving the environment and installing packages, but is not guaranteed to work in all cases.
+
+2. **Failed Dependencies**:
     - **Description**: Sometimes, certain dependencies might fail to install or conflict with pre-existing ones.
     - **Solution**: Try installing the failed dependencies separately using ``pip`` or ``conda`` before installing POSYDON. If using ``conda``, consider creating a fresh environment specifically for POSYDON. Additionally, some of the package versions are only available on ``conda-forge``. Please ensure that ``conda-forge`` has been added to conda as a channel using the command ``conda config --add channels conda-forge``.
 
     We try our best to keep the dependencies updated and compatible. However, if you encounter issues, please let us know!
 
-2. **Failed to Set Environment Variables**:
+3. **Failed to Set Environment Variables**:
     - **Description**: After installation, you might forget to set the ``PATH_TO_POSYDON`` and ``PATH_TO_POSYDON_DATA`` environment variables.
     - **Solution**: Refer back to the :ref:`installation guide <installation-guide>` to ensure all post-installation steps are followed.
 
-3. **Insufficient Storage Space**:
+4. **Insufficient Storage Space**:
     - **Description**: POSYDON requires around 40GB of free storage space for the lite MESA simulation library and related files.
     - **Solution**: Ensure you have enough space on your installation drive. Delete unnecessary files or consider using a larger storage solution.
 
-4. **Proxy or Network Issues**:
+5. **Proxy or Network Issues**:
     - **Description**: Installation might fail if you're behind a strict network proxy or firewall.
     - **Solution**: If you're using ``conda``, you can set proxy settings using the ``--proxy`` flag. For pip, you can use the ``--proxy`` flag as well.
 
 
-5. **Error with Experimental Visualization Libraries**:
+6. **Error with Experimental Visualization Libraries**:
     - **Description**: Issues after installing the experimental visualization libraries with ``pip install ".[vis]"``.
     - **Solution**: These libraries are experimental. Please ensure you have all required system dependencies. Consider reaching out to our support channels for more guidance or troubleshooting.
 

--- a/docs/_source/troubleshooting-faqs/installation-issues.rst
+++ b/docs/_source/troubleshooting-faqs/installation-issues.rst
@@ -11,10 +11,10 @@ Common Installation Issues
 1. **Slow `conda` solving:
 
 `conda` can be very slow and sometimes gets stuck on "Verifying transaction" or "Executing transaction", especially when installing packages on a cluster.
-It creates many small files, which can become very slow on the HPC clusters.
+It creates many small files, which can be difficult for HPC clusters to solve.
 One way to speed up the installation is to use the `mamba` package manager, which is a drop-in replacement for `conda` but is much faster.
-Please proceed at your own discretion. Alternatively, you can install the libmamba solver to speed up the solving process for new installations in a `conda` environment.
-To install the libmamba solver, run the following command in your environment or `base` environment:
+Please proceed at your own discretion. Alternatively, you can install the `libmamba` solver to speed up the solving process for new installations in a `conda` environment.
+To install the `libmamba` solver, run the following command in your environment or `base` environment:
 
 ```bash
 conda install conda-libmamba-solver


### PR DESCRIPTION
I've added a small FAQ about a slow `conda` creating of a new environment.

This suggest installing `mamba` or the mamba-solver in `conda`. I tried to be clear that we do not support it. (I've been using the mamba-solver most of the time to speed up solving new environments.