### PR TITLE
Check for array-like data in `BinaryStar.to_df()` in case of failed binaries

### DIFF
--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -23,6 +23,7 @@ __authors__ = [
     "Philipp Moura Srivastava <philipp.msrivastava@gmail.com>",
     "Devina Misra <devina.misra@unige.ch>",
     "Scott Coughlin <scottcoughlin2014@u.northwestern.edu>",
+    "Seth Gossage <seth.gossage@northwestern.edu>"
 ]
 
 
@@ -391,7 +392,12 @@ class BinaryStar:
             all_equal_length_cols = len(set(col_lengths)) == 1
             if not all_equal_length_cols:
                 for col in data_to_save:
-                    col.extend([np.nan] * abs(max_col_length - len(col)))
+                    # check if the data column type is array-like
+                    if hasattr(col, '__len__') and hasattr(col, '__getitem__') and not isinstance(col, str):
+                        data_len = len(col)
+                        col.extend( [[np.nan] * data_len] * abs(max_col_length - len(col)))
+                    else:
+                        col.extend([np.nan] * abs(max_col_length - len(col)))
 
             where_none = np.array([[True if var is None else False
                                     for var in column]

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -409,8 +409,6 @@ class BinaryStar:
                         # never happen.
                         dtype = 'float64'
 
-                    max_ele_length = 0
-
                     # check type of data and determine what to fill data column with
                     if dtype == 'string':
                         filler_value = 'None'

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -148,7 +148,7 @@ class BinaryStar:
         # Set the initial binary properties
         for item in BINARYPROPERTIES:
             if item == 'V_sys':
-                setattr(self, item, binary_kwargs.pop(item, [0,0,0]))
+                setattr(self, item, binary_kwargs.pop(item, np.array([0,0,0])))
             elif item == 'mass_transfer_case':
                 setattr(self, item, binary_kwargs.pop(item, 'None'))
             elif item == 'nearest_neighbour_distance':
@@ -390,6 +390,7 @@ class BinaryStar:
             # If a binary fails, usually history cols have diff lengths.
             # This should append NAN to create even columns.
             all_equal_length_cols = len(set(col_lengths)) == 1
+
             if not all_equal_length_cols:
                 for col in data_to_save:
                     # check if the data column type is array-like

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -413,12 +413,7 @@ class BinaryStar:
                         # get the max length that data elements have
                         ele_lengths = [len(x) for x in col]
                         max_ele_length = np.max(ele_lengths)
-
-                        try:
-                            sub_dtype = OBJECT_FIXED_SUB_DTYPES[dkey]
-                        except KeyError:
-                            sub_type = ''
-                            pass
+                        sub_dtype = OBJECT_FIXED_SUB_DTYPES.get(dkey, '')
 
                         # array of strings
                         if sub_dtype == 'string':

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -401,11 +401,7 @@ class BinaryStar:
                 for i, col in enumerate(data_to_save):
 
                     dkey = all_keys[i]
-                    try:
-                        dtype = properties_dtypes[dkey]
-                    except KeyError:
-                        dtype = ''
-                        pass
+                    dtype = properties_dtypes.get(dkey, '')
 
                     # check type of data and determine what to fill data column with
                     if dtype == 'string':

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -395,8 +395,8 @@ class BinaryStar:
                     # check if the data column type is array-like
                     element = col[0]
                     if hasattr(element, '__len__') and hasattr(element, '__getitem__') and not isinstance(element, str):
-                        data_len = len(element)
-                        col.extend( [[np.nan] * data_len] * abs(max_col_length - len(col)))
+                        element_len = len(element)
+                        col.extend( [[np.nan] * element_len] * abs(max_col_length - len(col)))
                     else:
                         col.extend([np.nan] * abs(max_col_length - len(col)))
 

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -397,15 +397,17 @@ class BinaryStar:
             # This should append NAN to create even columns.
             all_equal_length_cols = len(set(col_lengths)) == 1
 
-            for i, col in enumerate(data_to_save):
-                print(all_keys[i])
-                print(col)
-
             if not all_equal_length_cols:
                 for i, col in enumerate(data_to_save):
 
                     dkey = all_keys[i]
-                    dtype = properties_dtypes[dkey]
+                    try:
+                        dtype = properties_dtypes[dkey]
+                    except KeyError:
+                        # default back to float64 -> np.nan fillers if can not 
+                        # determine what the data type should be. This should
+                        # never happen.
+                        dtype = 'float64'
 
                     max_ele_length = 0
 

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -393,8 +393,9 @@ class BinaryStar:
             if not all_equal_length_cols:
                 for col in data_to_save:
                     # check if the data column type is array-like
-                    if hasattr(col, '__len__') and hasattr(col, '__getitem__') and not isinstance(col, str):
-                        data_len = len(col)
+                    element = col[0]
+                    if hasattr(element, '__len__') and hasattr(element, '__getitem__') and not isinstance(element, str):
+                        data_len = len(element)
                         col.extend( [[np.nan] * data_len] * abs(max_col_length - len(col)))
                     else:
                         col.extend([np.nan] * abs(max_col_length - len(col)))

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -404,6 +404,7 @@ class BinaryStar:
                     try:
                         dtype = properties_dtypes[dkey]
                     except KeyError:
+                        dtype = ''
                         pass
 
                     # check type of data and determine what to fill data column with
@@ -420,6 +421,7 @@ class BinaryStar:
                         try:
                             sub_dtype = OBJECT_FIXED_SUB_DTYPES[dkey]
                         except KeyError:
+                            sub_type = ''
                             pass
 
                         # array of strings

--- a/posydon/popsyn/io.py
+++ b/posydon/popsyn/io.py
@@ -31,7 +31,7 @@ BINARYPROPERTIES_DTYPES = {
     'separation': 'float64',               # binary orbital separation (solar radii)
     'orbital_period': 'float64',           # binary orbital period (days)
     'eccentricity': 'float64',             # binary eccentricity
-    'V_sys': 'object',                    # list of the 3 systemic velocity coordinates
+    'V_sys': 'object.float64',                    # array of the 3 systemic velocity coordinates
     # (R_{star} - R_{Roche_lobe}) / R_{Roche_lobe}...
     'rl_relative_overflow_1': 'float64',   # ...for star 1
     'rl_relative_overflow_2': 'float64',   # ...for star 2
@@ -45,13 +45,13 @@ BINARYPROPERTIES_DTYPES = {
     't_sync_conv_1': 'float64',
     't_sync_rad_2': 'float64',
     't_sync_conv_2': 'float64',
-    'nearest_neighbour_distance': 'object',   # the distance of system from its nearest
-                                            # neighbour of MESA binary system  in case
-                                            # of interpolation during the the end of
-                                            # the previous step including MESA psygrid.
-                                            # The distance is normalized in the
-                                            # parameter space and limits at which it
-                                            # was calculated. See `mesa_step` for more.
+    'nearest_neighbour_distance': 'object.string',   # the distance of system from its nearest
+                                                     # neighbour of MESA binary system  in case
+                                                     # of interpolation during the the end of
+                                                     # the previous step including MESA psygrid.
+                                                     # The distance is normalized in the
+                                                     # parameter space and limits at which it
+                                                     # was calculated. See `mesa_step` for more.
 }
 
 

--- a/posydon/popsyn/io.py
+++ b/posydon/popsyn/io.py
@@ -31,7 +31,7 @@ BINARYPROPERTIES_DTYPES = {
     'separation': 'float64',               # binary orbital separation (solar radii)
     'orbital_period': 'float64',           # binary orbital period (days)
     'eccentricity': 'float64',             # binary eccentricity
-    'V_sys': 'object.float64',                    # array of the 3 systemic velocity coordinates
+    'V_sys': 'object',                    # array of the 3 systemic velocity coordinates
     # (R_{star} - R_{Roche_lobe}) / R_{Roche_lobe}...
     'rl_relative_overflow_1': 'float64',   # ...for star 1
     'rl_relative_overflow_2': 'float64',   # ...for star 2
@@ -45,15 +45,20 @@ BINARYPROPERTIES_DTYPES = {
     't_sync_conv_1': 'float64',
     't_sync_rad_2': 'float64',
     't_sync_conv_2': 'float64',
-    'nearest_neighbour_distance': 'object.string',   # the distance of system from its nearest
-                                                     # neighbour of MESA binary system  in case
-                                                     # of interpolation during the the end of
-                                                     # the previous step including MESA psygrid.
-                                                     # The distance is normalized in the
-                                                     # parameter space and limits at which it
-                                                     # was calculated. See `mesa_step` for more.
+    'nearest_neighbour_distance': 'object',   # the distance of system from its nearest
+                                              # neighbour of MESA binary system  in case
+                                              # of interpolation during the the end of
+                                              # the previous step including MESA psygrid.
+                                              # The distance is normalized in the
+                                              # parameter space and limits at which it
+                                              # was calculated. See `mesa_step` for more.
 }
 
+# specifies the dtypes of elements within an object (e.g., of elements in an array)
+OBJECT_FIXED_SUB_DTYPES = {
+    'V_sys': 'float64',
+    'nearest_neighbour_distance': 'float64'
+}
 
 STARPROPERTIES_DTYPES = {
     'state': 'string',            # the evolutionary state of the star. For more info see


### PR DESCRIPTION
This adds functionality to `binarystar.py`'s `BinaryStar` class function `to_df` to check for array like data types in data columns and pad them appropriately in the case of a failed binary.

A user reported the following error previously, which the fix above is meant to address:

```
Error during breakdown of BinaryStar(ERR, FAILED, p=0.74, S1=(H-rich_Shell_H_burning,M=0.19), S2=(WD,M=1.50)):
'float' object is not subscriptable
Traceback (most recent call last):
  File "/projects/b1095/sbisco/posydon_runs/bbh_test2/./run_metallicity.py", line 14, in <module>
    synpop.evolve()
  File "/home/asb9716/.conda/envs/posydon_dev/lib/python3.11/site-packages/posydon/popsyn/binarypopulation.py", line 258, in evolve
    self._safe_evolve(**self.kwargs)
  File "/home/asb9716/.conda/envs/posydon_dev/lib/python3.11/site-packages/posydon/popsyn/binarypopulation.py", line 418, in _safe_evolve
    self.manager.save(path, mode="w", **kw)
  File "/home/asb9716/.conda/envs/posydon_dev/lib/python3.11/site-packages/posydon/popsyn/binarypopulation.py", line 830, in save
    history_df = self.to_df(**kwargs)
                 ^^^^^^^^^^^^^^^^^^^^
  File "/home/asb9716/.conda/envs/posydon_dev/lib/python3.11/site-packages/posydon/popsyn/binarypopulation.py", line 687, in to_df
    holder.append(binary.to_df(**kwargs))
                  ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/asb9716/.conda/envs/posydon_dev/lib/python3.11/site-packages/posydon/binary_evol/binarystar.py", line 421, in to_df
    V_sys_x[i] = bin_df.iloc[i]['V_sys'][0]
                 ~~~~~~~~~~~~~~~~~~~~~~~^^^
TypeError: 'float' object is not subscriptable
```

The error occurs when the code attempts to subscript `V_sys` in this case, which apparently exists as a `float`. Prior to this PR, data columns were padded with `np.nan` only, which is inappropriate for variables like `V_sys`, which are arrays. Attempting to index `np.nan` can lead to the above error. This pads array-like data with arrays comprised of `np.nan` (or their appropriate data type as determined from `popsyn/io.py`), rather than just `np.nan`.