### PR TITLE
Fix fetching all tags of the repository

### DIFF
--- a/.github/workflows/deploy-github-pages-development.yml
+++ b/.github/workflows/deploy-github-pages-development.yml
@@ -15,6 +15,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
+        fetch-depth: 0
         fetch-tags: true
         path: 'POSYDON'
 

--- a/.github/workflows/deploy-github-pages-release.yml
+++ b/.github/workflows/deploy-github-pages-release.yml
@@ -14,6 +14,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
+        fetch-depth: 0
         fetch-tags: true
         path: 'POSYDON'
 


### PR DESCRIPTION
The documentation workflows are failing because they cannot find all the tags in the repository.
It turns out that `fetch-tags: true` doesn't fetch any tags without altering the default `fetch-depth` from 1. See this issue on the checkout repository: https://github.com/actions/checkout/issues/1471

Adding `fetch-depth:0` to the checkout action is the recommended solution.