### PR TITLE
fix install_extras github actions workflow

### DIFF
--- a/.github/workflows/install_extras.yml
+++ b/.github/workflows/install_extras.yml
@@ -22,12 +22,16 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Install conda (via Miniconda)
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        auto-activate-base: true
+
     - name: Install POSYDON with extras
       run: |
-        # Create a new env with Python 3.11 and activate it
         conda create -n test-env python=3.11 mpi4py -y
+        source $(conda info --base)/etc/profile.d/conda.sh
         conda activate test-env
-        # Install the rest of the package
         python -m pip install --upgrade pip
         pip install ".[doc,vis,ml,hpc]"
-      shell: bash -l  # <- Important! Enables conda activation
+      shell: bash


### PR DESCRIPTION
Found another error:
Run # Create a new env with Python 3.11 and activate it
Error: Invalid shell option. Shell must be a valid built-in (bash, sh, cmd, powershell, pwsh) or a format string containing '{0}'

`bash -l` is not recognized directly by GitHub actions, so I need to specify a built-in shell without extra flags. GitHub Actions needs a different way to make conda work properly. I have added a step that installs conda directly (conda-incubator/setup-miniconda@v2), and then in the install posydon step, I've added a line that activates the environment. 