### PR TITLE
Update test to install posydon extras

### DIFF
--- a/.github/workflows/install_extras.yml
+++ b/.github/workflows/install_extras.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-13, macos-latest, ubuntu-latest]
         python-version: ['3.11']  # can add more if we want to support
 
     steps:
@@ -24,5 +24,7 @@ jobs:
 
     - name: Install POSYDON with extras
       run: |
+        # mpi4py needs to be preinstalled for the hpc option on pip
+        conda install mpi4py
         python -m pip install --upgrade pip
         pip install ".[doc,vis,ml,hpc]" 


### PR DESCRIPTION
There looks to be no clean way to add the MPI installation, mpi4py requires into pip.
- [x] add conda install of mpi4py
- [x] additionally add macos-13 to run on like we do for the continuous integration