### PR TITLE
Docs deployment test hotfix

### DIFF
--- a/.github/workflows/deploy-github-pages-release.yml
+++ b/.github/workflows/deploy-github-pages-release.yml
@@ -61,7 +61,7 @@ jobs:
         # make the output folder
         output_folder=$GITHUB_WORKSPACE/_build/
         echo "Output folder: $output_folder"
-        mkdir $output_folder
+        mkdir -p $output_folder
         
         # move to the repository folder
         export PATH_TO_POSYDON=$GITHUB_WORKSPACE/POSYDON
@@ -170,7 +170,7 @@ jobs:
         # make the output folder
         output_folder=$GITHUB_WORKSPACE/_build/
         echo "Output folder: $output_folder"
-        mkdir $output_folder
+        mkdir -p $output_folder
 
         # move to the repository folder
         export PATH_TO_POSYDON=$GITHUB_WORKSPACE/POSYDON

--- a/docs/_source/conf.py
+++ b/docs/_source/conf.py
@@ -61,6 +61,8 @@ def get_github_tags():
 
 github_tags = get_github_tags()
 
+print("github_tags: ", github_tags)
+
 # 2.0.0-dev needs to be removed from the list and replaced with development
 github_tags.remove('2.0.0-dev')
 


### PR DESCRIPTION
This adds `mkdir -p` to both the `build_v1` and `build_v2` jobs in our doc deployment on release action. This is to test if it alleviates a potential race condition in accessing/creating the same directory.

This also adds debug output to `docs/_source/conf.py` to display the retrieved git tags.