### PR TITLE
Evolution of secondary if primary is CO + S2 and S2 flip

### DIFF
--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -353,7 +353,7 @@ class detached_step:
                                     dense_output=True)
 
             t_after_ODEsolution = time.time()
-            
+
             if self.verbose:
                 ivp_tspan = t_after_ODEsolution - t_before_ODEsolution
                 print(f"\nODE solver duration: {ivp_tspan:.6g} sec")
@@ -372,7 +372,7 @@ class detached_step:
             secondary.state = check_state_of_star(secondary, star_CO=False)
             for timestep in range(-len(t[:-1]), 0):
                 secondary.state_history[timestep] = check_state_of_star(secondary, i=timestep, star_CO=False)
-            
+
             if primary.state == "massless_remnant":
                 pass
             elif primary.co:

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -305,7 +305,7 @@ class detached_step:
 
         # match stars to single star models for detached evolution
         primary, secondary, only_CO = self.track_matcher.do_matching(binary, "step_detached")
-
+        
         if only_CO:
             if self.verbose:
                 print("Binary system only contains compact objects."

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -351,11 +351,8 @@ class detached_step:
                                         secondary.omega0, primary.omega0],
                                     args=(primary, secondary),
                                     dense_output=True)
-
+            
             t_after_ODEsolution = time.time()
-            print(primary.mass, secondary.mass)
-            print(primary.state, secondary.state)
-            print(binary.state)
             
             if self.verbose:
                 ivp_tspan = t_after_ODEsolution - t_before_ODEsolution

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -305,7 +305,6 @@ class detached_step:
 
         # match stars to single star models for detached evolution
         primary, secondary, only_CO = self.track_matcher.do_matching(binary, "step_detached")
-        
         if only_CO:
             if self.verbose:
                 print("Binary system only contains compact objects."
@@ -372,7 +371,8 @@ class detached_step:
             secondary.state = check_state_of_star(secondary, star_CO=False)
             for timestep in range(-len(t[:-1]), 0):
                 secondary.state_history[timestep] = check_state_of_star(secondary, i=timestep, star_CO=False)
-
+            
+            
             if primary.state == "massless_remnant":
                 pass
             elif primary.co:
@@ -385,6 +385,7 @@ class detached_step:
                 primary.state = check_state_of_star(primary, star_CO=False)
                 for timestep in range(-len(t[:-1]), 0):
                     primary.state_history[timestep] = check_state_of_star(primary, i=timestep, star_CO=False)
+
 
             ## CHECK IF THE BINARY IS IN RLO
             if res.t_events[0] or res.t_events[1]:
@@ -444,6 +445,7 @@ class detached_step:
 
             ## CHECK IF STARS WILL UNDERGO CC
             elif res.t_events[2]:
+                print('HERE')
                 # reached t_max of track. End of life (possible collapse) of secondary
                 if secondary == binary.star_1:
                     binary.event = "CC1"
@@ -470,6 +472,7 @@ class detached_step:
                             "step, but do not have the same mass")
 
             elif res.t_events[3]:
+                print("HERE2")
                 # reached t_max of track. End of life (possible collapse) of primary
                 if secondary == binary.star_1:
                     binary.event = "CC2"

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -351,7 +351,7 @@ class detached_step:
                                         secondary.omega0, primary.omega0],
                                     args=(primary, secondary),
                                     dense_output=True)
-            
+
             t_after_ODEsolution = time.time()
             
             if self.verbose:
@@ -372,7 +372,6 @@ class detached_step:
             secondary.state = check_state_of_star(secondary, star_CO=False)
             for timestep in range(-len(t[:-1]), 0):
                 secondary.state_history[timestep] = check_state_of_star(secondary, i=timestep, star_CO=False)
-            
             
             if primary.state == "massless_remnant":
                 pass

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -305,6 +305,7 @@ class detached_step:
 
         # match stars to single star models for detached evolution
         primary, secondary, only_CO = self.track_matcher.do_matching(binary, "step_detached")
+
         if only_CO:
             if self.verbose:
                 print("Binary system only contains compact objects."
@@ -352,7 +353,10 @@ class detached_step:
                                     dense_output=True)
 
             t_after_ODEsolution = time.time()
-
+            print(primary.mass, secondary.mass)
+            print(primary.state, secondary.state)
+            print(binary.state)
+            
             if self.verbose:
                 ivp_tspan = t_after_ODEsolution - t_before_ODEsolution
                 print(f"\nODE solver duration: {ivp_tspan:.6g} sec")
@@ -385,7 +389,6 @@ class detached_step:
                 primary.state = check_state_of_star(primary, star_CO=False)
                 for timestep in range(-len(t[:-1]), 0):
                     primary.state_history[timestep] = check_state_of_star(primary, i=timestep, star_CO=False)
-
 
             ## CHECK IF THE BINARY IS IN RLO
             if res.t_events[0] or res.t_events[1]:
@@ -445,7 +448,6 @@ class detached_step:
 
             ## CHECK IF STARS WILL UNDERGO CC
             elif res.t_events[2]:
-                print('HERE')
                 # reached t_max of track. End of life (possible collapse) of secondary
                 if secondary == binary.star_1:
                     binary.event = "CC1"
@@ -472,7 +474,6 @@ class detached_step:
                             "step, but do not have the same mass")
 
             elif res.t_events[3]:
-                print("HERE2")
                 # reached t_max of track. End of life (possible collapse) of primary
                 if secondary == binary.star_1:
                     binary.event = "CC2"

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -4,7 +4,8 @@
 __authors__ = [
     "Emmanouil Zapartas <ezapartas@gmail.com>",
     "Simone Bavera <Simone.Bavera@unige.ch>",
-    "Konstantinos Kovlakas <Konstantinos.Kovlakas@unige.ch>"
+    "Konstantinos Kovlakas <Konstantinos.Kovlakas@unige.ch>",
+    "Max Briel <max.briel@gmail.com>",
 ]
 
 

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -547,10 +547,10 @@ class MergedStep(IsolatedStep):
         elif (s1 in STAR_STATES_NOT_CO
             and s2 in ["NS", "BH"]):
                 # TODO: potentially flag a Thorne-Zytkov object
-                massless_remnant = convert_star_to_massless_remnant(comp)
+                massless_remnant = convert_star_to_massless_remnant(star_base)
 
                 ## in this case, want CO companion object to stay the same, and base star to be assigned massless remnant
-                return massless_remnant, merged_star
+                return massless_remnant, comp
         else:
             raise ModelError(f"Combination of merging star states not expected: {s1} {s2}")
         # ad hoc spin of merged star to be used in the detached step

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -86,7 +86,7 @@ class MergedStep(IsolatedStep):
     def __call__(self,binary):
 
         merged_star_properties = self.merged_star_properties
-
+        
         if self.verbose:
             print("Before Merger", binary.star_1.state, binary.star_2.state,
                   binary.state, binary.event)
@@ -117,7 +117,7 @@ class MergedStep(IsolatedStep):
                 raise ValueError("step_merged initiated for He stars but RLO not initiated")
         else:
             raise ValueError("step_merged initiated but binary is not in valid merging state!")
-
+        
         binary.event = None
 
         if self.verbose:
@@ -130,7 +130,7 @@ class MergedStep(IsolatedStep):
 
         super().__call__(binary)
 
-    def merged_star_properties(self,star_base,comp):
+    def merged_star_properties(self, star_base, comp):
         """
         Make assumptions about the core/total mass, and abundances of the star of a merged product.
 
@@ -172,7 +172,6 @@ class MergedStep(IsolatedStep):
             and s2 in LIST_ACCEPTABLE_STATES_FOR_HMS):
                 #these stellar attributes change value
                 merged_star.mass = (star_base.mass + comp.mass) * (1.-self.rel_mass_lost_HMS_HMS)
-
                 #TODO for key in ["center_h1", "center_he4", "center_c12", "center_n14","center_o16"]:
                 merged_star.center_h1 = mass_weighted_avg()
                 merged_star.center_he4 = mass_weighted_avg(abundance_name = "center_he4")
@@ -229,8 +228,7 @@ class MergedStep(IsolatedStep):
         # as above but opposite stars
         elif (s1 in LIST_ACCEPTABLE_STATES_FOR_HMS
             and s2 in LIST_ACCEPTABLE_STATES_FOR_POSTMS):
-
-                merged_star = comp
+            
                 merged_star.mass = star_base.mass + comp.mass
 
                 merged_star.surface_h1 = mass_weighted_avg(abundance_name = "surface_h1", mass_weight2="H-rich_envelope_mass", mass_weight1="mass")
@@ -252,7 +250,7 @@ class MergedStep(IsolatedStep):
                 merged_star.log_LZ = comp.log_LZ
 
                 merged_star.state = check_state_of_star(merged_star, star_CO=False)  # TODO for sure this needs testing!
-                massless_remnant = convert_star_to_massless_remnant(star_base)
+                massless_remnant = convert_star_to_massless_remnant(comp)
 
         #postMS + postMS
         elif (s1 in LIST_ACCEPTABLE_STATES_FOR_POSTMS
@@ -260,7 +258,7 @@ class MergedStep(IsolatedStep):
 
                 # add total and core masses
                 for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
-                    current = getattr(merged_star, key) + getattr(comp, key)
+                    current = getattr(star_base, key) + getattr(comp, key)
                     setattr(merged_star, key,current)
 
                 # weighted central abundances if merging cores. Else only from star_base
@@ -312,7 +310,7 @@ class MergedStep(IsolatedStep):
 
                 # add total and core masses
                 for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
-                    current = getattr(merged_star, key) + getattr(comp, key)
+                    current = getattr(star_base, key) + getattr(comp, key)
                     setattr(merged_star, key,current)
 
                 # weighted central abundances if merging cores. Else only from star_base
@@ -342,11 +340,9 @@ class MergedStep(IsolatedStep):
         elif (s1 in  LIST_ACCEPTABLE_STATES_FOR_HeMS
             and s2 in LIST_ACCEPTABLE_STATES_FOR_POSTMS):
 
-                merged_star = comp
-
                 # add total and core masses
                 for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
-                    current = getattr(merged_star, key) + getattr(star_base, key)
+                    current = getattr(star_base, key) + getattr(comp, key)
                     setattr(merged_star, key,current)
 
                 # weighted central abundances if merging cores. Else only from star_base
@@ -369,8 +365,9 @@ class MergedStep(IsolatedStep):
                         if key in [ "c12_c12", "center_gamma",
                                    "avg_c_in_c_core", "total_moment_of_inertia", "spin"]:
                             setattr(merged_star, key, np.nan)
+                            
                 merged_star.state = check_state_of_star(merged_star, star_CO=False)  # TODO for sure this needs testing!
-                massless_remnant = convert_star_to_massless_remnant(star_base)
+                massless_remnant = convert_star_to_massless_remnant(comp)
 
         #postMS + HeStar that is not in HeMS
         elif (s1 in LIST_ACCEPTABLE_STATES_FOR_POSTMS
@@ -378,7 +375,7 @@ class MergedStep(IsolatedStep):
 
                 # add total and core masses
                 for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
-                    current = getattr(merged_star, key) + getattr(comp, key)
+                    current = getattr(star_base, key) + getattr(comp, key)
                     setattr(merged_star, key,current)
 
                 # weighted central abundances if merging cores. Else only from star_base
@@ -420,10 +417,9 @@ class MergedStep(IsolatedStep):
         elif (s1 in LIST_ACCEPTABLE_STATES_FOR_POSTHeMS
             and s2 in LIST_ACCEPTABLE_STATES_FOR_POSTMS):
 
-                merged_star = comp
                 # add total and core masses
                 for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
-                    current = getattr(merged_star, key) + getattr(star_base, key)
+                    current = getattr(star_base, key) + getattr(comp, key)
                     setattr(merged_star, key,current)
                 # weighted central abundances if merging cores. Else only from star_base
                 if star_base.co_core_mass == 0 and comp.co_core_mass == 0: # two stars with Helium cores
@@ -458,7 +454,7 @@ class MergedStep(IsolatedStep):
                                    "avg_c_in_c_core", "total_moment_of_inertia", "spin"]:
                             setattr(merged_star, key, np.nan)
                 merged_star.state = check_state_of_star(merged_star, star_CO=False)  # TODO for sure this needs testing!
-                massless_remnant = convert_star_to_massless_remnant(star_base)
+                massless_remnant = convert_star_to_massless_remnant(comp)
 
         # HeStar + HeStar
         elif (s1 in STAR_STATES_HE_RICH
@@ -466,7 +462,7 @@ class MergedStep(IsolatedStep):
 
                 # add total and core masses
                 for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
-                    current = getattr(merged_star, key) + getattr(comp, key)
+                    current = getattr(star_base, key) + getattr(comp, key)
                     setattr(merged_star, key,current)
 
                 # weighted central abundances if merging cores. Else only from star_base
@@ -518,7 +514,7 @@ class MergedStep(IsolatedStep):
                 #WD is considered a stripped CO core
                 # add total and core masses
                 for key in ["mass", "he_core_mass", "c_core_mass", "o_core_mass", "co_core_mass"]:
-                    current = getattr(merged_star, key) + getattr(comp, "mass")
+                    current = getattr(star_base, key) + getattr(comp, "mass")
                     setattr(merged_star, key,current)
                 # weighted central abundances if merging cores. Else only from star_base
                 if (comp.co_core_mass > 0 and star_base.co_core_mass == 0): # comp with CO core and the star_base has not
@@ -550,15 +546,13 @@ class MergedStep(IsolatedStep):
         # Star + NS/BH
         elif (s1 in STAR_STATES_NOT_CO
             and s2 in ["NS", "BH"]):
-                merged_star = comp
                 # TODO: potentially flag a Thorne-Zytkov object
-                massless_remnant = convert_star_to_massless_remnant(star_base)
+                massless_remnant = convert_star_to_massless_remnant(comp)
 
                 ## in this case, want CO companion object to stay the same, and base star to be assigned massless remnant
                 return massless_remnant, merged_star
         else:
             raise ModelError(f"Combination of merging star states not expected: {s1} {s2}")
-
         # ad hoc spin of merged star to be used in the detached step
         merged_star.surf_avg_omega_div_omega_crit = self.merger_critical_rot
 

--- a/posydon/binary_evol/DT/step_merged.py
+++ b/posydon/binary_evol/DT/step_merged.py
@@ -86,7 +86,7 @@ class MergedStep(IsolatedStep):
     def __call__(self,binary):
 
         merged_star_properties = self.merged_star_properties
-        
+
         if self.verbose:
             print("Before Merger", binary.star_1.state, binary.star_2.state,
                   binary.state, binary.event)
@@ -117,7 +117,7 @@ class MergedStep(IsolatedStep):
                 raise ValueError("step_merged initiated for He stars but RLO not initiated")
         else:
             raise ValueError("step_merged initiated but binary is not in valid merging state!")
-        
+
         binary.event = None
 
         if self.verbose:

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -1498,7 +1498,7 @@ class TrackMatcher:
         interp1d["m0"] = match_m0
 
         if star.co:
-            kvalue["mass"] = np.zeros_like(kvalue["mass"]) + secondary.mass
+            kvalue["mass"] = np.zeros_like(kvalue["mass"]) + star.mass
             kvalue["R"] = np.zeros_like(kvalue["log_R"])
             kvalue["mdot"] = np.zeros_like(kvalue["mdot"])
             interp1d["mass"] = PchipInterpolator(age, kvalue["mass"])

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -1914,8 +1914,9 @@ class TrackMatcher:
 
         if binary.non_existent_companion == 0: # both stars exist, detached step of a binary
 
-            # states match, either both H stars or both He stars
-            if (all(s_valid) and (all(s_htrack) or all(~s_htrack))):
+            # states match, either both H stars or both He stars and not any COs
+            # prevents He+CO going into here.
+            if (all(s_valid) and (all(s_htrack) or all(~s_htrack)) and not (any(s_CO))):
                 primary = s_arr[0]
                 primary.co = s_CO[0]
                 primary.htrack = s_htrack[0]

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -8,7 +8,8 @@ __authors__ = [
     "Kyle Akira Rocha <kylerocha2024@u.northwestern.edu>",
     "Jeffrey Andrews <jeffrey.andrews@northwestern.edu>",
     "Camille Liotine <cliotine@u.northwestern.edu>",
-    "Seth Gossage <seth.gossage@northwestern.edu>"
+    "Seth Gossage <seth.gossage@northwestern.edu>",
+    "Max Briel <max.briel@gmail.com>",
 ]
 
 import os

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -1362,7 +1362,7 @@ class TrackMatcher:
         return match_vals, best_sol
 
 
-    def get_star_match_data(self, binary, star, secondary_htrack=None,
+    def get_star_match_data(self, binary, star,
                             copy_prev_m0=None, copy_prev_t0=None):
         """
             Match a given component of a binary (i.e., a star) to a 
@@ -1408,9 +1408,6 @@ class TrackMatcher:
                 match_m0, match_t0 = star.mass, 0
             elif star.co:
                 match_m0, match_t0 = copy_prev_m0, copy_prev_t0
-                if secondary_htrack == None:
-                    raise ValueError("Secondary htrack must be provided "
-                                     "when matching a compact object.")
             else:
                 t_before_matching = time.time()
                 # matching to single star grids (getting mass, age of 
@@ -1426,16 +1423,10 @@ class TrackMatcher:
         if pd.isna(match_m0) or pd.isna(match_t0):
             return None, None, None
         
-        if star.co:
-            if secondary_htrack:
-                self.grid = self.grid_Hrich
-            else:
-                self.grid = self.grid_strippedHe
+        if star.htrack:
+            self.grid = self.grid_Hrich
         else:
-            if star.htrack:
-                self.grid = self.grid_Hrich
-            else:
-                self.grid = self.grid_strippedHe
+            self.grid = self.grid_strippedHe
 
         # check if m0 is in the grid bounds
         outside_low = match_m0 < self.grid.grid_mass.min()
@@ -1792,7 +1783,6 @@ class TrackMatcher:
             # copy the secondary star except mass which is of the primary,
             # and radius, mdot, Idot = 0
             self.get_star_match_data(binary, primary,
-                                     secondary.htrack,
                                      copy_prev_m0 = m0,
                                      copy_prev_t0 = t0)
         elif self.primary_normal:
@@ -1950,7 +1940,7 @@ class TrackMatcher:
 
                 primary = s_arr[CO_mask].item()
                 primary.co = s_CO[CO_mask].item()
-                primary.htrack = s_htrack[CO_mask].item()
+                primary.htrack = s_htrack[~CO_mask].item()
 
                 secondary = s_arr[~CO_mask].item()
                 secondary.co = s_CO[~CO_mask].item()
@@ -1971,7 +1961,7 @@ class TrackMatcher:
             # massless remnant
             primary = s_arr[0]
             primary.co = True
-            primary.htrack = False
+            primary.htrack = s_htrack[1]
 
             secondary = s_arr[1]
             secondary.htrack = s_htrack[1]
@@ -1984,7 +1974,7 @@ class TrackMatcher:
         elif binary.non_existent_companion == 2:
             primary = s_arr[1]
             primary.co = True
-            primary.htrack = False
+            primary.htrack = s_htrack[0]
 
             secondary = s_arr[0]
             secondary.htrack = s_htrack[0]

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -1755,6 +1755,8 @@ class TrackMatcher:
 
         # determine star states for matching
         primary, secondary, only_CO = self.determine_star_states(binary)
+        print(primary.mass)
+        print(secondary.mass)
         if only_CO:
             return (None, None, None), (None, None, None), only_CO
 
@@ -1777,6 +1779,7 @@ class TrackMatcher:
         all_exist = binary.non_existent_companion == 0
         self.primary_not_normal = primary.co or has_non_existent
         self.primary_normal = not primary.co and all_exist
+        print(self.primary_not_normal)
 
         if self.primary_not_normal:
             # copy the secondary star except mass which is of the primary,
@@ -1902,7 +1905,7 @@ class TrackMatcher:
         s_He = np.array([s.state in STAR_STATES_FOR_Hestar_MATCHING for s in s_arr])
         s_massless = np.array([s.state == "massless_remnant" for s in s_arr])
         s_valid = s_H | s_He | s_CO | s_massless    # states considered here
-        s_htrack = s_H & ~(s_CO)                    # only true if h rich and not a CO
+        s_htrack = s_H & ~(s_CO)   # only true if h rich and not a CO
 
         # check if star states are recognizable
         if any(~s_valid):
@@ -1968,6 +1971,7 @@ class TrackMatcher:
             if secondary.co:
                 only_CO = True
                 return primary, secondary, only_CO
+            print(secondary.mass)
 
         # star 2 is a massless remnant, only star 1 exists
         elif binary.non_existent_companion == 2:

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -1346,7 +1346,7 @@ class TrackMatcher:
                            "\nOptimizer termination reason: "
                            f"{best_sol.message}") 
 
-            track_vals0 = (np.nan, np.nan)
+            match_vals = (np.nan, np.nan)
 
         # or else we found a solution
         else:

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -348,9 +348,9 @@ class TrackMatcher:
 
         # min/max ranges of ages for each grid
         t_min_H = 0.0
-        t_max_H = np.max(self.grid_Hrich.grid_age)
+        t_max_H = None
         t_min_He = 0.0
-        t_max_He = np.max(self.grid_strippedHe.grid_age)
+        t_max_He = None
 
         # Stellar parameter matching metrics
         # ========================================
@@ -1252,7 +1252,7 @@ class TrackMatcher:
             try:
                 # Minimize sq, Euclidean dist. w/ Newton's method (TNC)
                 sol = minimize(square_difference, x0, args=fnc_args,
-                                method=method, bounds=bounds, tol=1e-6)
+                                method=method, bounds=bounds)
             
                 # guard against NaN solutions, ensuring they will fail
                 sol.fun = 1e99 if np.isnan(sol.fun) else sol.fun

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -1361,7 +1361,7 @@ class TrackMatcher:
         return match_vals, best_sol
 
 
-    def get_star_match_data(self, binary, star, 
+    def get_star_match_data(self, binary, star, secondary_htrack=None,
                             copy_prev_m0=None, copy_prev_t0=None):
         """
             Match a given component of a binary (i.e., a star) to a 
@@ -1421,11 +1421,17 @@ class TrackMatcher:
         # bad result
         if pd.isna(match_m0) or pd.isna(match_t0):
             return None, None, None
-
-        if star.htrack:
-            self.grid = self.grid_Hrich
+        
+        if secondary_htrack != None:
+            if secondary_htrack:
+                self.grid = self.grid_Hrich
+            else:
+                self.grid = self.grid_strippedHe
         else:
-            self.grid = self.grid_strippedHe
+            if star.htrack:
+                self.grid = self.grid_Hrich
+            else:
+                self.grid = self.grid_strippedHe
 
         # check if m0 is in the grid bounds
         outside_low = match_m0 < self.grid.grid_mass.min()
@@ -1755,8 +1761,6 @@ class TrackMatcher:
 
         # determine star states for matching
         primary, secondary, only_CO = self.determine_star_states(binary)
-        print(primary.mass)
-        print(secondary.mass)
         if only_CO:
             return (None, None, None), (None, None, None), only_CO
 
@@ -1779,14 +1783,14 @@ class TrackMatcher:
         all_exist = binary.non_existent_companion == 0
         self.primary_not_normal = primary.co or has_non_existent
         self.primary_normal = not primary.co and all_exist
-        print(self.primary_not_normal)
 
         if self.primary_not_normal:
             # copy the secondary star except mass which is of the primary,
             # and radius, mdot, Idot = 0
             self.get_star_match_data(binary, primary,
+                                     secondary_htrack=secondary.htrack,
                                      copy_prev_m0 = m0,
-                                     copy_prev_t0 = t0)
+                                     copy_prev_t0 = t0,)
         elif self.primary_normal:
             # match primary
             self.get_star_match_data(binary, primary)
@@ -1971,7 +1975,6 @@ class TrackMatcher:
             if secondary.co:
                 only_CO = True
                 return primary, secondary, only_CO
-            print(secondary.mass)
 
         # star 2 is a massless remnant, only star 1 exists
         elif binary.non_existent_companion == 2:

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -1186,7 +1186,8 @@ class TrackMatcher:
             rescale_facs, bnds, scalers = scls_bnds
 
             if not match_ok:
-                return None, (new_htrack, None, None, None), None, match_ok
+                fnc_args = (new_htrack, None, None, None)
+                return None, fnc_args, None, match_ok
 
             # Get closest matching point along track single star grids. x0 
             # contains the corresponding initial guess for mass and age

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -1361,7 +1361,7 @@ class TrackMatcher:
         return match_vals, best_sol
 
 
-    def get_star_match_data(self, binary, star, secondary_htrack=None,
+    def get_star_match_data(self, binary, star, secondary=None,
                             copy_prev_m0=None, copy_prev_t0=None):
         """
             Match a given component of a binary (i.e., a star) to a 
@@ -1407,6 +1407,9 @@ class TrackMatcher:
                 match_m0, match_t0 = star.mass, 0
             elif star.co:
                 match_m0, match_t0 = copy_prev_m0, copy_prev_t0
+                if secondary == None:
+                    raise ValueError("Secondary star must be provided "
+                                     "when matching a compact object.")
             else:
                 t_before_matching = time.time()
                 # matching to single star grids (getting mass, age of 
@@ -1422,8 +1425,8 @@ class TrackMatcher:
         if pd.isna(match_m0) or pd.isna(match_t0):
             return None, None, None
         
-        if secondary_htrack != None:
-            if secondary_htrack:
+        if star.co:
+            if secondary.htrack:
                 self.grid = self.grid_Hrich
             else:
                 self.grid = self.grid_strippedHe
@@ -1495,7 +1498,7 @@ class TrackMatcher:
         interp1d["m0"] = match_m0
 
         if star.co:
-            kvalue["mass"] = np.zeros_like(kvalue["mass"]) + star.mass
+            kvalue["mass"] = np.zeros_like(kvalue["mass"]) + secondary.mass
             kvalue["R"] = np.zeros_like(kvalue["log_R"])
             kvalue["mdot"] = np.zeros_like(kvalue["mdot"])
             interp1d["mass"] = PchipInterpolator(age, kvalue["mass"])
@@ -1788,9 +1791,9 @@ class TrackMatcher:
             # copy the secondary star except mass which is of the primary,
             # and radius, mdot, Idot = 0
             self.get_star_match_data(binary, primary,
-                                     secondary_htrack=secondary.htrack,
+                                     secondary,
                                      copy_prev_m0 = m0,
-                                     copy_prev_t0 = t0,)
+                                     copy_prev_t0 = t0)
         elif self.primary_normal:
             # match primary
             self.get_star_match_data(binary, primary)

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -1421,6 +1421,7 @@ class TrackMatcher:
 
         # bad result
         if pd.isna(match_m0) or pd.isna(match_t0):
+            star.interp1d = None
             return None, None
 
         if star.htrack:
@@ -1806,7 +1807,7 @@ class TrackMatcher:
                             f"{binary.companion_2_exists}")
 
 
-        if not hasattr(secondary, 'interp1d') or not hasattr(primary, 'interp1d'):
+        if (secondary.interp1d == None) or (primary.interp1d == None):
             failed_state = binary.state
             set_binary_to_failed(binary)
             raise MatchingError("Grid matching failed for " 

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -1361,7 +1361,7 @@ class TrackMatcher:
         return match_vals, best_sol
 
 
-    def get_star_match_data(self, binary, star, secondary=None,
+    def get_star_match_data(self, binary, star, secondary_htrack=None,
                             copy_prev_m0=None, copy_prev_t0=None):
         """
             Match a given component of a binary (i.e., a star) to a 
@@ -1407,8 +1407,8 @@ class TrackMatcher:
                 match_m0, match_t0 = star.mass, 0
             elif star.co:
                 match_m0, match_t0 = copy_prev_m0, copy_prev_t0
-                if secondary == None:
-                    raise ValueError("Secondary star must be provided "
+                if secondary_htrack == None:
+                    raise ValueError("Secondary htrack must be provided "
                                      "when matching a compact object.")
             else:
                 t_before_matching = time.time()
@@ -1426,7 +1426,7 @@ class TrackMatcher:
             return None, None, None
         
         if star.co:
-            if secondary.htrack:
+            if secondary_htrack:
                 self.grid = self.grid_Hrich
             else:
                 self.grid = self.grid_strippedHe
@@ -1791,7 +1791,7 @@ class TrackMatcher:
             # copy the secondary star except mass which is of the primary,
             # and radius, mdot, Idot = 0
             self.get_star_match_data(binary, primary,
-                                     secondary,
+                                     secondary.htrack,
                                      copy_prev_m0 = m0,
                                      copy_prev_t0 = t0)
         elif self.primary_normal:

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -810,7 +810,7 @@ class TrackMatcher:
 
         # if optimizer failed for some reason set solution as NaN
         if not sol.success or sol.x[1] < 0:
-            match_vals = (np.nan, np.nan)
+            match_vals = np.array([np.nan, np.nan])
         else:
             match_vals = sol.x
 
@@ -1346,7 +1346,7 @@ class TrackMatcher:
                            "\nOptimizer termination reason: "
                            f"{best_sol.message}") 
 
-            match_vals = (np.nan, np.nan)
+            match_vals = np.array([np.nan, np.nan])
 
         # or else we found a solution
         else:
@@ -1592,7 +1592,7 @@ class TrackMatcher:
                     Pwarn("Setting (post-match) rotation rate to zero.", 
                           "InappropriateValueWarning")
 
-        if self.verbose and omega is not None:
+        if self.verbose and omega is not None and (omega_in_rad_per_yr != 0):
             print("pre-match omega [rad/yr] = ", omega * const.secyer)
             print("calculated omega [rad/yr] = ", omega_in_rad_per_yr)
             pcdiff = 100.0*(omega_in_rad_per_yr-omega * const.secyer) \
@@ -1805,7 +1805,7 @@ class TrackMatcher:
                             f"{binary.companion_2_exists}")
 
 
-        if secondary.interp1d is None or primary.interp1d is None:
+        if not hasattr(secondary, 'interp1d') or not hasattr(primary, 'interp1d'):
             failed_state = binary.state
             set_binary_to_failed(binary)
             raise MatchingError("Grid matching failed for " 

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -1420,7 +1420,7 @@ class TrackMatcher:
 
         # bad result
         if pd.isna(match_m0) or pd.isna(match_t0):
-            return None, None, None
+            return None, None
 
         if star.htrack:
             self.grid = self.grid_Hrich

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -1100,7 +1100,7 @@ class TrackMatcher:
                         print(f"We cannot use match_type={match_type} " \
                                 "since star is on the MS. Skipping...")
                     match_ok = False
-                    return None, None, False, match_ok
+                    return (None, None, False, match_ok), (None, None, None)
 
                 # if he star, try matching to H-rich grid
                 elif star.state in STAR_STATES_FOR_Hestar_MATCHING:
@@ -1183,7 +1183,7 @@ class TrackMatcher:
             rescale_facs, bnds, scalers = scls_bnds
 
             if not match_ok:
-                return None, None, None, new_htrack, match_ok
+                return None, (new_htrack, None, None, None), None, match_ok
 
             # Get closest matching point along track single star grids. x0 
             # contains the corresponding initial guess for mass and age

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -1101,7 +1101,9 @@ class TrackMatcher:
                         print(f"We cannot use match_type={match_type} " \
                                 "since star is on the MS. Skipping...")
                     match_ok = False
-                    return (None, None, False, match_ok), (None, None, None)
+                    match_attrs = (None, None, new_htrack, match_ok)
+                    scls_bnds = (None, None, None)
+                    return match_attrs, scls_bnds
 
                 # if he star, try matching to H-rich grid
                 elif star.state in STAR_STATES_FOR_Hestar_MATCHING:

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -1249,7 +1249,7 @@ class TrackMatcher:
             try:
                 # Minimize sq, Euclidean dist. w/ Newton's method (TNC)
                 sol = minimize(square_difference, x0, args=fnc_args,
-                                method=method, bounds=bounds)
+                                method=method, bounds=bounds, tol=1e-6)
             
                 # guard against NaN solutions, ensuring they will fail
                 sol.fun = 1e99 if np.isnan(sol.fun) else sol.fun

--- a/posydon/binary_evol/flow_chart.py
+++ b/posydon/binary_evol/flow_chart.py
@@ -109,6 +109,7 @@ STAR_STATES_FOR_postMS_MATCHING = [st for st in STAR_STATES_NORMALSTAR if \
 # states to ID an He star (Xcore < 0.01, Xsurf < 0.01)
 STAR_STATES_FOR_Hestar_MATCHING = [st for st in STAR_STATES_NORMALSTAR if \
                                    ("stripped_He" in st)]
+STAR_STATES_FOR_Hestar_MATCHING.extend(['accreted_He_Core_He_burning'])
 
 BINARY_STATES_ALL = [
     'initially_single_star',

--- a/posydon/binary_evol/singlestar.py
+++ b/posydon/binary_evol/singlestar.py
@@ -163,7 +163,8 @@ class SingleStar:
             self.M4 = None
         if not hasattr(self, 'mu4'):
             self.mu4 = None
-
+        if not hasattr(self, 'interp1d'):
+            self.interp1d = None
 
         # the following quantities are updated in mesa_step.py
 


### PR DESCRIPTION
In solving issue #600 with the latest v2.1-dev version, I encountered an issue with `step_detached` introduced in v2.1-dev with the separation of the matching.

When the `primary` star has become a compact object, we replace the primary's properties in `step_detached` with the secondary. This makes it possible to use the solver correctly. However, it needs to grab the values from the `secondary` star, not the `primary` to do this. In the rewrite, this got lost.

Here I reimplement it, such that the solver gives back the correct ages.
Additionally, I also solved #600 by making sure that the star initiating the RLO is always the system that becomes the main object. This stops S1 and S2 from switching.

Code cleanup + examples on the way (or available below)
