### PR TITLE
Update grids/io.py to keep first part of dirname

### DIFF
--- a/posydon/grids/io.py
+++ b/posydon/grids/io.py
@@ -478,12 +478,12 @@ def initial_values_from_dirname(mesa_dir):
     base_name = os.path.basename(dirname) # base name of the MESA run dir
     
     if "initial_mass" in base_name:                           # single-star grid
-        if "_v1/" in dirname: # version 1 dirnames don't contain initial_z
+        if "v1/" in dirname: # version 1 dirnames don't contain initial_z
             variable_names = ["initial_mass"]
         else:
             variable_names = ["initial_mass", "initial_z"]
     else:                                                   # binary-star grid
-        if "_v1/" in dirname: # version 1 dirnames don't contain initial_z
+        if "v1/" in dirname: # version 1 dirnames don't contain initial_z
             variable_names = ["m1", "m2", "initial_period_in_days"]
         else:
             variable_names = ["m1", "m2", "initial_period_in_days", "initial_z"]

--- a/posydon/grids/io.py
+++ b/posydon/grids/io.py
@@ -469,20 +469,23 @@ def initial_values_from_dirname(mesa_dir):
             orbital period, and metallicity
 
     """
-    dirname = str(os.path.basename(os.path.normpath(mesa_dir)))
-    if "initial_mass" in dirname:                           # single-star grid
-        if "v1/" in str(mesa_dir): # version 1 dirnames don't contain initial_z
+    dirname = os.path.normpath(mesa_dir.decode("utf-8")) 
+    parent_path = os.path.dirname(dirname) # get path to parent dir
+    base_name = os.path.basename(dirname) # base name of the MESA run dir
+    
+    if "initial_mass" in base_name:                           # single-star grid
+        if "v1/" in parent_path: # version 1 dirnames don't contain initial_z
             variable_names = ["initial_mass"]
         else:
             variable_names = ["initial_mass", "initial_z"]
     else:                                                   # binary-star grid
-        if "v1/" in str(mesa_dir): # version 1 dirnames don't contain initial_z
+        if "v1/" in parent_path: # version 1 dirnames don't contain initial_z
             variable_names = ["m1", "m2", "initial_period_in_days"]
         else:
             variable_names = ["m1", "m2", "initial_period_in_days", "initial_z"]
         for variable_name in variable_names:
-            assert variable_name in dirname
+            assert variable_name in base_name
 
-    values = [dirname.split(variable_name+"_")[1].split("_")[0]
+    values = [base_name.split(variable_name+"_")[1].split("_")[0]
               for variable_name in variable_names]
     return tuple(values)

--- a/posydon/grids/io.py
+++ b/posydon/grids/io.py
@@ -469,7 +469,12 @@ def initial_values_from_dirname(mesa_dir):
             orbital period, and metallicity
 
     """
-    dirname = os.path.normpath(mesa_dir.decode("utf-8")) 
+
+    if isinstance(mesa_dir, bytes):
+        dirname = os.path.normpath(mesa_dir.decode("utf-8"))
+    else:
+        dirname = os.path.normpath(mesa_dir)
+        
     parent_path = os.path.dirname(dirname) # get path to parent dir
     base_name = os.path.basename(dirname) # base name of the MESA run dir
     

--- a/posydon/grids/io.py
+++ b/posydon/grids/io.py
@@ -475,19 +475,19 @@ def initial_values_from_dirname(mesa_dir):
     else:
         dirname = os.path.normpath(mesa_dir)
         
-    parent_path = os.path.dirname(dirname) # get path to parent dir
     base_name = os.path.basename(dirname) # base name of the MESA run dir
     
     if "initial_mass" in base_name:                           # single-star grid
-        if "v1/" in parent_path: # version 1 dirnames don't contain initial_z
+        if "_v1/" in dirname: # version 1 dirnames don't contain initial_z
             variable_names = ["initial_mass"]
         else:
             variable_names = ["initial_mass", "initial_z"]
     else:                                                   # binary-star grid
-        if "v1/" in parent_path: # version 1 dirnames don't contain initial_z
+        if "_v1/" in dirname: # version 1 dirnames don't contain initial_z
             variable_names = ["m1", "m2", "initial_period_in_days"]
         else:
             variable_names = ["m1", "m2", "initial_period_in_days", "initial_z"]
+
         for variable_name in variable_names:
             assert variable_name in base_name
 

--- a/posydon/unit_tests/grids/test_psygrid.py
+++ b/posydon/unit_tests/grids/test_psygrid.py
@@ -1176,7 +1176,7 @@ class TestPSyGrid:
             # get run directories for index 0 to 2
             add_MESA_run_files(path, i, binary_run=True, with_histories=False,\
                                with_profiles=True)
-        return path
+        return path.encode("utf-8")
 
     @fixture
     def MESA_files_single(self, tmp_path):

--- a/posydon/unit_tests/grids/test_psygrid.py
+++ b/posydon/unit_tests/grids/test_psygrid.py
@@ -1176,7 +1176,7 @@ class TestPSyGrid:
             # get run directories for index 0 to 2
             add_MESA_run_files(path, i, binary_run=True, with_histories=False,\
                                with_profiles=True)
-        return path.encode("utf-8")
+        return path
 
     @fixture
     def MESA_files_single(self, tmp_path):


### PR DESCRIPTION
This is a small edit. Working with Abhishek to use some of the v2 reruns on the v1 grids, we realized that the function `initial_values_from_dirname(mesa_dir)` was not properly checking the full directory path for the presence of `"v1/"` to identify a v1 run.

This removes code that cut out the parent path so that the code can identify a v1 run as intended.