### PR TITLE
Update install_extras.yml

### DIFF
--- a/.github/workflows/install_extras.yml
+++ b/.github/workflows/install_extras.yml
@@ -24,7 +24,10 @@ jobs:
 
     - name: Install POSYDON with extras
       run: |
-        # mpi4py needs to be preinstalled for the hpc option on pip
-        conda install mpi4py
+        # Create a new env with Python 3.11 and activate it
+        conda create -n test-env python=3.11 mpi4py -y
+        conda activate test-env
+        # Install the rest of the package
         python -m pip install --upgrade pip
-        pip install ".[doc,vis,ml,hpc]" 
+        pip install ".[doc,vis,ml,hpc]"
+      shell: bash -l  # <- Important! Enables conda activation


### PR DESCRIPTION
Addressing issue #538 

It looks like the error with the install extras workflow is caused by python being pinned to 3.12 despite specifying python 3.11 in the "set up python" step. however, apparently the conda commands in the "install posydon with extras" step does not use the python from "set up python", but instead the base conda environment. 

I've added a line in the install step to create a conda environment with the correct python version. The `shell: bash -l` line at the end makes the step run as a login shell, allowing `conda activate` to work, which otherwise would fail in github actions. 