### PR TITLE
Zero bad negative values from detached evolution

### DIFF
--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -752,8 +752,13 @@ class detached_step:
         mass_interp_pri = primary.interp1d[self.translate["mass"]]
 
         secondary.interp1d["sep"] = sep_interp
-        secondary.interp1d["ecc"] = ecc_interp    
+        secondary.interp1d["ecc"] = ecc_interp
+        secondary.interp1d["time"] = t    
         secondary.interp1d["omega"] = omega_interp_sec
+
+        primary.interp1d["sep"] = sep_interp
+        primary.interp1d["ecc"] = ecc_interp
+        primary.interp1d["time"] = t            
         primary.interp1d["omega"] = omega_interp_pri
 
         secondary.interp1d["porb"] = orbital_period_from_separation(
@@ -762,8 +767,6 @@ class detached_step:
         primary.interp1d["porb"] = orbital_period_from_separation(
             sep_interp, mass_interp_pri(t - primary.t_offset),
             mass_interp_sec(t - secondary.t_offset))
-
-        secondary.interp1d["time"] = t
 
         for obj, prop in zip([secondary, primary, binary], 
                                 [STARPROPERTIES, STARPROPERTIES, BINARYPROPERTIES]):

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -807,8 +807,8 @@ class detached_step:
                         history = (interp1d["omega"][:-1] / const.secyer / omega_crit_hist)
 
                         # ensure positive rotation values
-                        current = zero_negative_values([current])[0]
-                        history = zero_negative_values(history)
+                        current = zero_negative_values([current], key)[0]
+                        history = zero_negative_values(history, key)
 
                 elif (key in ["surf_avg_omega"] and obj != binary):
                     if obj.co:
@@ -818,8 +818,8 @@ class detached_step:
                         current = interp1d["omega"][-1] / const.secyer
                         history = interp1d["omega"][:-1] / const.secyer
 
-                        current = zero_negative_values([current])[0]
-                        history = zero_negative_values(history)
+                        current = zero_negative_values([current], key)[0]
+                        history = zero_negative_values(history, key)
                         
                 elif ("rl_relative_overflow_" in key and obj == binary):
                     s = binary.star_1 if "_1" in key[-2:] else binary.star_2
@@ -840,8 +840,8 @@ class detached_step:
                     current = interp1d[self.translate[key]][-1].item()
                     history = interp1d[self.translate[key]][:-1]
 
-                    current = zero_negative_values([current])[0]
-                    history = zero_negative_values(history)
+                    current = zero_negative_values([current], key)[0]
+                    history = zero_negative_values(history, key)
                     
                 elif (key in ["total_moment_of_inertia"] and obj != binary):
                     if obj.co:
@@ -869,8 +869,8 @@ class detached_step:
                                        t[:-1] - t_offset) * (const.msol * const.rsol**2))
                         history = np.where(tot_j_hist > 0, np.log10(tot_j_hist), -99)
 
-                        current = zero_negative_values([current])[0]
-                        history = zero_negative_values(history)
+                        current = zero_negative_values([current], key)[0]
+                        history = zero_negative_values(history, key)
                     
                 elif (key in ["spin"] and obj != binary):
                     if obj.co:

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -308,8 +308,7 @@ class detached_step:
         # get the next step's name to display for match recording in data frame
         # (in the event that the total_state is not in the flow, this will be None,
         #  and the binary will be set to fail in BinaryStar().run_step()).
-        total_state = (binary.star_1.state, binary.star_2.state, binary.state, binary.event)
-        next_step_name = binary.properties.flow.get(total_state)
+        next_step_name = binary.get_next_step_name()
         
         # match stars to single star models for detached evolution
         primary, secondary, only_CO = self.track_matcher.do_matching(binary, next_step_name)

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -31,7 +31,8 @@ from posydon.utils.common_functions import (bondi_hoyle,
                                             zero_negative_values)
 from posydon.binary_evol.flow_chart import (STAR_STATES_CC, 
                                             STAR_STATES_H_RICH_EVOLVABLE,
-                                            STAR_STATES_HE_RICH_EVOLVABLE)
+                                            STAR_STATES_HE_RICH_EVOLVABLE,
+                                            UNDEFINED_STATES)
 import posydon.utils.constants as const
 from posydon.utils.posydonerror import (NumericalError, POSYDONError, 
                                         FlowError, ClassificationError)
@@ -305,7 +306,15 @@ class detached_step:
         all_step_names = getattr(binary_sim_prop, "all_step_names")
 
         # match stars to single star models for detached evolution
-        primary, secondary, only_CO = self.track_matcher.do_matching(binary, binary.step_names[-1])
+        total_state = (binary.star_1.state, binary.star_2.state, binary.state, binary.event)
+        if total_state in UNDEFINED_STATES:
+            raise FlowError(f"Binary failed with a known undefined state in the flow:\n{total_state}")
+
+        next_step_name = binary.properties.flow.get(total_state)
+        if next_step_name is None:
+            raise ValueError("Undefined next step given stars/binary states {}.".format(total_state))
+
+        primary, secondary, only_CO = self.track_matcher.do_matching(binary, next_step_name)
         
         if only_CO:
             if self.verbose:

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -305,15 +305,13 @@ class detached_step:
         binary_sim_prop = getattr(binary, "properties")
         all_step_names = getattr(binary_sim_prop, "all_step_names")
 
-        # match stars to single star models for detached evolution
+        # get the next step's name to display for match recording in data frame
+        # (in the event that the total_state is not in the flow, this will be None,
+        #  and the binary will be set to fail in BinaryStar().run_step()).
         total_state = (binary.star_1.state, binary.star_2.state, binary.state, binary.event)
-        if total_state in UNDEFINED_STATES:
-            raise FlowError(f"Binary failed with a known undefined state in the flow:\n{total_state}")
-
         next_step_name = binary.properties.flow.get(total_state)
-        if next_step_name is None:
-            raise ValueError("Undefined next step given stars/binary states {}.".format(total_state))
-
+        
+        # match stars to single star models for detached evolution
         primary, secondary, only_CO = self.track_matcher.do_matching(binary, next_step_name)
         
         if only_CO:

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -893,6 +893,9 @@ class detached_step:
                                     t[:-1] - t_offset) * (const.msol * const.rsol**2)
                             / (const.standard_cgrav * (interp1d[self.translate["mass"]](
                                     t[:-1] - t_offset) * const.msol)**2))
+                        
+                        current = zero_negative_values([current], key)[0]
+                        history = zero_negative_values(history, key)
 
                 elif (key in ["lg_mdot", "lg_wind_mdot"] and obj != binary):
                     if obj.co:

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -850,6 +850,9 @@ class detached_step:
 
                         history = interp1d[self.translate[key]](
                             t[:-1] - t_offset) * (const.msol * const.rsol**2)
+                        
+                        current = zero_negative_values([current], key)[0]
+                        history = zero_negative_values(history, key)
                     
                 elif (key in ["log_total_angular_momentum"] and obj != binary):
                     if obj.co:

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -244,15 +244,15 @@ class BinaryStar:
 
     def run_step(self):
         """Evolve the binary through one evolutionary step."""
-        total_state = (self.star_1.state, self.star_2.state, self.state, self.event)
+        total_state = self.get_total_state()
         if total_state in UNDEFINED_STATES:
             raise FlowError(f"Binary failed with a known undefined state in the flow:\n{total_state}")
 
-        next_step_name = self.properties.flow.get(total_state)
+        next_step_name = self.get_next_step_name()
         if next_step_name is None:
             raise ValueError("Undefined next step given stars/binary states {}.".format(total_state))
 
-        next_step = getattr(self.properties, next_step_name, None)
+        next_step = self.get_next_step()
         if next_step is None:
             raise ValueError("Next step name '{}' does not correspond to a function in "
                              "SimulationProperties.".format(next_step_name))
@@ -262,6 +262,18 @@ class BinaryStar:
         
         self.append_state()
         self.properties.post_step(self, next_step_name)
+    
+    def get_total_state(self):
+        """Return the total state of the binary (star1.state, star2.state, binary.state, binary.event)."""
+        return (self.star_1.state, self.star_2.state, self.state, self.event)
+    
+    def get_next_step_name(self):
+        """Return the name of the next step based on the current total state."""
+        return self.properties.flow.get(self.get_total_state())
+    
+    def get_next_step(self):
+        """Get the next step class object based on the current total state."""
+        return getattr(self.properties, self.get_next_step_name(), None)
 
     def append_state(self):
         """Update the history of the binaries' properties."""

--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -164,6 +164,10 @@
   absolute_import = None
     # if given, use an absolute filepath to user defined step:
     # ['<PATH_TO_PY_FILE>', '<NAME>']
+  record_matching = False
+    # True, False
+  verbose = False
+    # True, False
 
 [step_merged]
   import = ['posydon.binary_evol.DT.step_merged','MergedStep']
@@ -178,6 +182,10 @@
   absolute_import = None
     # if given, use an absolute filepath to user defined step:
     # ['<PATH_TO_PY_FILE>', '<NAME>']
+  record_matching = False
+    # True, False
+  verbose = False
+    # True, False
 
 [step_CE]
   import = ['posydon.binary_evol.CE.step_CEE', 'StepCEE']

--- a/posydon/unit_tests/utils/test_common_functions.py
+++ b/posydon/unit_tests/utils/test_common_functions.py
@@ -111,7 +111,8 @@ class TestElements:
                     'rzams', 'separation_evol_wind_loss',\
                     'set_binary_to_failed', 'spin_stable_mass_transfer',\
                     'stefan_boltzmann_law', 'STAR_STATES_H_RICH',\
-                    'STAR_STATES_HE_RICH'}
+                    'STAR_STATES_HE_RICH', 'zero_negative_values'}
+
         totest_elements = set(dir(totest))
         missing_in_test = elements - totest_elements
         assert len(missing_in_test) == 0, "There are missing objects in "\

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -96,7 +96,7 @@ def is_number(s):
     except ValueError:
         return False
 
-def zero_negative_values(arr): # pragma no cover
+def zero_negative_values(arr):
     """
         Set negative values in the array to zero.
 

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -95,6 +95,24 @@ def is_number(s):
         return True
     except ValueError:
         return False
+    
+def zero_negative_values(arr):
+    """
+        Set negative values in the array to zero.
+
+        Parameters
+        ----------
+        arr : np.ndarray
+            The input array to process.
+
+        Returns
+        -------
+        np.ndarray
+            The processed array with negative values set to zero.
+    """
+    arr = np.array(arr)
+    arr[arr < 0] = 0.0
+    return arr
 
 
 def stefan_boltzmann_law(L, R):

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -95,8 +95,8 @@ def is_number(s):
         return True
     except ValueError:
         return False
-    
-def zero_negative_values(arr):
+
+def zero_negative_values(arr): # pragma no cover
     """
         Set negative values in the array to zero.
 

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -115,8 +115,9 @@ def zero_negative_values(arr, key): # pragma no cover
     arr = np.array(arr)
 
     if np.any(arr < 0):
-        raise ReplaceValueWarning("A " + key + " value is negative. Setting to zero.")
-        
+        Pwarn("A " + key + " value is negative. Setting to zero.", 
+              "ReplaceValueWarning")
+
     arr[arr < 0] = 0.0
     return arr
 

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -96,7 +96,7 @@ def is_number(s):
     except ValueError:
         return False
 
-def zero_negative_values(arr):
+def zero_negative_values(arr): # pragma no cover
     """
         Set negative values in the array to zero.
 

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -96,7 +96,7 @@ def is_number(s):
     except ValueError:
         return False
 
-def zero_negative_values(arr): # pragma no cover
+def zero_negative_values(arr, key): # pragma no cover
     """
         Set negative values in the array to zero.
 
@@ -104,6 +104,8 @@ def zero_negative_values(arr): # pragma no cover
         ----------
         arr : np.ndarray
             The input array to process.
+        key : string
+            The name of the array column
 
         Returns
         -------
@@ -111,6 +113,10 @@ def zero_negative_values(arr): # pragma no cover
             The processed array with negative values set to zero.
     """
     arr = np.array(arr)
+
+    if np.any(arr < 0):
+        raise ReplaceValueWarning("A " + key + " value is negative. Setting to zero.")
+        
     arr[arr < 0] = 0.0
     return arr
 


### PR DESCRIPTION
Sometimes you can get negative angular rotation rates for example from detached evolution (this also happens in `main`).

1. Adds a new `zero_negative_values()` function to `common_functions.py`. This will zero the negative values in an array to keep things positive.
2. Adds the options for match recording and verbosity to step initially single and step disrupted in our .ini file.
3. Now the match recording will use the current step name, rather than always use `step_detached`.
4. As a part of point 3, `BinaryStar` also given 3 new helper functions to facilitate getting the total state (s1.state, s2.state, binary.state, binary.event), next step name, and next step class object from its flow. I.e., `binary.get_total_state()`, `binary.get_next_step_name()` and `binary.get_next_step()`.