### PR TITLE
Remove source code text from warnings

### DIFF
--- a/posydon/unit_tests/utils/test_posydonwarning.py
+++ b/posydon/unit_tests/utils/test_posydonwarning.py
@@ -37,7 +37,7 @@ class TestElements:
                     '__loader__', '__name__', '__package__', '__spec__',\
                     '_apply_POSYDON_filter', '_get_POSYDONWarning_class',\
                     '_issue_warn', 'copy', 'get_stats', 'print_stats', 'sys',\
-                    'warnings', 'no_src_code_format'}
+                    'warnings', 'nosrc_code_format'}
         totest_elements = set(dir(totest))
         missing_in_test = elements - totest_elements
         assert len(missing_in_test) == 0, "There are missing objects in "\

--- a/posydon/unit_tests/utils/test_posydonwarning.py
+++ b/posydon/unit_tests/utils/test_posydonwarning.py
@@ -37,7 +37,7 @@ class TestElements:
                     '__loader__', '__name__', '__package__', '__spec__',\
                     '_apply_POSYDON_filter', '_get_POSYDONWarning_class',\
                     '_issue_warn', 'copy', 'get_stats', 'print_stats', 'sys',\
-                    'warnings'}
+                    'warnings', 'no_src_code_format'}
         totest_elements = set(dir(totest))
         missing_in_test = elements - totest_elements
         assert len(missing_in_test) == 0, "There are missing objects in "\

--- a/posydon/utils/posydonwarning.py
+++ b/posydon/utils/posydonwarning.py
@@ -39,6 +39,16 @@ import sys
 import warnings
 
 
+def nosrc_code_format(message, category, filename, lineno, line=None):
+    """
+    This sets the warning format to not include the source code line.
+    """
+    return f"{filename}:{lineno}: {category.__name__}: {message}\n"
+
+# Setting the warning format to use the above format function
+warnings.formatwarning = nosrc_code_format
+
+
 class POSYDONWarning(Warning):
     """General POSYDON warning class."""
     def __init__(self, message=''):

--- a/posydon/utils/posydonwarning.py
+++ b/posydon/utils/posydonwarning.py
@@ -30,7 +30,8 @@ caught warnings after it is copy to be returned:
 __authors__ = [
     "Monica Gallegos-Garcia <monicagallegosgarcia@u.northwestern.edu>",
     "Camille Liotine <cliotine@u.northwestern.edu>",
-    "Matthias Kruckow <Matthias.Kruckow@unige.ch>",   
+    "Matthias Kruckow <Matthias.Kruckow@unige.ch>",
+    "Seth Gossage <seth.gossage@northwestern.edu>"   
 ]
 
 


### PR DESCRIPTION
This adds a custom format to our warnings so that it does not also print the source code of the warning itself. Meant to improve readability of the warnings.

Before:

<img width="1575" height="160" alt="Screenshot 2025-08-27 123926" src="https://github.com/user-attachments/assets/4837adc8-7154-4d0b-a69d-43f0bd3d9dde" />

After:

<img width="1572" height="78" alt="Screenshot 2025-08-27 124133" src="https://github.com/user-attachments/assets/4511ecda-48a0-442c-b57a-898874708852" />
