### PR TITLE
Additional kicksv2.1

### DIFF
--- a/docs/_source/components-overview/pop_syn/population_params.rst
+++ b/docs/_source/components-overview/pop_syn/population_params.rst
@@ -514,6 +514,7 @@ The collection of trained prescriptions can be found in the ``MODELS.py`` file a
       * ``'zero'``
       * ``'asym_ej'``
       * ``'linear'``
+      * ``'log_normal'``
     - ``'one_over_mass'``
 
   * - ``sigma_kick_CCSN_NS``

--- a/docs/_source/components-overview/pop_syn/population_params.rst
+++ b/docs/_source/components-overview/pop_syn/population_params.rst
@@ -512,6 +512,8 @@ The collection of trained prescriptions can be found in the ``MODELS.py`` file a
       * ``'NS_one_minus_fallback_BH_one'``
       * ``'one'``
       * ``'zero'``
+      * ``'asym_ej'``
+      * ``'linear'``
     - ``'one_over_mass'``
 
   * - ``sigma_kick_CCSN_NS``

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -1968,13 +1968,11 @@ class StepSN(object):
 
         -------------------------------------------------------------------------------------
 
-        Natal kicks based on the mass of the ejected envelope during SN.
+        The following natal kick prescriptions are based on the mass of the 
+        ejected envelope during the supernova explosion:
 
-        Two kick prescriptions are provided below, both of which are 
-        based on the mass of ejecta lost during the supernova. 
-        
-        Each model is named with the prefix "ejecta_mass" followed by the name of 
-        the first author of the respective kick prescription.
+        "asym_ej" - reference [1]
+        "linear" - reference [2]
 
         References
         ----------
@@ -1989,7 +1987,7 @@ class StepSN(object):
 
         -------------------------------------------------------------------------------------
 
-        Another kick prescription has been added which draws kicks from a log-normal distribution, 
+        The "log_normal" precription draws kicks from a log-normal distribution, 
         based on Disberg P., Mandel I., 2025, arXiv e-prints, p. arXiv:2505.22102v1
 
 
@@ -2010,7 +2008,7 @@ class StepSN(object):
             else:
                 norm = 1.0
 
-        elif self.kick_normalisation == 'ejecta_mass_Janka17':
+        elif self.kick_normalisation == 'asym_ej':
            
             f_kin = 0.1         # Fraction of SN explosion energy that is kinetic energy of the gas
             beta = 0.1          # Fraction of ejecta mass that is neutrino heated
@@ -2022,7 +2020,7 @@ class StepSN(object):
 
             Vkick_ej = 211*(f_kin*beta*epsilon)**(1/2)*(alpha_ej/0.1)*(M_ej/0.1)*(M_NS/1.5)**(-1)
         
-        elif self.kick_normalisation == 'ejecta_mass_Richards+23':
+        elif self.kick_normalisation == 'linear':
             
             M_ej = star.co_core_mass_history[-1]-star.mass        # Ejecta mass
             M_rem = star.mass                                     # Neutron star mass
@@ -2048,7 +2046,7 @@ class StepSN(object):
         if sigma is not None:
             # f_fb = self.compute_m_rembar(star, None)[1]
 
-            if self.kick_normalisation in ['ejecta_mass_Janka17', 'ejecta_mass_Richards+23']:
+            if self.kick_normalisation in ['asym_ej', 'linear']:
                 Vkick = Vkick_ej
             elif self.kick_normalisation == 'log_normal':
                 Vkick = norm * sp.stats.lognorm.rvs(s=0.68, scale=np.exp(5.60), size=1)[0]

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -2010,8 +2010,8 @@ class StepSN(object):
 
             Vkick_ej = 211*(f_kin*beta*epsilon)**(1/2)*(alpha_ej/0.1)*(M_ej/0.1)*(M_NS/1.5)**(-1)
         
-         elif self.kick_normalisation == 'ejecta_mass_Richards+23':
-
+        elif self.kick_normalisation == 'ejecta_mass_Richards+23':
+            
             M_ej = star.co_core_mass_history[-1]-star.mass        # Ejecta mass
             M_rem = star.mass                                     # Neutron star mass
             alpha = 115                                           # alpha and beta are best-fit parameters

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -1973,7 +1973,7 @@ class StepSN(object):
         Two kick prescriptions are provided below, both of which are 
         based on the mass of ejecta lost during the supernova. 
         
-        Each is named with the prefix "ejecta_mass" followed by the name of 
+        Each model is named with the prefix "ejecta_mass" followed by the name of 
         the first author of the respective kick prescription.
 
         References
@@ -1989,7 +1989,8 @@ class StepSN(object):
 
         -------------------------------------------------------------------------------------
 
-        Log-normal kicks are based on Disberg P., Mandel I., 2025, arXiv e-prints, p. arXiv:2505.22102v1
+        Another kick prescription has been added which draws kicks from a log-normal distribution, 
+        based on Disberg P., Mandel I., 2025, arXiv e-prints, p. arXiv:2505.22102v1
 
 
         """

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -1966,7 +1966,7 @@ class StepSN(object):
         Vkick : double
             Natal orbital kick in km/s.
 
-        ---------------------------------------------------------------
+        -------------------------------------------------------------------------------------
 
         Natal kicks based on the mass of the ejected envelope during SN.
 
@@ -1987,12 +1987,23 @@ class StepSN(object):
             multiple distinct observations, Richards S. M., Eldridge J. J., Briel M. M., 
             Stevance H. F., Willcox R., 2022, arXiv e-prints, p. arXiv:2208.02407
 
+        -------------------------------------------------------------------------------------
+
+        Log-normal kicks are based on Disberg P., Mandel I., 2025, arXiv e-prints, p. arXiv:2505.22102v1
+
+
         """
         if self.kick_normalisation == 'one_minus_fallback':
             # Normalization from Eq. 21, Fryer, C. L., Belczynski, K., Wiktorowicz,
             # G., Dominik, M., Kalogera, V., & Holz, D. E. (2012), ApJ, 749(1), 91.
             norm = (1.0 - star.f_fb)
         elif self.kick_normalisation == 'one_over_mass':
+            if star.state == 'BH':
+                norm = 1.4/star.mass
+            else:
+                norm = 1.0
+
+        elif self.kick_normalisation == 'log_normal':
             if star.state == 'BH':
                 norm = 1.4/star.mass
             else:
@@ -2038,8 +2049,11 @@ class StepSN(object):
 
             if self.kick_normalisation in ['ejecta_mass_Janka17', 'ejecta_mass_Richards+23']:
                 Vkick = Vkick_ej
+            elif self.kick_normalisation == 'log_normal':
+                Vkick = norm * sp.stats.lognorm.rvs(s=0.68, scale=np.exp(5.60), size=1)[0]
             else:
                 Vkick = norm * sp.stats.maxwell.rvs(loc=0., scale=sigma, size=1)[0]
+            
         else:
             Vkick = 0.0
 

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -1966,6 +1966,27 @@ class StepSN(object):
         Vkick : double
             Natal orbital kick in km/s.
 
+        ---------------------------------------------------------------
+
+        Natal kicks based on the mass of the ejected envelope during SN.
+
+        Two kick prescriptions are provided below, both of which are 
+        based on the mass of ejecta lost during the supernova. 
+        
+        Each is named with the prefix "ejecta_mass" followed by the name of 
+        the first author of the respective kick prescription.
+
+        References
+        ----------
+
+        [1] Neutron Star Kicks by the Gravitational Tug-boat Mechanism in Asymmetric
+            Supernova Explosions: Progenitor and Explosion Dependence, Janka H.T., 2017, 
+            ApJ 837(1):84, arXiv:1611.07562 [astro-ph.HE]
+
+        [2] New constraints on the Bray conservation-of-momentum natal kick model from 
+            multiple distinct observations, Richards S. M., Eldridge J. J., Briel M. M., 
+            Stevance H. F., Willcox R., 2022, arXiv e-prints, p. arXiv:2208.02407
+
         """
         if self.kick_normalisation == 'one_minus_fallback':
             # Normalization from Eq. 21, Fryer, C. L., Belczynski, K., Wiktorowicz,
@@ -1976,6 +1997,28 @@ class StepSN(object):
                 norm = 1.4/star.mass
             else:
                 norm = 1.0
+
+        elif self.kick_normalisation == 'ejecta_mass_Janka17':
+           
+            f_kin = 0.1         # Fraction of SN explosion energy that is kinetic energy of the gas
+            beta = 0.1          # Fraction of ejecta mass that is neutrino heated
+            epsilon = 1    
+            alpha_ej = 0.01
+            M_NS = star.mass                                    # Neutron star mass
+            M_rembar=(((3*M_NS/20 + 1)**2) - 1)/0.3             # Remnant baryonic mass 
+            M_ej=abs(star.mass_history[-1] - M_rembar)          # Ejecta mass
+
+            Vkick_ej = 211*(f_kin*beta*epsilon)**(1/2)*(alpha_ej/0.1)*(M_ej/0.1)*(M_NS/1.5)**(-1)
+        
+         elif self.kick_normalisation == 'ejecta_mass_Richards+23':
+
+            M_ej = star.co_core_mass_history[-1]-star.mass        # Ejecta mass
+            M_rem = star.mass                                     # Neutron star mass
+            alpha = 115                                           # alpha and beta are best-fit parameters
+            beta = 15                                             
+
+            Vkick_ej = alpha * (M_ej/M_rem) + beta
+
         elif self.kick_normalisation == 'NS_one_minus_fallback_BH_one':
             if star.state == 'BH':
                 norm = 1.
@@ -1993,7 +2036,10 @@ class StepSN(object):
         if sigma is not None:
             # f_fb = self.compute_m_rembar(star, None)[1]
 
-            Vkick = norm * sp.stats.maxwell.rvs(loc=0., scale=sigma, size=1)[0]
+            if self.kick_normalisation in ['ejecta_mass_Janka17', 'ejecta_mass_Richards+23']:
+                Vkick = Vkick_ej
+            else:
+                Vkick = norm * sp.stats.maxwell.rvs(loc=0., scale=sigma, size=1)[0]
         else:
             Vkick = 0.0
 

--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -249,8 +249,8 @@
   kick = True
     # True, False
   kick_normalisation = 'one_over_mass'
-    # "one_minus_fallback", "one_over_mass", "NS_one_minus_fallback_BH_one",
-    # "one", "zero"
+    # "one_minus_fallback", "one_over_mass", "NS_one_minus_fallback_BH_one", "one", "zero",
+    # "ejecta_mass_Janka17", "ejecta_mass_Richards+23", "log_normal"
   sigma_kick_CCSN_NS = 265.0
     # float (0,inf)
   sigma_kick_CCSN_BH = 265.0

--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -249,8 +249,8 @@
   kick = True
     # True, False
   kick_normalisation = 'one_over_mass'
-    # "one_minus_fallback", "one_over_mass", "NS_one_minus_fallback_BH_one", "one", "zero",
-    # "ejecta_mass_Janka17", "ejecta_mass_Richards+23", "log_normal"
+    # "one_minus_fallback", "one_over_mass", "NS_one_minus_fallback_BH_one", 
+    # "one", "zero", "asym_ej", "linear", "log_normal"
   sigma_kick_CCSN_NS = 265.0
     # float (0,inf)
   sigma_kick_CCSN_BH = 265.0


### PR DESCRIPTION
@astro-abhishek created the branch https://github.com/POSYDON-code/POSYDON/tree/abhishek_NS_kicks to include 2 additional kick prescriptions.

This PR brings these prescriptions to the `v2.1-dev` version as a base.

Additional documentation still needs to be added:

- [x] Add new options to `population_params_default` inlist
- [x] Add new options to documentation page

See the diff from before: https://github.com/POSYDON-code/POSYDON/compare/development...abhishek_NS_kicks