### PR TITLE
Matching output fixes

### DIFF
--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -1346,7 +1346,7 @@ class TrackMatcher:
                            "\nOptimizer termination reason: "
                            f"{best_sol.message}") 
 
-            track_vals0 = (np.nan, np.nan)
+            match_vals = (np.nan, np.nan)
 
         # or else we found a solution
         else:

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -810,7 +810,7 @@ class TrackMatcher:
 
         # if optimizer failed for some reason set solution as NaN
         if not sol.success or sol.x[1] < 0:
-            match_vals = (np.nan, np.nan)
+            match_vals = np.array([np.nan, np.nan])
         else:
             match_vals = sol.x
 
@@ -1346,7 +1346,7 @@ class TrackMatcher:
                            "\nOptimizer termination reason: "
                            f"{best_sol.message}") 
 
-            match_vals = (np.nan, np.nan)
+            match_vals = np.array([np.nan, np.nan])
 
         # or else we found a solution
         else:
@@ -1592,7 +1592,7 @@ class TrackMatcher:
                     Pwarn("Setting (post-match) rotation rate to zero.", 
                           "InappropriateValueWarning")
 
-        if self.verbose and omega is not None:
+        if self.verbose and omega is not None and (omega_in_rad_per_yr != 0):
             print("pre-match omega [rad/yr] = ", omega * const.secyer)
             print("calculated omega [rad/yr] = ", omega_in_rad_per_yr)
             pcdiff = 100.0*(omega_in_rad_per_yr-omega * const.secyer) \
@@ -1805,7 +1805,7 @@ class TrackMatcher:
                             f"{binary.companion_2_exists}")
 
 
-        if secondary.interp1d is None or primary.interp1d is None:
+        if not hasattr(secondary, 'interp1d') or not hasattr(primary, 'interp1d'):
             failed_state = binary.state
             set_binary_to_failed(binary)
             raise MatchingError("Grid matching failed for " 

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -1420,7 +1420,7 @@ class TrackMatcher:
 
         # bad result
         if pd.isna(match_m0) or pd.isna(match_t0):
-            return None, None, None
+            return None, None
 
         if star.htrack:
             self.grid = self.grid_Hrich

--- a/posydon/binary_evol/DT/track_match.py
+++ b/posydon/binary_evol/DT/track_match.py
@@ -1100,7 +1100,7 @@ class TrackMatcher:
                         print(f"We cannot use match_type={match_type} " \
                                 "since star is on the MS. Skipping...")
                     match_ok = False
-                    return None, None, False, match_ok
+                    return (None, None, False, match_ok), (None, None, None)
 
                 # if he star, try matching to H-rich grid
                 elif star.state in STAR_STATES_FOR_Hestar_MATCHING:
@@ -1183,7 +1183,7 @@ class TrackMatcher:
             rescale_facs, bnds, scalers = scls_bnds
 
             if not match_ok:
-                return None, None, None, new_htrack, match_ok
+                return None, (new_htrack, None, None, None), None, match_ok
 
             # Get closest matching point along track single star grids. x0 
             # contains the corresponding initial guess for mass and age


### PR DESCRIPTION
1. Fixes the output structure for "later" matching attempts, such that the right information is passed along, if a matched failed.
2. Renames a variable such that it's correctly used in the output. Otherwise, the variable is undefined.
3. Fixes that interp1d might not be set for the `primary` or `secondary`, instead we check for the existence of the variable.