### PR TITLE
Change m2 minimum to 0.5, our DR2 HMS-HMS minimum mass

### DIFF
--- a/docs/_source/components-overview/pop_syn/population_params.rst
+++ b/docs/_source/components-overview/pop_syn/population_params.rst
@@ -770,7 +770,8 @@ It also contains which sampling distributions to use for the initial conditions 
     - | Minimum secondary mass (in solar masses).
       | Is required to be smaller than the minimum primary mass.
       | limits: 0-270
-    - ``0.35``
+      | DR2 HMS-HMS grid has a minimum M2 mass of 0.5.
+    - ``0.5``
 
   * - ``secondary_mass_max``
     - | Maximum secondary mass (in solar masses).

--- a/docs/_source/components-overview/pop_syn/population_params.rst
+++ b/docs/_source/components-overview/pop_syn/population_params.rst
@@ -771,6 +771,7 @@ It also contains which sampling distributions to use for the initial conditions 
       | Is required to be smaller than the minimum primary mass.
       | limits: 0-270
       | DR2 HMS-HMS grid has a minimum M2 mass of 0.5.
+      | We always check if q>=0.05 and M2>=secondary_mass_min are satisfied in the initial sampling.
     - ``0.5``
 
   * - ``secondary_mass_max``

--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -339,7 +339,7 @@
     # float (0,130)
   secondary_mass_scheme = 'flat_mass_ratio'
     # 'flat_mass_ratio', 'q=1'
-  secondary_mass_min = 0.35
+  secondary_mass_min = 0.5
     # float (0,130)
   secondary_mass_max = 150.0
     # float (0,130)


### PR DESCRIPTION
Changes the default $m_2$ minimum value to 0.5, since it's our lowest grid value.
This change makes $q$ dependent on the primary mass (It's no longer the flat between 0.05 and 1). 

I don't know if we want this.