### PR TITLE
Pop params ini fix

### DIFF
--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -170,24 +170,6 @@
   absolute_import = None
     # If given, use an absolute filepath to user defined step: ['<PATH_TO_PY_FILE>', '<NAME>']
 
-[step_disrupted]
-  import = ['posydon.binary_evol.DT.step_disrupted','DisruptedStep']
-    # builtin posydon step
-  absolute_import = None
-    # If given, use an absolute filepath to user defined step: ['<PATH_TO_PY_FILE>', '<NAME>']
-
-[step_merged]
-  import = ['posydon.binary_evol.DT.step_merged','MergedStep']
-    # builtin posydon step
-  absolute_import = None
-    # If given, use an absolute filepath to user defined step: ['<PATH_TO_PY_FILE>', '<NAME>']
-
-[step_initially_single]
-  import = ['posydon.binary_evol.DT.step_initially_single','InitiallySingleStep']
-    # builtin posydon step
-  absolute_import = None
-    # If given, use an absolute filepath to user defined step: ['<PATH_TO_PY_FILE>', '<NAME>']
-
 [step_CE]
   import = ['posydon.binary_evol.CE.step_CEE', 'StepCEE']
     # builtin posydon step


### PR DESCRIPTION
This removed the double definition of steps introduced with the rework of the matching step.
Must have happened during the rebasing.
