### PR TITLE
[PATCH v2.0.3] Updating Installation Docs

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "posydon" %}
-{% set version = "2.0.2" %}
+{% set version = "2.0.3" %}
 
 package:
   name: "{{ name|lower }}"

--- a/docs/_source/components-overview/pop_syn/binary_population.rst
+++ b/docs/_source/components-overview/pop_syn/binary_population.rst
@@ -192,12 +192,14 @@ Depending on the initialization parameters, the evolved population can be access
    You can access the individual binaries using the ``manager`` attribute:
 
   .. code-block:: python
+
     first_binary = population.manager.binaries[0]
     print(first_binary)
 
    Additionally you can show turn the binary into a history DataFrame or create a oneline summary DataFrame:
 
   .. code-block:: python
+
     history = population.to_df()
     print(history)
 
@@ -209,6 +211,7 @@ Depending on the initialization parameters, the evolved population can be access
    Make sure the file name has ``.h5`` extension, as this is required for the Population class to read the file correctly.
 
    .. code-block:: python
+    
     from posydon.popsyn.synthetic_population import Population
     population = Population('./population.h5')
 

--- a/docs/_source/getting-started/first-grids.rst
+++ b/docs/_source/getting-started/first-grids.rst
@@ -1,7 +1,7 @@
 .. _first-grids:
 
 Quick Start: Examining the MESA Grids
-============================
+=====================================
 
 Installation and Data Download
 ------------------------------
@@ -18,7 +18,7 @@ Additionally, POSYDON requires data to be downloaded from Zenodo. For our simple
     get-posydon-data DR2_1Zsun
 
 Loading a MESA grid
---------------
+-------------------
 
 You can access our grids of MESA simulations using the ``PSyGrid`` module (for an overview of this module, see :ref:`here </components-overview/post_processing/psygrid.rst>`). We will run through some simple commands to orient ourselves with the ``PSyGrid`` object below. 
 

--- a/docs/_source/getting-started/first-population.rst
+++ b/docs/_source/getting-started/first-population.rst
@@ -1,7 +1,7 @@
 .. _first-population:
 
 Quick Start: Your First Population
-=============================
+==================================
 
 Installation and Data Download
 ------------------------------

--- a/docs/_source/getting-started/installation-guide.rst
+++ b/docs/_source/getting-started/installation-guide.rst
@@ -47,7 +47,13 @@ Anaconda (Recommended)
         conda install -c posydon posydon
 
     .. note:: 
-        Please remember the current path (get it via :code:`pwd`) or the one you specified for the next step.
+        In the next step you will need to know where this package was installed. You can find it by running the following 
+        commands in Python:
+
+        .. code-block:: python
+
+            import posydon
+            print(posydon.__file__)
 
 .. _posydon-env:
 
@@ -57,14 +63,18 @@ Anaconda (Recommended)
 
     .. code-block:: bash
 
-        export PATH_TO_POSYDON=/path/to/your/posydon/installation
-        export PATH_TO_POSYDON_DATA=/path/where/you/want/to/store/data
+        conda env config vars set PATH_TO_POSYDON=/path/to/your/posydon/installation
+        conda env config vars set PATH_TO_POSYDON_DATA=/path/where/you/want/to/store/data
 
-    The path for the data location is up to you, but keeping the data separate 
-    from the code is recommended for better organization.
+    The path for the data location is up to you, but keeping the data separate from the code is recommended for organization.
 
     .. note:: 
-        You can add these lines to your :code:`~/.bashrc` or :code:`~/.bash_profile` or your shell equivalent to ensure the environment variables are set every time you open a new terminal.
+        So that your new `conda` environment is loaded whenever you open a new terminal, you can add the following line to 
+        your :code:`~/.bashrc` or :code:`~/.bash_profile` or your shell equivalent:
+        
+        .. code-block:: bash
+            
+            conda activate posydon_env
 
 5. **Download the Dataset**
 
@@ -85,23 +95,39 @@ Anaconda (Recommended)
 
 .. _dev-version:
 
-GitHub (Development Version)
+GitHub (Stable Version)
 ----------------------------
 
 For users interested in the latest features and developments, you can install POSYDON directly from its GitHub repository:
 
 1. **Clone the Repository**
 
-    In your terminal or command prompt (by default, the repository will be placed in the current directory, so navigate to your desired location before proceeding):
+    In your terminal or command prompt execute one of the following command to clone the repo with the ``https`` protocol:
+
+    .. warning:: 
+        By default, the repository will be placed in the current directory, so navigate to your desired location before proceeding.
 
     .. code-block:: bash
 
         git clone https://github.com/POSYDON-code/POSYDON.git
 
-2. **Install the Development Version**
+    For the ``ssh`` protocol:
+
+    .. code-block:: bash
+
+        git clone git@github.com:POSYDON-code/POSYDON.git
+
+    Or for the Github CLI:
+
+    .. code-block:: bash
+
+        gh repo clone POSYDON-code/POSYDON
+
+2. **Install the Stable Version**
 
     .. warning::
-        If you are installing POSYDON on a Mac with Apple M1 or M2 chips, you should first install `hdf5` and `pytables` through conda with `conda install hdf5 pytables`, before following the instructions below.
+        If you are installing POSYDON on a Mac with Apple M1 or M2 chips, you should first install ``hdf5`` and ``pytables`` through ``conda``
+        with ``conda install hdf5 pytables``, before following the instructions below.
 
     Navigate to the cloned repository's directory:
 
@@ -109,15 +135,46 @@ For users interested in the latest features and developments, you can install PO
 
         cd POSYDON
 
-    Install the software as an editable package using `pip`:
+    Install the software as an editable package using ``pip`:
 
     .. code-block:: bash
 
         pip install -e .
 
-3. **Set Environment Variables and Download Data**
+3. **Set Environment Variables*
 
-    Refer back to the recommended installation steps, starting from :ref:`point 4 <posydon-env>`, to download the required dataset and set the necessary environment variables.
+    Next, export the required paths as environment variables. From the ``POSYDON`` directory that you just performed the installation in, 
+    you can execute ``pwd`` if you are unsure of the path name. Please change the location names accordingly below to your installation 
+    path:
+
+    .. code-block:: bash
+
+        export PATH_TO_POSYDON=/path/to/your/posydon/installation
+        export PATH_TO_POSYDON_DATA=/path/where/you/want/to/store/data
+
+    The path for the data location is up to you, but keeping the data separate 
+    from the code is recommended for organization.
+
+    .. note:: 
+        You can add these lines to your :code:`~/.bashrc` or :code:`~/.bash_profile` or your shell equivalent to ensure the environment variables are set every time you open a new terminal.
+
+4. **Download the Dataset**
+
+    You can use POSYDON's built-in API command (the downloaded data will be downloaded to the directory specified by :code:`PATH_TO_POSYDON_DATA`):
+
+    .. code-block:: bash
+
+        get-posydon-data
+
+    You may use :code:`get-posydon-data -h` to see all the options for this command, which allows you to list all the datasets and download the one of your choice.
+    If you have the disk space and want to download the full DR2 dataset, you can use the following command:
+
+    .. code-block:: bash
+
+        get-posydon-data DR2
+
+    Alternatively, you can manually download the datasets from Zenodo. You can find the POSYDON datasets on the `POSYDON community <https://zenodo.org/communities/posydon/>`_ on Zenodo.
+
 
 
 Installing Jupyter for Tutorials
@@ -143,7 +200,7 @@ Our tutorials are provided as Jupyter notebooks. If you want to run these notebo
 2. **Alternatively, via pip**
 
 
-    If you prefer using `pip`, you can also install Jupyter Lab or Notebook using the following commands:
+    If you prefer using ``pip``, you can also install Jupyter Lab or Notebook using the following commands:
 
     .. code-block:: bash
 
@@ -203,7 +260,9 @@ You do not need to have ``mpi4py`` installed if you are only running population 
 
 
 .. warning::
-    Users have reported issues when trying to install `mpi4py` via pip. If you encounter any issues, try installing `mpi4py` through Anaconda. If you cannot solve the issue, please refer to the :ref:`Troubleshooting Guide <installation-issues>` or seek support from the community or developers, see the :ref:`contact us <contact_info>` page.
+    Users have reported issues when trying to install ``mpi4py`` via pip. If you encounter any issues, try installing ``mpi4py`` through 
+    Anaconda. If you cannot solve the issue, please refer to the :ref:`Troubleshooting Guide <installation-issues>` or seek support from 
+    the community or developers, see the :ref:`contact us <contact_info>` page.
 
 
 Documentation Building
@@ -220,7 +279,8 @@ If you're interested in building the POSYDON documentation locally:
         pip install ".[doc]"
 
     .. warning::
-        If you are installing POSYDON on a Mac with Apple M1 or M2 chips, you should install `pandoc` separately through brew with `brew install pandoc`.
+        If you are installing POSYDON on a Mac with Apple M1 or M2 chips, you should install ``pandoc`` separately through brew with 
+        ``brew install pandoc``.
 
 2. **Compile the Documentation**:
 
@@ -231,18 +291,18 @@ If you're interested in building the POSYDON documentation locally:
         cd docs
         make html
 
-    This command will generate the HTML documentation in the `_build/html` directory within the `docs` folder.
+    This command will generate the HTML documentation in the ``_build/html`` directory within the ``docs`` folder.
 
 3. **Open the Compiled Documentation**:
 
-    After successfully building the documentation, you can view it in your preferred browser. Navigate to the build directory and open the `index.html`:
+    After successfully building the documentation, you can view it in your preferred browser. Navigate to the build directory and open the ``index.html``:
 
     .. code-block:: bash
 
         open _build/html/index.html
 
     .. note::
-        The `open` command works on macOS. If you're using a different OS, you might need to open the `index.html` using your file manager or use a different command.
+        The ``open`` command works on macOS. If you're using a different OS, you might need to open the ``index.html`` using your file manager or use a different command.
 
 
 
@@ -253,7 +313,7 @@ For users who wish to utilize POSYDON's latest machine learning features.
 This is specifically used in the active learning module and profile interpolation.
 You do not require these dependencies if you are using the provided Initial-Final interpolators.
 
-1. **Navigate to your POSYDON directory** (where the `setup.py` is located) and run:
+1. **Navigate to your POSYDON directory** (where the ``setup.py`` is located) and run:
 
     .. code-block:: bash
 

--- a/docs/_source/getting-started/installation-guide.rst
+++ b/docs/_source/getting-started/installation-guide.rst
@@ -135,13 +135,13 @@ For users interested in the latest features and developments, you can install PO
 
         cd POSYDON
 
-    Install the software as an editable package using ``pip`:
+    Install the software as an editable package using ``pip``:
 
     .. code-block:: bash
 
         pip install -e .
 
-3. **Set Environment Variables*
+3. **Set Environment Variables**
 
     Next, export the required paths as environment variables. From the ``POSYDON`` directory that you just performed the installation in, 
     you can execute ``pwd`` if you are unsure of the path name. Please change the location names accordingly below to your installation 


### PR DESCRIPTION
This adds some improvements to our installation docs from users. This also increments the version number to v2.0.3 (although maybe we want to roll these changes in with others for a larger patch?).

This also updates out install documentation to be labeled as for the Stable version (v2.0.X right now). Previously it was labeled as the Development version, which was how it was in the past.