### PR TITLE
Hotfixes new documentation build

### DIFF
--- a/.github/workflows/deploy-github-pages-development.yml
+++ b/.github/workflows/deploy-github-pages-development.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        fetch-tags: true
+        path: 'POSYDON'
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/deploy-github-pages-release.yml
+++ b/.github/workflows/deploy-github-pages-release.yml
@@ -97,8 +97,7 @@ jobs:
           touch _build/html/.nojekyll
           
           # move and copy docs out of the POSYDON folder
-          tag_without_v=${tag//v}
-          mv _build/html/ $output_folder/$tag_without_v
+          mv _build/html/ $output_folder/$tag
 
           # cleanup for the next build
           make clean

--- a/.github/workflows/deploy-github-pages-release.yml
+++ b/.github/workflows/deploy-github-pages-release.yml
@@ -209,8 +209,7 @@ jobs:
           touch _build/html/.nojekyll
           
           # move and copy docs out of the POSYDON folder
-          tag_without_v=${tag//v}
-          mv _build/html/ $output_folder/$tag_without_v
+          mv _build/html/ $output_folder/$tag
 
           # cleanup for the next build
           make clean

--- a/docs/_source/conf.py
+++ b/docs/_source/conf.py
@@ -82,7 +82,7 @@ else:
 base_url = 'https://posydon.org/POSYDON'
 
 # get the list of versions
-url_list = [f'{base_url}/{tag}' for tag in github_tags]
+url_list = [f'{base_url}/v{tag}' for tag in github_tags]
 v1_versions = [[tag, url] for tag, url in zip(github_tags, url_list) if tag.startswith('1.')]
 v2_versions = [[tag, url] for tag, url in zip(github_tags, url_list) if tag.startswith('2.')]
  


### PR DESCRIPTION
Currently, not all the tags from Github are correctly pulled in this workflow, as such the code fails.
This should enforce that the Github tags are correctly pulled.

Additionally, this should consolidate the usage of "v" in the linking and folders
