### PR TITLE
posydon-popsyn multi-jobID fix

### DIFF
--- a/bin/posydon-popsyn
+++ b/bin/posydon-popsyn
@@ -507,7 +507,7 @@ def check_batches(run_folder, metallicity, batch_folder_name):
                     idx = int(input("\nEnter the index to the job ID: "))
                     if 0 <= idx < len(jobIDs):
                         selected_job_idx = idx
-                        jobID = [jobIDs[idx]]  # Filter to only the selected job ID
+                        jobID = jobIDs[idx]  # Filter to only the selected job ID
                     else:
                         print("Invalid selection. Please try again.")
                 except ValueError:


### PR DESCRIPTION
If multiple population synthesis reruns are present, the jobID check was returning a list of one. This should have just been the jobID.

This corrects that selection.