### PR TITLE
Prepend path before importing versioneer

### DIFF
--- a/.github/workflows/publish-to-anaconda.yml
+++ b/.github/workflows/publish-to-anaconda.yml
@@ -6,7 +6,7 @@ on:
     
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
 
     - name: Checkout

--- a/.github/workflows/publish-to-anaconda.yml
+++ b/.github/workflows/publish-to-anaconda.yml
@@ -6,7 +6,7 @@ on:
     
 jobs:
   publish:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
 
     - name: Checkout

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,10 @@
 from __future__ import print_function
 import glob
 import sys
-import versioneer
 import os.path
+sys.path.insert(0, os.path.dirname(__file__))
+
+import versioneer
 
 cmdclass = {}
 


### PR DESCRIPTION
The Git actions currently fail because `versioneer` can not be found. It was suggested [here](https://github.com/python-versioneer/python-versioneer/issues/193) that prepending the path to `POSYDON` could resolve this (i.e., where our `versioneer.py` exists, generated from initial `versioneer` installation). This appears to solve the issue on a local build at least.