### PR TITLE
Bump miniconda version to v3 and add proper bash shell initiation

### DIFF
--- a/.github/workflows/install_extras.yml
+++ b/.github/workflows/install_extras.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [macos-13, macos-latest, ubuntu-latest]
         python-version: ['3.11']  # can add more if we want to support
-      
+    
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/install_extras.yml
+++ b/.github/workflows/install_extras.yml
@@ -33,6 +33,5 @@ jobs:
     - name: Install POSYDON with extras
       run: |
         conda create -n test-env python=3.11 mpi4py conda-forge::qt -y
-        source $(conda info --base)/etc/profile.d/conda.sh
         conda activate test-env
         pip install ".[doc,vis,ml,hpc]"

--- a/.github/workflows/install_extras.yml
+++ b/.github/workflows/install_extras.yml
@@ -7,12 +7,15 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -el {0}
 
     strategy:
       matrix:
         os: [macos-13, macos-latest, ubuntu-latest]
         python-version: ['3.11']  # can add more if we want to support
-
+      
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -23,15 +26,13 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install conda (via Miniconda)
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         auto-activate-base: true
 
     - name: Install POSYDON with extras
       run: |
-        conda create -n test-env python=3.11 mpi4py -y
+        conda create -n test-env python=3.11 mpi4py conda-forge::qt -y
         source $(conda info --base)/etc/profile.d/conda.sh
         conda activate test-env
-        python -m pip install --upgrade pip
         pip install ".[doc,vis,ml,hpc]"
-      shell: bash

--- a/.github/workflows/install_extras.yml
+++ b/.github/workflows/install_extras.yml
@@ -3,7 +3,9 @@ name: Testing installation of extras in setup.py
 on:
   schedule:
     - cron: "0 0 * * 0"  # Runs at 00:00 (UTC) every Sunday
-
+  pull_request:
+    branches: [development]
+    
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/install_extras.yml
+++ b/.github/workflows/install_extras.yml
@@ -33,5 +33,6 @@ jobs:
     - name: Install POSYDON with extras
       run: |
         conda create -n test-env python=3.11 mpi4py conda-forge::qt -y
+        python -m pip install --upgrade pip
         conda activate test-env
         pip install ".[doc,vis,ml,hpc]"

--- a/.github/workflows/install_extras.yml
+++ b/.github/workflows/install_extras.yml
@@ -3,9 +3,7 @@ name: Testing installation of extras in setup.py
 on:
   schedule:
     - cron: "0 0 * * 0"  # Runs at 00:00 (UTC) every Sunday
-  pull_request:
-    branches: [development]
-    
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Main points:
- setup-miniconda v2 -> v3
- add bash -el {0} let conda be seen.
- add conda install `qt`
- removed sourcing `conda`; already done.

The latest setup-miniconda version is v3 with the bash shell initiation (set as default for the steps).

This loads `conda` properly. 

The installation still fails due to what seems like a pyQT issue (with QT5 not being installed), although this is not super clear.
I added the latest version to the conda environment.

I was unable to verify if this addition of installing qt allows POSYDON to be installed, since it hangs due to the virtualisation on my machine. However, it no longer crashes as it did without qt installed.