### PR TITLE
Update dataset definitions for v2 data release

### DIFF
--- a/docs/_source/getting-started/prerequisites.rst
+++ b/docs/_source/getting-started/prerequisites.rst
@@ -28,9 +28,9 @@ Hardware Requirements
 
 In order to run a population synthesis model with POSYDON, you must ensure that you have enough free storage space. It depends on the dataset how much free space you need:
 
-- v1: approximately **40GB**
-- v2: approximately **140GB** (the default in the :ref:`installation <installation-guide>`)
-- one of the eight metallicities in v2: approximately **20GB**
+- DR1: approximately **40GB**
+- DR2: approximately **140GB** (the default in the :ref:`installation <installation-guide>`)
+- one of the eight metallicities in DR2: approximately **20GB**
 
 This is crucial for downloading the lite MESA simulation library, interpolation objects, and other auxiliary files used by the code.
 

--- a/docs/_source/getting-started/prerequisites.rst
+++ b/docs/_source/getting-started/prerequisites.rst
@@ -10,7 +10,6 @@ POSYDON has been tested on the following operating systems:
 
 - Linux (Ubuntu 20.04 and newer, CentOS 7, etc.)
 - macOS (10.14 and newer)
-- Windows 10
 
 (Note: Adapt and expand the list based on the actual compatibility of POSYDON)
 
@@ -18,7 +17,7 @@ Software Dependencies
 ~~~~~~~~~~~~~~~~~~~~~
 
 1. Python 3.11
-2. [List other software dependencies here, if any.]
+2. More dependencies are defined in our setup file and should be automatically applied during the installation. To allow you having different versions of the packages we require we strongly encourage to use a dedicated conda environment for POSYDON.
 
 (Note: Expand on any specific versions or configurations, if necessary.)
 
@@ -27,7 +26,13 @@ Hardware Requirements
 
 **Storage**: 
 
-In order to run a population synthesis model with POSYDON, you must ensure that you have approximately **40GB** of free storage space. This is crucial for downloading the lite MESA simulation library, interpolation objects, and other auxiliary files used by the code.
+In order to run a population synthesis model with POSYDON, you must ensure that you have enough free storage space. It depends on the dataset how much free space you need:
+
+- v1: approximately **40GB**
+- v2: approximately **140GB** (the default in the :ref:`installation <installation-guide>`)
+- one of the eight metallicities in v2: approximately **20GB**
+
+This is crucial for downloading the lite MESA simulation library, interpolation objects, and other auxiliary files used by the code.
 
 Memory:
 

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -258,7 +258,7 @@ class MesaGridStep:
         filename = os.path.join(self.path,grid_name)
         if not (os.path.exists(filename.replace('%d','0')) or
                 os.path.exists(filename.replace('_%d',''))):
-            data_download() #TODO: specify dataset
+            data_download()
 
         if self.verbose:
             print("loading psyTrackInterp: {}".format(filename))
@@ -274,7 +274,7 @@ class MesaGridStep:
 
         # Check if interpolation files exist
         if not os.path.exists(filename):
-            data_download() #TODO: specify dataset
+            data_download()
 
         # Load interpolator
         self._Interp = IFInterpolator()

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -330,8 +330,7 @@ class StepSN(object):
                     filename = os.path.join(self.path_to_Patton_datasets,
                                             file_name)
                     if not os.path.exists(filename):
-                        #TODO: specify dataset, e.g. 'auxiliary' when it exists
-                        data_download()
+                        data_download(set_name='auxiliary')
 
                     # Reading the dataset
                     data = np.loadtxt(filename, skiprows=6, dtype='str')
@@ -2238,8 +2237,7 @@ class Sukhbold16_corecollapse(object):
             filename = os.path.join(path_engine_dataset,
                                     "results_" + self.engine + "_table.csv")
             if not os.path.exists(filename):
-                #TODO: specify dataset, e.g. 'auxiliary' when it exists
-                data_download()
+                data_download(set_name='auxiliary')
 
             Engine_data = read_csv(filename)
 
@@ -2432,8 +2430,7 @@ class Couch20_corecollapse(object):
             # Check if interpolation files exist
             filename = os.path.join(path_to_Couch_datasets, 'explDatsSTIR2.json')
             if not os.path.exists(filename):
-                #TODO: specify dataset, e.g. 'auxiliary' when it exists
-                data_download()
+                data_download(set_name='auxiliary')
 
             Couch_data_file = open(filename)
             Couch_data = json.load(Couch_data_file)

--- a/posydon/unit_tests/utils/test_data_download.py
+++ b/posydon/unit_tests/utils/test_data_download.py
@@ -109,7 +109,7 @@ class TestFunctions:
                         match="unknown dataset, use -l to show defined sets"):
                 totest._parse_commandline()
             # example
-            self.commandline_args = totest.argparse.Namespace(dataset='v1',\
+            self.commandline_args = totest.argparse.Namespace(dataset='DR1',\
              listedsets=None, nomd5check=False, verbose=False)
             assert totest._parse_commandline() == self.commandline_args
 
@@ -187,7 +187,7 @@ class TestFunctions:
             with raises(NotADirectoryError, match="PATH_TO_POSYDON_DATA does "\
                                                   +"not refer to a valid "\
                                                   +"directory."):
-                totest.download_one_dataset(dataset='v1_for_v2.0.0-pre1')
+                totest.download_one_dataset(dataset='DR1_for_v2.0.0-pre1')
         # bad input
         with monkeypatch.context() as mp:
             mock_ZENODO_COLLECTION = {'Test': {'data' : "./", 'md5': "Unit"}}
@@ -326,7 +326,7 @@ class TestFunctions:
                 for v in [True, False]:
                     self.list_printed = None
                     self.commandline_args = totest.argparse.Namespace(\
-                     dataset='v1', listedsets=l, nomd5check=False, verbose=v)
+                     dataset='DR1', listedsets=l, nomd5check=False, verbose=v)
                     totest._get_posydon_data()
                     assert self.list_printed['individual_sets']\
                            == (l == 'individual')
@@ -334,7 +334,7 @@ class TestFunctions:
             # examples
             for n in [True, False]:
                 for v in [True, False]:
-                    for d in ['v1', 'v2']:
+                    for d in ['DR1', 'DR2']:
                         self.downloaded = None
                         self.commandline_args = totest.argparse.Namespace(\
                          dataset=d, listedsets=None, nomd5check=n, verbose=v)

--- a/posydon/unit_tests/utils/test_datasets.py
+++ b/posydon/unit_tests/utils/test_datasets.py
@@ -67,7 +67,7 @@ class TestValues:
 
     def test_value_COMPLETE_SETS(self):
         # check base versions
-        for k in ['v1', 'v2']:
+        for k in ['DR1', 'DR2']:
             assert k in totest.COMPLETE_SETS
         # check complete datasets
         for k,s in totest.COMPLETE_SETS.items():

--- a/posydon/utils/data_download.py
+++ b/posydon/utils/data_download.py
@@ -121,13 +121,12 @@ def list_datasets(individual_sets=False, verbose=False):
                     print(wrapper.fill("more information at "
                                        +ZENODO_COLLECTION[dataset]['url']))
 
-def download_one_dataset(dataset='v1_for_v2.0.0-pre1', MD5_check=True,
-                         verbose=False):
+def download_one_dataset(dataset='v2_1Zsun', MD5_check=True, verbose=False):
     """Download a data set from Zenodo if they do not exist.
 
         Parameters
         ----------
-        dataset : string (default: 'v1_for_v2.0.0-pre1')
+        dataset : string (default: 'v2_1Zsun')
             Name of the data set to be in COMPLETE_SETS or ZENODO_COLLECTION.
         MD5_check : boolean (default: True)
             Use the MD5 check to make sure data is not corrupted.
@@ -198,12 +197,12 @@ def download_one_dataset(dataset='v1_for_v2.0.0-pre1', MD5_check=True,
             print('Removed downloaded tar file.')
         os.remove(filepath)
 
-def data_download(set_name='v1', MD5_check=True, verbose=False):
+def data_download(set_name='v2', MD5_check=True, verbose=False):
     """Download data files from Zenodo if they do not exist.
 
         Parameters
         ----------
-        set_name : string (default: 'v1')
+        set_name : string (default: 'v2')
             Name of the data set to be in COMPLETE_SETS or ZENODO_COLLECTION.
         MD5_check : boolean (default: True)
             Use the MD5 check to make sure data is not corrupted.

--- a/posydon/utils/data_download.py
+++ b/posydon/utils/data_download.py
@@ -33,9 +33,9 @@ def _parse_commandline():
     parser = argparse.ArgumentParser(description="Downloading POSYDON data "
                                                  "from Zenodo")
     parser.add_argument('dataset',
-                        help="Name of the dataset to download (default: v1)",
+                        help="Name of the dataset to download (default: DR2)",
                         nargs='?',
-                        default='v1')
+                        default='DR2')
     parser.add_argument('-l', '--listedsets',
                         help="list the datasets: 'complete' shows the full "
                              "dataset able to run POSYDON, 'individual' lists "
@@ -121,12 +121,12 @@ def list_datasets(individual_sets=False, verbose=False):
                     print(wrapper.fill("more information at "
                                        +ZENODO_COLLECTION[dataset]['url']))
 
-def download_one_dataset(dataset='v2_1Zsun', MD5_check=True, verbose=False):
+def download_one_dataset(dataset='DR2_1Zsun', MD5_check=True, verbose=False):
     """Download a data set from Zenodo if they do not exist.
 
         Parameters
         ----------
-        dataset : string (default: 'v2_1Zsun')
+        dataset : string (default: 'DR2_1Zsun')
             Name of the data set to be in COMPLETE_SETS or ZENODO_COLLECTION.
         MD5_check : boolean (default: True)
             Use the MD5 check to make sure data is not corrupted.
@@ -197,12 +197,12 @@ def download_one_dataset(dataset='v2_1Zsun', MD5_check=True, verbose=False):
             print('Removed downloaded tar file.')
         os.remove(filepath)
 
-def data_download(set_name='v2', MD5_check=True, verbose=False):
+def data_download(set_name='DR2', MD5_check=True, verbose=False):
     """Download data files from Zenodo if they do not exist.
 
         Parameters
         ----------
-        set_name : string (default: 'v2')
+        set_name : string (default: 'DR2')
             Name of the data set to be in COMPLETE_SETS or ZENODO_COLLECTION.
         MD5_check : boolean (default: True)
             Use the MD5 check to make sure data is not corrupted.

--- a/posydon/utils/datasets.py
+++ b/posydon/utils/datasets.py
@@ -38,11 +38,11 @@ ZENODO_COLLECTION['auxiliary'] = {
     'description': "Auxiliary data for POSYDON. It contains data on "\
                    + "supernova prescriptions (Sukhbold+2016, Couch+2020, "\
                    + "Patton+Sukhbold2020), star formation history "\
-                   + "(IllustrisTNG), and detector sensitivity (of O3, O4low, "\
-                   + "O4high, design of three gravitational wave detectors "\
-                   + "H1, L1, V1).", #TODO
+                   + "(IllustrisTNG, Zavala+2021, Chruslinska+2021), and "\
+                   + "detector sensitivity (of O3, O4low, O4high, design of "\
+                   + "three gravitational wave detectors H1, L1, V1).",
     'md5': None, #TODO
-    'title': "Auxiliary POSYDON data", #TODO
+    'title': "Auxiliary POSYDON data",
     'url': "https://zenodo.org/communities/posydon" #TODO
 }
 
@@ -84,73 +84,81 @@ COMPLETE_SETS['super-Eddington_v1'] = ['v1_for_v2.0.0-pre1',
 ZENODO_COLLECTION['v2_grids_2Zsun'] = {
     'data': None, #TODO
     'description': "The POSYDON v2 dataset at twice solar metallicity. It "\
-                   + "contains single-HMS, single-HeMS, HMS-HMS, CO-HMS_RLO, "\
-                   + "CO-HeMS, CO-HeMS_RLO all at twice solar metallicity.", #TODO
+                   + "contains single-HMS, single-HeMS, HMS-HMS, HMS-HMS_RLO,"\
+                   + " CO-HMS_RLO, CO-HeMS, CO-HeMS_RLO all at twice solar "\
+                   + "metallicity.",
     'md5': None, #TODO
-    'title': "POSYDON v2.0 dataset at 2 Zsun", #TODO
+    'title': "POSYDON v2.0 dataset at 2 Zsun",
     'url': "https://zenodo.org/communities/posydon" #TODO
 }
 ZENODO_COLLECTION['v2_grids_1Zsun'] = {
     'data': None, #TODO
     'description': "The POSYDON v2 dataset at solar metallicity. It "\
-                   + "contains single-HMS, single-HeMS, HMS-HMS, CO-HMS_RLO, "\
-                   + "CO-HeMS, CO-HeMS_RLO all at solar metallicity.", #TODO
+                   + "contains single-HMS, single-HeMS, HMS-HMS, HMS-HMS_RLO,"\
+                   + " CO-HMS_RLO, CO-HeMS, CO-HeMS_RLO all at twice solar "\
+                   + "metallicity.",
     'md5': None, #TODO
-    'title': "POSYDON v2.0 dataset at Zsun", #TODO
+    'title': "POSYDON v2.0 dataset at Zsun",
     'url': "https://zenodo.org/communities/posydon" #TODO
 }
 ZENODO_COLLECTION['v2_grids_0.45Zsun'] = {
     'data': None, #TODO
     'description': "The POSYDON v2 dataset at 0.45 solar metallicity. It "\
-                   + "contains single-HMS, single-HeMS, HMS-HMS, CO-HMS_RLO, "\
-                   + "CO-HeMS, CO-HeMS_RLO all at 0.45 solar metallicity.", #TODO
+                   + "contains single-HMS, single-HeMS, HMS-HMS, HMS-HMS_RLO,"\
+                   + " CO-HMS_RLO, CO-HeMS, CO-HeMS_RLO all at twice solar "\
+                   + "metallicity.",
     'md5': None, #TODO
-    'title': "POSYDON v2.0 dataset at 0.45 Zsun", #TODO
+    'title': "POSYDON v2.0 dataset at 0.45 Zsun",
     'url': "https://zenodo.org/communities/posydon" #TODO
 }
 ZENODO_COLLECTION['v2_grids_0.2Zsun'] = {
     'data': None, #TODO
     'description': "The POSYDON v2 dataset at 0.2 solar metallicity. It "\
-                   + "contains single-HMS, single-HeMS, HMS-HMS, CO-HMS_RLO, "\
-                   + "CO-HeMS, CO-HeMS_RLO all at 0.2 solar metallicity.", #TODO
+                   + "contains single-HMS, single-HeMS, HMS-HMS, HMS-HMS_RLO,"\
+                   + " CO-HMS_RLO, CO-HeMS, CO-HeMS_RLO all at twice solar "\
+                   + "metallicity.",
     'md5': None, #TODO
-    'title': "POSYDON v2.0 dataset at 0.2 Zsun", #TODO
+    'title': "POSYDON v2.0 dataset at 0.2 Zsun",
     'url': "https://zenodo.org/communities/posydon" #TODO
 }
 ZENODO_COLLECTION['v2_grids_0.1Zsun'] = {
     'data': None, #TODO
     'description': "The POSYDON v2 dataset at 0.1 solar metallicity. It "\
-                   + "contains single-HMS, single-HeMS, HMS-HMS, CO-HMS_RLO, "\
-                   + "CO-HeMS, CO-HeMS_RLO all at 0.1 solar metallicity.", #TODO
+                   + "contains single-HMS, single-HeMS, HMS-HMS, HMS-HMS_RLO,"\
+                   + " CO-HMS_RLO, CO-HeMS, CO-HeMS_RLO all at twice solar "\
+                   + "metallicity.",
     'md5': None, #TODO
-    'title': "POSYDON v2.0 dataset at 0.1 Zsun", #TODO
+    'title': "POSYDON v2.0 dataset at 0.1 Zsun",
     'url': "https://zenodo.org/communities/posydon" #TODO
 }
 ZENODO_COLLECTION['v2_grids_0.01Zsun'] = {
     'data': None, #TODO
     'description': "The POSYDON v2 dataset at 0.01 solar metallicity. It "\
-                   + "contains single-HMS, single-HeMS, HMS-HMS, CO-HMS_RLO, "\
-                   + "CO-HeMS, CO-HeMS_RLO all at 0.01 solar metallicity.", #TODO
+                   + "contains single-HMS, single-HeMS, HMS-HMS, HMS-HMS_RLO,"\
+                   + " CO-HMS_RLO, CO-HeMS, CO-HeMS_RLO all at twice solar "\
+                   + "metallicity.",
     'md5': None, #TODO
-    'title': "POSYDON v2.0 dataset at 0.01 Zsun", #TODO
+    'title': "POSYDON v2.0 dataset at 0.01 Zsun",
     'url': "https://zenodo.org/communities/posydon" #TODO
 }
 ZENODO_COLLECTION['v2_grids_1e-3Zsun'] = {
     'data': None, #TODO
     'description': "The POSYDON v2 dataset at 10^{-3} solar metallicity. It "\
-                   + "contains single-HMS, single-HeMS, HMS-HMS, CO-HMS_RLO, "\
-                   + "CO-HeMS, CO-HeMS_RLO all at 10^{-3} solar metallicity.", #TODO
+                   + "contains single-HMS, single-HeMS, HMS-HMS, HMS-HMS_RLO,"\
+                   + " CO-HMS_RLO, CO-HeMS, CO-HeMS_RLO all at twice solar "\
+                   + "metallicity.",
     'md5': None, #TODO
-    'title': "POSYDON v2.0 dataset at 10^{-3} Zsun", #TODO
+    'title': "POSYDON v2.0 dataset at 10^{-3} Zsun",
     'url': "https://zenodo.org/communities/posydon" #TODO
 }
 ZENODO_COLLECTION['v2_grids_1e-4Zsun'] = {
     'data': None, #TODO
     'description': "The POSYDON v2 dataset at 10^{-4} solar metallicity. It "\
-                   + "contains single-HMS, single-HeMS, HMS-HMS, CO-HMS_RLO, "\
-                   + "CO-HeMS, CO-HeMS_RLO all at 10^{-4} solar metallicity.", #TODO
+                   + "contains single-HMS, single-HeMS, HMS-HMS, HMS-HMS_RLO,"\
+                   + " CO-HMS_RLO, CO-HeMS, CO-HeMS_RLO all at twice solar "\
+                   + "metallicity.",
     'md5': None, #TODO
-    'title': "POSYDON v2.0 dataset at 10^{-4} Zsun", #TODO
+    'title': "POSYDON v2.0 dataset at 10^{-4} Zsun",
     'url': "https://zenodo.org/communities/posydon" #TODO
 }
 COMPLETE_SETS['v2'] = ['auxiliary', 'v2_grids_2Zsun', 'v2_grids_1Zsun',

--- a/posydon/utils/datasets.py
+++ b/posydon/utils/datasets.py
@@ -28,22 +28,22 @@ ZENODO_COLLECTION = {'POSYDON':
                                          + "sets.",
                           'md5': None,
                           'title': "POSYDON community",
-                          'url': "https://zenodo.org/communities/posydon"
+                          'url': "https://zenodo.org/records/15194708"
                          }}
 COMPLETE_SETS = {}
 
 # auxiliary data
 ZENODO_COLLECTION['auxiliary'] = {
-    'data': None, #TODO
+    'data': "https://zenodo.org/records/15194708/files/POSYDON_data_auxiliary.tar.gz",
     'description': "Auxiliary data for POSYDON. It contains data on "\
                    + "supernova prescriptions (Sukhbold+2016, Couch+2020, "\
                    + "Patton+Sukhbold2020), star formation history "\
                    + "(IllustrisTNG), and detector sensitivity (of O3, O4low, "\
                    + "O4high, design of three gravitational wave detectors "\
-                   + "H1, L1, V1).", #TODO
-    'md5': None, #TODO
-    'title': "Auxiliary POSYDON data", #TODO
-    'url': "https://zenodo.org/communities/posydon" #TODO
+                   + "H1, L1, V1).",
+    'md5': "7eed35f08065628656fd140c03800cd6",
+    'title': "Auxiliary POSYDON data",
+    'url': "https://zenodo.org/records/15194708",
 }
 
 # v1
@@ -82,76 +82,76 @@ COMPLETE_SETS['super-Eddington_v1'] = ['v1_for_v2.0.0-pre1',
 
 # v2
 ZENODO_COLLECTION['v2_grids_2Zsun'] = {
-    'data': None, #TODO
-    'description': "The POSYDON v2 dataset at twice solar metallicity. It "\
+    'data': "https://zenodo.org/records/15194708/files/POSYDON_data_v2_grids_2Zsun.tar.gz",
+    'description': "The POSYDON DR2 at twice solar metallicity. It "\
                    + "contains single-HMS, single-HeMS, HMS-HMS, CO-HMS_RLO, "\
-                   + "CO-HeMS, CO-HeMS_RLO all at twice solar metallicity.", #TODO
-    'md5': None, #TODO
-    'title': "POSYDON v2.0 dataset at 2 Zsun", #TODO
-    'url': "https://zenodo.org/communities/posydon" #TODO
+                   + "CO-HeMS, CO-HeMS_RLO all at twice solar metallicity.", 
+    'md5': "32d216cd95857b3d29c73188377f31dc",
+    'title': "POSYDON DR2 dataset at 2 Zsun",
+    'url': "https://zenodo.org/records/15194708"
 }
 ZENODO_COLLECTION['v2_grids_1Zsun'] = {
-    'data': None, #TODO
-    'description': "The POSYDON v2 dataset at solar metallicity. It "\
+    'data': "https://zenodo.org/records/15194708/files/POSYDON_data_v2_grids_1Zsun.tar.gz",
+    'description': "The POSYDON DR2 at solar metallicity. It "\
                    + "contains single-HMS, single-HeMS, HMS-HMS, CO-HMS_RLO, "\
-                   + "CO-HeMS, CO-HeMS_RLO all at solar metallicity.", #TODO
-    'md5': None, #TODO
-    'title': "POSYDON v2.0 dataset at Zsun", #TODO
-    'url': "https://zenodo.org/communities/posydon" #TODO
+                   + "CO-HeMS, CO-HeMS_RLO all at solar metallicity.",
+    'md5': "fc6a17c9675e44909e3fae14aad4c4dc",
+    'title': "POSYDON DR2 dataset at Zsun",
+    'url': "https://zenodo.org/records/15194708"
 }
 ZENODO_COLLECTION['v2_grids_0.45Zsun'] = {
-    'data': None, #TODO
-    'description': "The POSYDON v2 dataset at 0.45 solar metallicity. It "\
+    'data': "https://zenodo.org/records/15194708/files/POSYDON_data_v2_grids_0.45Zsun.tar.gz",
+    'description': "The POSYDON DR2 at 0.45 solar metallicity. It "\
                    + "contains single-HMS, single-HeMS, HMS-HMS, CO-HMS_RLO, "\
-                   + "CO-HeMS, CO-HeMS_RLO all at 0.45 solar metallicity.", #TODO
-    'md5': None, #TODO
-    'title': "POSYDON v2.0 dataset at 0.45 Zsun", #TODO
-    'url': "https://zenodo.org/communities/posydon" #TODO
+                   + "CO-HeMS, CO-HeMS_RLO all at 0.45 solar metallicity.",
+    'md5': "b2dc618a8399084c9c239b6c9af67bd7",
+    'title': "POSYDON DR2 dataset at 0.45 Zsun",
+    'url': "https://zenodo.org/records/15194708"
 }
 ZENODO_COLLECTION['v2_grids_0.2Zsun'] = {
-    'data': None, #TODO
-    'description': "The POSYDON v2 dataset at 0.2 solar metallicity. It "\
+    'data': "https://zenodo.org/records/15194708/files/POSYDON_data_v2_grids_0.2Zsun.tar.gz",
+    'description': "The POSYDON DR2 at 0.2 solar metallicity. It "\
                    + "contains single-HMS, single-HeMS, HMS-HMS, CO-HMS_RLO, "\
-                   + "CO-HeMS, CO-HeMS_RLO all at 0.2 solar metallicity.", #TODO
-    'md5': None, #TODO
-    'title': "POSYDON v2.0 dataset at 0.2 Zsun", #TODO
-    'url': "https://zenodo.org/communities/posydon" #TODO
+                   + "CO-HeMS, CO-HeMS_RLO all at 0.2 solar metallicity.",
+    'md5': "37b6879d194f5ac5c0eb76b46330cfd8",
+    'title': "POSYDON DR2 dataset at 0.2 Zsun",
+    'url': "https://zenodo.org/records/15194708"
 }
 ZENODO_COLLECTION['v2_grids_0.1Zsun'] = {
-    'data': None, #TODO
-    'description': "The POSYDON v2 dataset at 0.1 solar metallicity. It "\
+    'data': "https://zenodo.org/records/15194708/files/POSYDON_data_v2_grids_0.1Zsun.tar.gz",
+    'description': "The POSYDON DR2 at 0.1 solar metallicity. It "\
                    + "contains single-HMS, single-HeMS, HMS-HMS, CO-HMS_RLO, "\
-                   + "CO-HeMS, CO-HeMS_RLO all at 0.1 solar metallicity.", #TODO
-    'md5': None, #TODO
-    'title': "POSYDON v2.0 dataset at 0.1 Zsun", #TODO
-    'url': "https://zenodo.org/communities/posydon" #TODO
+                   + "CO-HeMS, CO-HeMS_RLO all at 0.1 solar metallicity.",
+    'md5': "07225092f2c21519c884afa33d143b59",
+    'title': "POSYDON DR2 dataset at 0.1 Zsun",
+    'url': "https://zenodo.org/records/15194708"
 }
 ZENODO_COLLECTION['v2_grids_0.01Zsun'] = {
-    'data': None, #TODO
-    'description': "The POSYDON v2 dataset at 0.01 solar metallicity. It "\
+    'data': "https://zenodo.org/records/15194708/files/POSYDON_data_v2_grids_0.01Zsun.tar.gz",
+    'description': "The POSYDON DR2 at 0.01 solar metallicity. It "\
                    + "contains single-HMS, single-HeMS, HMS-HMS, CO-HMS_RLO, "\
-                   + "CO-HeMS, CO-HeMS_RLO all at 0.01 solar metallicity.", #TODO
-    'md5': None, #TODO
-    'title': "POSYDON v2.0 dataset at 0.01 Zsun", #TODO
-    'url': "https://zenodo.org/communities/posydon" #TODO
+                   + "CO-HeMS, CO-HeMS_RLO all at 0.01 solar metallicity.",
+    'md5': "25157c0e156c729b3a4cecbe878cbf51",
+    'title': "POSYDON DR2 dataset at 0.01 Zsun",
+    'url': "https://zenodo.org/records/15194708",
 }
 ZENODO_COLLECTION['v2_grids_1e-3Zsun'] = {
-    'data': None, #TODO
-    'description': "The POSYDON v2 dataset at 10^{-3} solar metallicity. It "\
+    'data': "https://zenodo.org/records/15194708/files/POSYDON_data_v2_grids_1e-3Zsun.tar.gz",
+    'description': "The POSYDON DR2 at 10^{-3} solar metallicity. It "\
                    + "contains single-HMS, single-HeMS, HMS-HMS, CO-HMS_RLO, "\
-                   + "CO-HeMS, CO-HeMS_RLO all at 10^{-3} solar metallicity.", #TODO
-    'md5': None, #TODO
-    'title': "POSYDON v2.0 dataset at 10^{-3} Zsun", #TODO
-    'url': "https://zenodo.org/communities/posydon" #TODO
+                   + "CO-HeMS, CO-HeMS_RLO all at 10^{-3} solar metallicity.",
+    'md5': "6b5c260ac80a6abee20f9f5313fb3b83",
+    'title': "POSYDON DR2 dataset at 10^{-3} Zsun",
+    'url': "https://zenodo.org/records/15194708",
 }
 ZENODO_COLLECTION['v2_grids_1e-4Zsun'] = {
-    'data': None, #TODO
-    'description': "The POSYDON v2 dataset at 10^{-4} solar metallicity. It "\
+    'data': "https://zenodo.org/records/15194708/files/POSYDON_data_v2_grids_1e-4Zsun.tar.gz",
+    'description': "The POSYDON DR2 at 10^{-4} solar metallicity. It "\
                    + "contains single-HMS, single-HeMS, HMS-HMS, CO-HMS_RLO, "\
-                   + "CO-HeMS, CO-HeMS_RLO all at 10^{-4} solar metallicity.", #TODO
-    'md5': None, #TODO
-    'title': "POSYDON v2.0 dataset at 10^{-4} Zsun", #TODO
-    'url': "https://zenodo.org/communities/posydon" #TODO
+                   + "CO-HeMS, CO-HeMS_RLO all at 10^{-4} solar metallicity.",
+    'md5': "f44d0035d80ccc30998537de99d440e4",
+    'title': "POSYDON DR2 dataset at 10^{-4} Zsun",
+    'url': "https://zenodo.org/records/15194708",
 }
 COMPLETE_SETS['v2'] = ['auxiliary', 'v2_grids_2Zsun', 'v2_grids_1Zsun',
                        'v2_grids_0.45Zsun', 'v2_grids_0.2Zsun',

--- a/posydon/utils/datasets.py
+++ b/posydon/utils/datasets.py
@@ -101,13 +101,13 @@ ZENODO_COLLECTION['DR2_grids_1Zsun'] = {
     'title': "POSYDON DR2 dataset at Zsun",
     'url': "https://zenodo.org/records/15194708",
 }
-ZENODO_COLLECTION['v2_grids_0.45Zsun'] = {
+ZENODO_COLLECTION['DR2_grids_0.45Zsun'] = {
     'data': "https://zenodo.org/records/15194708/files/POSYDON_data_v2_grids_0.45Zsun.tar.gz",
     'description': "The POSYDON v2 dataset at 0.45 solar metallicity. It "\
                    + "contains single-HMS, single-HeMS, HMS-HMS, HMS-HMS_RLO,"\
                    + " CO-HMS_RLO, CO-HeMS, CO-HeMS_RLO all at 0.45 solar metallicity.",
     'md5': "b2dc618a8399084c9c239b6c9af67bd7",
-    'title': "POSYDON v2.0 dataset at 0.45 Zsun",
+    'title': "POSYDON DR2 dataset at 0.45 Zsun",
     'url': "https://zenodo.org/records/15194708",
 }
 ZENODO_COLLECTION['DR2_grids_0.2Zsun'] = {

--- a/posydon/utils/datasets.py
+++ b/posydon/utils/datasets.py
@@ -40,16 +40,17 @@ ZENODO_COLLECTION['auxiliary'] = {
                    + "Patton+Sukhbold2020), star formation history "\
                    + "(IllustrisTNG, Zavala+2021, Chruslinska+2021), and "\
                    + "detector sensitivity (of O3, O4low, O4high, design of "\
-                   + "three gravitational wave detectors H1, L1, V1).",
+                   + "three gravitational wave detectors H1, L1, V1). About "\
+                   + "4GB on disk.",
     'md5': None, #TODO
     'title': "Auxiliary POSYDON data",
     'url': "https://zenodo.org/communities/posydon" #TODO
 }
 
-# v1
-ZENODO_COLLECTION['v1_for_v2.0.0-pre1'] = {
+# DR1
+ZENODO_COLLECTION['DR1_for_v2.0.0-pre1'] = {
     'data': "https://zenodo.org/record/14205146/files/POSYDON_data.tar.gz",
-    'description': "The POSYDON v1 dataset post-processed to work with the "\
+    'description': "The POSYDON DR1 dataset post-processed to work with the "\
                    + "v2.0.0-pre1 version of the code. It contains "\
                    + "single-HMS, single-HeMS, HMS-HMS, CO-HMS_RLO, CO-HeMS, "\
                    + "CO-HeMS_RLO all at solar metallicity. Additionally, it "\
@@ -59,117 +60,116 @@ ZENODO_COLLECTION['v1_for_v2.0.0-pre1'] = {
                    + "sensitivity (of O3, O4low, O4high, design of three "\
                    + "gravitational wave detectors H1, L1, V1).",
     'md5': "cf645a45b9b92c2ad01e759eb1950beb",
-    'title': "Re-postprocessed POSYDON v1.0 dataset compatible with code "\
-             + "release v2.0.0-pre1",
+    'title': "Re-postprocessed POSYDON DR1 dataset compatible with code "\
+             + "release v2.0.0-pre1 and v2.0.0-pre2", #TODO create a version for code version v2.0.0 and update the entry
     'url': "https://zenodo.org/records/14205146"
 }
-ZENODO_COLLECTION['super-Eddington_v1'] = {
+ZENODO_COLLECTION['DR1-super_Eddington'] = {
     'data': "https://zenodo.org/records/14216817/files/"\
             + "POSYDON_data_super_Eddington.tar.gz",
     'description': "Data for super-Eddington accretion compatible with "\
-                   + "'v1_for_v2.0.0-pre1'. It contains CO-HMS_RLO, CO-HeMS, "\
+                   + "'DR1_for_v2.0.0-pre1'. It contains CO-HMS_RLO, CO-HeMS, "\
                    + "CO-HeMS_RLO all at solar metallicity to replace the "\
-                   + "corresponding data in 'v1_for_v2.0.0-pre1'",
+                   + "corresponding data in 'DR1_for_v2.0.0-pre1'",
     'md5': "64b46fbd65cb54819371a1cbc714019c",
-    'title': "Re-postprocessed POSYDON v1.0 dataset, assuming "\
+    'title': "Re-postprocessed POSYDON DR1 dataset, assuming "\
              + "super-Eddington accretion, compatible with code release "\
-             + "v2.0.0-pre1",
+             + "v2.0.0-pre1 and v2.0.0-pre2", #TODO create a version for code version v2.0.0 and update the entry
     'url': "https://zenodo.org/records/14216817"
 }
-COMPLETE_SETS['v1'] = ['v1_for_v2.0.0-pre1']
-COMPLETE_SETS['super-Eddington_v1'] = ['v1_for_v2.0.0-pre1',
-                                       'super-Eddington_v1']
+COMPLETE_SETS['DR1'] = ['DR1_for_v2.0.0-pre1']
+COMPLETE_SETS['DR1.1'] = ['DR1_for_v2.0.0-pre1', 'DR1-super_Eddington']
 
-# v2
-ZENODO_COLLECTION['v2_grids_2Zsun'] = {
+# DR2
+ZENODO_COLLECTION['DR2_grids_2Zsun'] = {
     'data': None, #TODO
-    'description': "The POSYDON v2 dataset at twice solar metallicity. It "\
+    'description': "The POSYDON DR2 dataset at twice solar metallicity. It "\
                    + "contains single-HMS, single-HeMS, HMS-HMS, HMS-HMS_RLO,"\
                    + " CO-HMS_RLO, CO-HeMS, CO-HeMS_RLO all at twice solar "\
                    + "metallicity.",
     'md5': None, #TODO
-    'title': "POSYDON v2.0 dataset at 2 Zsun",
+    'title': "POSYDON DR2 dataset at 2 Zsun",
     'url': "https://zenodo.org/communities/posydon" #TODO
 }
-ZENODO_COLLECTION['v2_grids_1Zsun'] = {
+ZENODO_COLLECTION['DR2_grids_1Zsun'] = {
     'data': None, #TODO
-    'description': "The POSYDON v2 dataset at solar metallicity. It "\
+    'description': "The POSYDON DR2 dataset at solar metallicity. It "\
                    + "contains single-HMS, single-HeMS, HMS-HMS, HMS-HMS_RLO,"\
                    + " CO-HMS_RLO, CO-HeMS, CO-HeMS_RLO all at twice solar "\
                    + "metallicity.",
     'md5': None, #TODO
-    'title': "POSYDON v2.0 dataset at Zsun",
+    'title': "POSYDON DR2 dataset at Zsun",
     'url': "https://zenodo.org/communities/posydon" #TODO
 }
-ZENODO_COLLECTION['v2_grids_0.45Zsun'] = {
+ZENODO_COLLECTION['DR2_grids_0.45Zsun'] = {
     'data': None, #TODO
-    'description': "The POSYDON v2 dataset at 0.45 solar metallicity. It "\
+    'description': "The POSYDON DR2 dataset at 0.45 solar metallicity. It "\
                    + "contains single-HMS, single-HeMS, HMS-HMS, HMS-HMS_RLO,"\
                    + " CO-HMS_RLO, CO-HeMS, CO-HeMS_RLO all at twice solar "\
                    + "metallicity.",
     'md5': None, #TODO
-    'title': "POSYDON v2.0 dataset at 0.45 Zsun",
+    'title': "POSYDON DR2 dataset at 0.45 Zsun",
     'url': "https://zenodo.org/communities/posydon" #TODO
 }
-ZENODO_COLLECTION['v2_grids_0.2Zsun'] = {
+ZENODO_COLLECTION['DR2_grids_0.2Zsun'] = {
     'data': None, #TODO
-    'description': "The POSYDON v2 dataset at 0.2 solar metallicity. It "\
+    'description': "The POSYDON DR2 dataset at 0.2 solar metallicity. It "\
                    + "contains single-HMS, single-HeMS, HMS-HMS, HMS-HMS_RLO,"\
                    + " CO-HMS_RLO, CO-HeMS, CO-HeMS_RLO all at twice solar "\
                    + "metallicity.",
     'md5': None, #TODO
-    'title': "POSYDON v2.0 dataset at 0.2 Zsun",
+    'title': "POSYDON DR2 dataset at 0.2 Zsun",
     'url': "https://zenodo.org/communities/posydon" #TODO
 }
-ZENODO_COLLECTION['v2_grids_0.1Zsun'] = {
+ZENODO_COLLECTION['DR2_grids_0.1Zsun'] = {
     'data': None, #TODO
-    'description': "The POSYDON v2 dataset at 0.1 solar metallicity. It "\
+    'description': "The POSYDON DR2 dataset at 0.1 solar metallicity. It "\
                    + "contains single-HMS, single-HeMS, HMS-HMS, HMS-HMS_RLO,"\
                    + " CO-HMS_RLO, CO-HeMS, CO-HeMS_RLO all at twice solar "\
                    + "metallicity.",
     'md5': None, #TODO
-    'title': "POSYDON v2.0 dataset at 0.1 Zsun",
+    'title': "POSYDON DR2 dataset at 0.1 Zsun",
     'url': "https://zenodo.org/communities/posydon" #TODO
 }
-ZENODO_COLLECTION['v2_grids_0.01Zsun'] = {
+ZENODO_COLLECTION['DR2_grids_0.01Zsun'] = {
     'data': None, #TODO
-    'description': "The POSYDON v2 dataset at 0.01 solar metallicity. It "\
+    'description': "The POSYDON DR2 dataset at 0.01 solar metallicity. It "\
                    + "contains single-HMS, single-HeMS, HMS-HMS, HMS-HMS_RLO,"\
                    + " CO-HMS_RLO, CO-HeMS, CO-HeMS_RLO all at twice solar "\
                    + "metallicity.",
     'md5': None, #TODO
-    'title': "POSYDON v2.0 dataset at 0.01 Zsun",
+    'title': "POSYDON DR2 dataset at 0.01 Zsun",
     'url': "https://zenodo.org/communities/posydon" #TODO
 }
-ZENODO_COLLECTION['v2_grids_1e-3Zsun'] = {
+ZENODO_COLLECTION['DR2_grids_1e-3Zsun'] = {
     'data': None, #TODO
-    'description': "The POSYDON v2 dataset at 10^{-3} solar metallicity. It "\
+    'description': "The POSYDON DR2 dataset at 10^{-3} solar metallicity. It "\
                    + "contains single-HMS, single-HeMS, HMS-HMS, HMS-HMS_RLO,"\
                    + " CO-HMS_RLO, CO-HeMS, CO-HeMS_RLO all at twice solar "\
                    + "metallicity.",
     'md5': None, #TODO
-    'title': "POSYDON v2.0 dataset at 10^{-3} Zsun",
+    'title': "POSYDON DR2 dataset at 10^{-3} Zsun",
     'url': "https://zenodo.org/communities/posydon" #TODO
 }
-ZENODO_COLLECTION['v2_grids_1e-4Zsun'] = {
+ZENODO_COLLECTION['DR2_grids_1e-4Zsun'] = {
     'data': None, #TODO
-    'description': "The POSYDON v2 dataset at 10^{-4} solar metallicity. It "\
+    'description': "The POSYDON DR2 dataset at 10^{-4} solar metallicity. It "\
                    + "contains single-HMS, single-HeMS, HMS-HMS, HMS-HMS_RLO,"\
                    + " CO-HMS_RLO, CO-HeMS, CO-HeMS_RLO all at twice solar "\
                    + "metallicity.",
     'md5': None, #TODO
-    'title': "POSYDON v2.0 dataset at 10^{-4} Zsun",
+    'title': "POSYDON DR2 dataset at 10^{-4} Zsun",
     'url': "https://zenodo.org/communities/posydon" #TODO
 }
-COMPLETE_SETS['v2'] = ['auxiliary', 'v2_grids_2Zsun', 'v2_grids_1Zsun',
-                       'v2_grids_0.45Zsun', 'v2_grids_0.2Zsun',
-                       'v2_grids_0.1Zsun', 'v2_grids_0.01Zsun',
-                       'v2_grids_1e-3Zsun', 'v2_grids_1e-4Zsun']
-COMPLETE_SETS['v2_2Zsun'] = ['auxiliary', 'v2_grids_2Zsun']
-COMPLETE_SETS['v2_1Zsun'] = ['auxiliary', 'v2_grids_1Zsun']
-COMPLETE_SETS['v2_0.45Zsun'] = ['auxiliary', 'v2_grids_0.45Zsun']
-COMPLETE_SETS['v2_0.2Zsun'] = ['auxiliary', 'v2_grids_0.2Zsun']
-COMPLETE_SETS['v2_0.1Zsun'] = ['auxiliary', 'v2_grids_0.1Zsun']
-COMPLETE_SETS['v2_0.01Zsun'] = ['auxiliary', 'v2_grids_0.01Zsun']
-COMPLETE_SETS['v2_1e-3Zsun'] = ['auxiliary', 'v2_grids_1e-3Zsun']
-COMPLETE_SETS['v2_1e-4Zsun'] = ['auxiliary', 'v2_grids_1e-4Zsun']
+COMPLETE_SETS['DR2'] = ['auxiliary', 'DR2_grids_2Zsun', 'DR2_grids_1Zsun',
+                        'DR2_grids_0.45Zsun', 'DR2_grids_0.2Zsun',
+                        'DR2_grids_0.1Zsun', 'DR2_grids_0.01Zsun',
+                        'DR2_grids_1e-3Zsun', 'DR2_grids_1e-4Zsun']
+COMPLETE_SETS['DR2_2Zsun'] = ['auxiliary', 'DR2_grids_2Zsun']
+COMPLETE_SETS['DR2_1Zsun'] = ['auxiliary', 'DR2_grids_1Zsun']
+COMPLETE_SETS['DR2_0.45Zsun'] = ['auxiliary', 'DR2_grids_0.45Zsun']
+COMPLETE_SETS['DR2_0.2Zsun'] = ['auxiliary', 'DR2_grids_0.2Zsun']
+COMPLETE_SETS['DR2_0.1Zsun'] = ['auxiliary', 'DR2_grids_0.1Zsun']
+COMPLETE_SETS['DR2_0.01Zsun'] = ['auxiliary', 'DR2_grids_0.01Zsun']
+COMPLETE_SETS['DR2_1e-3Zsun'] = ['auxiliary', 'DR2_grids_1e-3Zsun']
+COMPLETE_SETS['DR2_1e-4Zsun'] = ['auxiliary', 'DR2_grids_1e-4Zsun']


### PR DESCRIPTION
- [x] update documentation: adjust size requirements(, remove Windows from supported OS, see issue #259 )
- [x] update default download: switch from v1 data to v2 data
- adjust data sets:
  - [x] adjust descriptions
  - [x] adjust urls and checksums (needs publication on zenodo first)
- may update v1 and super-Eddington datasets (@ZepeiX) as the zenodo version don't contain the new SN models
- [ ] testing it