### PR TITLE
Hotfix documentation-build again

### DIFF
--- a/.github/workflows/deploy-github-pages-development.yml
+++ b/.github/workflows/deploy-github-pages-development.yml
@@ -54,7 +54,8 @@ jobs:
         MESA_DIR: ./
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        export PATH_TO_POSYDON=$GITHUB_WORKSPACE
+        export PATH_TO_POSYDON=$GITHUB_WORKSPACE/POSYDON
+        cd $PATH_TO_POSYDON
         
         # build the documentation for the development branch
         git checkout -f development


### PR DESCRIPTION
Another fix to the building of the development version. This time, entering the git folder

I don't understand why this worked locally with Local Github Actions (act) and not on the actual Github Actions. 

@sgossage, you didn't experience issues either with the local workflow, right?