### PR TITLE
[PATCH v2.0.2] Fixes to binarystar.py/binarypopulation.py for BinaryPopulation().evolve() functionality, Fix MB

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "posydon" %}
-{% set version = "2.0.0" %}
+{% set version = "2.0.2" %}
 
 package:
   name: "{{ name|lower }}"

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -2610,8 +2610,9 @@ def diffeq(
         if verbose and verbose != 1:
             print("magnetic_braking_mode = ", magnetic_braking_mode)
             print("dOmega_mb = ", dOmega_mb_sec, dOmega_mb_pri)
-            dOmega_sec = dOmega_sec + dOmega_mb_sec
-            dOmega_pri = dOmega_pri + dOmega_mb_pri
+            
+        dOmega_sec = dOmega_sec + dOmega_mb_sec
+        dOmega_pri = dOmega_pri + dOmega_mb_pri
 
     if do_stellar_evolution_and_spin_from_winds:
         # Due to the secondary's own evolution, we have:

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -498,12 +498,12 @@ class MesaGridStep:
                     history_of_attribute = current + cb_bh[key_p][:-1]
                     getattr(binary, key_h).extend(history_of_attribute)
             elif key == 'nearest_neighbour_distance':
-                NN_d = self.nearest_neighbour_distance
-                setattr(binary, key, NN_d)
+                NN_dist = self.nearest_neighbour_distance
+                setattr(binary, key, NN_dist)
                 if self.save_initial_conditions:
-                    getattr(binary, key_h).append(NN_d)
+                    getattr(binary, key_h).append(NN_dist)
                 if track_interpolation:
-                    getattr(binary, key_h).extend([NN_d]*length_hist)
+                    getattr(binary, key_h).extend([NN_dist]*length_hist)
             elif key in ['eccentricity', 'V_sys']:
                 v_key = getattr(binary, key_h)[-1]
                 setattr(binary, key, v_key)
@@ -852,7 +852,7 @@ class MesaGridStep:
                 current = getattr(self.binary, key)
                 setattr(self.binary, key, current + fv[key_p])
             elif key == 'nearest_neighbour_distance':
-                setattr(self.binary, key, ['None', 'None', 'None'])
+                setattr(self.binary, key, [np.nan, np.nan, np.nan])
             elif key in ['eccentricity', 'V_sys']:
                 current = getattr(self.binary, key + '_history')[-1]
                 setattr(self.binary, key, current)

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -468,6 +468,23 @@ class BinaryStar:
             # Lose the V_sys list
             bin_df = bin_df.drop(['V_sys'], axis=1)
 
+        # Add 3 columns for nearest_neighbour_distance
+        if 'nearest_neighbour_distance' in column_names:
+            NN_dist_x = np.zeros(len(bin_df))
+            NN_dist_y = np.zeros(len(bin_df))
+            NN_dist_z = np.zeros(len(bin_df))
+            for i in range(len(bin_df)):
+                NN_dist_x[i] = bin_df.iloc[i]['nearest_neighbour_distance'][0]
+                NN_dist_y[i] = bin_df.iloc[i]['nearest_neighbour_distance'][1]
+                NN_dist_z[i] = bin_df.iloc[i]['nearest_neighbour_distance'][2]
+
+            bin_df['NN_dist_x'] = copy.deepcopy(NN_dist_x)
+            bin_df['NN_dist_y'] = copy.deepcopy(NN_dist_y)
+            bin_df['NN_dist_z'] = copy.deepcopy(NN_dist_z)
+
+            # Lose the nearest_neighbour_distance list
+            bin_df = bin_df.drop(['nearest_neighbour_distance'], axis=1)
+
         frames = [bin_df]
         if kwargs.get('include_S1', True):
             # we are hard coding the prefix
@@ -615,8 +632,8 @@ class BinaryStar:
         """Convert binary into a single row DataFrame."""
         if history:
             bin_kwargs = kwargs.copy()
-            bin_kwargs['include_S1'] = False
-            bin_kwargs['include_S2'] = False
+            bin_kwargs['include_S1'] = True
+            bin_kwargs['include_S2'] = True
             output_df = self.to_df(**bin_kwargs)
             initial_final_data = output_df.values[[0, -1], :]  # first/last row
             col_names = list(output_df.columns)

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -632,8 +632,8 @@ class BinaryStar:
         """Convert binary into a single row DataFrame."""
         if history:
             bin_kwargs = kwargs.copy()
-            bin_kwargs['include_S1'] = True
-            bin_kwargs['include_S2'] = True
+            bin_kwargs['include_S1'] = False
+            bin_kwargs['include_S2'] = False
             output_df = self.to_df(**bin_kwargs)
             initial_final_data = output_df.values[[0, -1], :]  # first/last row
             col_names = list(output_df.columns)

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -221,6 +221,8 @@ class BinaryPopulation:
             removing the binary instance from memory.
         tqdm : bool, False
             Show tqdm progress bar during evolution.
+        optimize_ram : bool, False
+            If True, dump binary data during evolve to save RAM.
 
         Returns
         -------
@@ -230,6 +232,7 @@ class BinaryPopulation:
         kw = {**self.kwargs, **kwargs}
         tqdm_bool = kw.get('tqdm', False)
         breakdown_to_df_bool = kw.get('breakdown_to_df', True)
+        optimize_ram = kw.get('optimize_ram', False)
         from_hdf_bool = kw.get('from_hdf', False)
 
         if self.JOB_ID is None and self.comm is None:   # do regular evolution
@@ -238,6 +241,7 @@ class BinaryPopulation:
             params = {'indices':indices,
                       'tqdm':tqdm_bool,
                       'breakdown_to_df':breakdown_to_df_bool,
+                      'optimize_ram':optimize_ram,
                       'from_hdf':from_hdf_bool}
             self.kwargs.update(params)
 
@@ -253,6 +257,7 @@ class BinaryPopulation:
             params = {'indices':batch_indices,
                       'tqdm':mpi_tqdm_bool,
                       'breakdown_to_df':breakdown_to_df_bool,
+                      'optimize_ram':optimize_ram,
                       'from_hdf':from_hdf_bool}
             self.kwargs.update(params)
             self._safe_evolve(**self.kwargs)
@@ -279,8 +284,6 @@ class BinaryPopulation:
                             else indices)
         breakdown_to_df = kwargs.get('breakdown_to_df', True)
         optimize_ram = kwargs.get("optimize_ram", True)
-        self.kwargs['optimize_ram'] = optimize_ram
-
         ram_per_cpu = kwargs.get("ram_per_cpu", None)
 
         if optimize_ram:
@@ -360,7 +363,6 @@ class BinaryPopulation:
                 # context
                 if not self.kwargs.get("warnings_verbose", False):
                     cpw.reset_cache()
-
         
             if breakdown_to_df:
                 self.manager.breakdown_to_df(binary, **self.kwargs)

--- a/posydon/popsyn/synthetic_population.py
+++ b/posydon/popsyn/synthetic_population.py
@@ -175,7 +175,7 @@ class PopulationRunner:
                     print(f"Removing {pop.kwargs['temp_directory']} directory...")
                 os.removedirs(pop.kwargs["temp_directory"])    
                 
-            pop.evolve()
+            pop.evolve(optimize_ram=True)
             if pop.comm is None:
                 self.merge_parallel_runs(pop)
 


### PR DESCRIPTION
> [!NOTE]  
> This is a patch for POSYDON v2.0.X, merging into `main`. For POSYDON v2.1.X, see here: [PR#662](https://github.com/POSYDON-code/POSYDON/pull/662). Right now the `meta.yml` is set to update to `v2.0.2`, anticipating that [PR#654](https://github.com/POSYDON-code/POSYDON/pull/654) will be accepted first.

- `optimize_ram` is now a keyword that can be applied to `BinaryPopulation.evolve()`, it is `False` by default now to enable simple functionality similar to v1 with data frame output after evolve. It is set to `True` (the old default) in `PopulationRunner()` to maintain old behavior there.
- Three new columns are added to enable panda to parse the binary star data column `nearest_neighbour_distance` (`NN_dist_x`, `NN_dist_y`, `NN_dist_z`). 
- Null values of `nearest_neighbour_distance` are now set to `np.nan` to enable easy float conversion, rather than the string `'None'` that it was before.
- Apparently the update to stellar spin from magnetic braking was inside the indent of a code block that would only trigger if `verbose = True` in `step_detached`. This has been corrected 