### PR TITLE
Spin in IF runs fix

### DIFF
--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -893,7 +893,7 @@ class MesaGridStep:
                         current = getattr(star, 'spin')
                         key_p = 'star_%d_mass' % (k+1)
                         # calculate new spin based on masses
-                        spin = cf.spin_stable_mass_transfer(current, prev_mass[k] , fv[key_p])
+                        spin = cf.spin_stable_mass_transfer(current, prev_mass[k], fv[key_p])
                         setattr(star, key, spin)
                         
                     elif key == 'log_R':

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -843,6 +843,7 @@ class MesaGridStep:
         stars = [binary.star_1, binary.star_2]
         stars_CO = [star_1_CO, star_2_CO]
         fv = self.final_values
+        prev_mass = [getattr(star, 'mass') for star in stars]
 
         for key in BINARYPROPERTIES:
             if POSYDON_TO_MESA['binary'][key] is None:
@@ -882,7 +883,7 @@ class MesaGridStep:
                     else:
                         key_p = 'S%d_' % (k+1)+POSYDON_TO_MESA['star'][key]
                         setattr(star, key, fv[key_p])
-                else:
+                else: # star is a compact object
                     if POSYDON_TO_MESA['star'][key] is None:
                         setattr(star, key, None)
                     elif key == 'mass':
@@ -890,7 +891,11 @@ class MesaGridStep:
                         setattr(star, key, fv[key_p])
                     elif key == 'spin':
                         current = getattr(star, 'spin')
-                        setattr(star, key, current)
+                        key_p = 'star_%d_mass' % (k+1)
+                        # calculate new spin based on masses
+                        spin = cf.spin_stable_mass_transfer(current, prev_mass[k] , fv[key_p])
+                        setattr(star, key, spin)
+                        
                     elif key == 'log_R':
                         mass = fv['star_%d_mass' % (k+1)]
                         st = infer_star_state(star_mass=mass, star_CO=True)


### PR DESCRIPTION
In runs with the initial-final interpolation, the spin was not properly treated. Despite high accretion amounts, the spin remained low. Only in NN runs, was the spin adjusted based on the accretion. See issue #650 for more details.

This adds the same treatment to IF runs for the spin. You can see in the example model below that this increases the spin in a similar fashion as the NN did (see Issue #650 for NN run values). They're not exactly the same, but close enough and better than before.

<img width="1098" height="215" alt="image" src="https://github.com/user-attachments/assets/017a197b-1f6e-4f41-84a1-cfba50d52c87" />

A zip with a notebook to check the difference. Note that the ini files point to the conservative grid interpolator and grid.
[BH_spin_other_grids.zip](https://github.com/user-attachments/files/21773723/BH_spin_other_grids.zip)
