### PR TITLE
[PATCH v2.0.3] Consistent star state naming in flow

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "posydon" %}
-{% set version = "2.0.2" %}
+{% set version = "2.0.3" %}
 
 package:
   name: "{{ name|lower }}"

--- a/docs/_source/components-overview/pop_syn/single_star.rst
+++ b/docs/_source/components-overview/pop_syn/single_star.rst
@@ -165,13 +165,13 @@ We also have additional extra states for objects that are not stars.
     - The star is burning hydrogen in a shell.
   * - ``Core_He_burning``
     - The star is burning helium in its core.
-  * - ``Central_He_depleted``
+  * - ``Core_He_depleted``
     - The star has a helium depleted core.
   * - ``Shell_He_burning``
     - The star is burning helium in a shell.
   * - ``Core_C_burning``
     - The star is burning carbon in its core.
-  * - ``Central_C_depletion``
+  * - ``Core_C_depleted``
     - The star has a carbon depleted core.
 
 .. list-table:: Additional States

--- a/posydon/binary_evol/CE/step_CEE.py
+++ b/posydon/binary_evol/CE/step_CEE.py
@@ -42,8 +42,11 @@ from posydon.binary_evol.binarystar import BINARYPROPERTIES
 from posydon.binary_evol.singlestar import STARPROPERTIES
 from posydon.config import PATH_TO_POSYDON
 from posydon.utils.common_functions import check_state_of_star
-from posydon.utils.common_functions import calculate_lambda_from_profile, calculate_Mejected_for_integrated_binding_energy
+from posydon.utils.common_functions import (calculate_lambda_from_profile, 
+                                            calculate_Mejected_for_integrated_binding_energy)
 from posydon.utils.posydonwarning import Pwarn
+from posydon.binary_evol.flow_chart import (STAR_STATES_POST_MS, 
+                                            STAR_STATES_POST_HeMS)
 
 
 MODEL = {"prescription": 'alpha-lambda',
@@ -82,27 +85,6 @@ MODEL = {"prescription": 'alpha-lambda',
 # "neutral_fraction_H", "neutral_fraction_He", and "avg_charge_He" as column
 # in the profile)
 # the mass fraction of an element which is used as threshold to define a core,
-
-
-STAR_STATE_POST_MS = [
-    "H-rich_Core_H_burning",
-    "H-rich_Shell_H_burning",
-    "H-rich_Core_He_burning",
-    "H-rich_Central_He_depleted",
-    "H-rich_Central_C_depletion",
-    "H-rich_non_burning",
-    "accreted_He_non_burning"
-]
-
-
-STAR_STATE_POST_HeMS = [
-    'accreted_He_Core_He_burning',
-    'stripped_He_Core_He_burning',
-    'stripped_He_Central_He_depleted',
-    'stripped_He_Central_C_depletion',
-    'stripped_He_non_burning'
-]
-
 
 class StepCEE(object):
     """Compute supernova final remnant mass, fallback fraction & stellar state.
@@ -283,13 +265,13 @@ class StepCEE(object):
         m1_i = donor.mass
         radius1 = 10. ** donor.log_R
 
-        if donor.state in STAR_STATE_POST_MS:       # "H_Giant":
+        if donor.state in STAR_STATES_POST_MS:       # "H_Giant":
             donor_type = 'He_core'
             core_element_fraction_definition = self.core_definition_H_fraction
             if core_element_fraction_definition not in [0.01, 0.1, 0.3]:
                 raise ValueError("He-core defintion should always be "
                                  "set to a H abundance of 1%, 10%, or 30%")
-        elif donor.state in STAR_STATE_POST_HeMS:   # "He_Giant":
+        elif donor.state in STAR_STATES_POST_HeMS:   # "He_Giant":
             donor_type = 'CO_core'
             core_element_fraction_definition = self.core_definition_He_fraction
             if core_element_fraction_definition != 0.1:

--- a/posydon/binary_evol/CE/step_CEE.py
+++ b/posydon/binary_evol/CE/step_CEE.py
@@ -1056,7 +1056,7 @@ class StepCEE(object):
         # don't sent it to the detached step after successful ejection, but
         # send the binary directly to the core collapse step to calculate the
         # explosion
-        if donor.state == 'stripped_He_Central_He_depleted':
+        if donor.state == 'stripped_He_Core_He_depleted':
             if donor == binary.star_1:
                 binary.event = 'CC1'
             elif donor == binary.star_2:

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -50,9 +50,9 @@ LIST_ACCEPTABLE_STATES_FOR_HMS = ["H-rich_Core_H_burning",
 LIST_ACCEPTABLE_STATES_FOR_postMS = [
     "H-rich_Shell_H_burning",
     "H-rich_Core_He_burning",
-    "H-rich_Central_He_depleted",
+    "H-rich_Core_He_depleted",
     "H-rich_Core_C_burning",
-    "H-rich_Central_C_depleted",
+    "H-rich_Core_C_depleted",
     "H-rich_non_burning",
     "accreted_He_Shell_H_burning",
     "accreted_He_non_burning"]
@@ -61,8 +61,8 @@ LIST_ACCEPTABLE_STATES_FOR_HeStar = [
     'accreted_He_Core_He_burning',
     'stripped_He_Core_He_burning',
     'stripped_He_Shell_He_burning',     # includes stars burning C in core
-    'stripped_He_Central_He_depleted',  # includes stars burning C in core
-    'stripped_He_Central_C_depleted',
+    'stripped_He_Core_He_depleted',  # includes stars burning C in core
+    'stripped_He_Core_C_depleted',
     'stripped_He_non_burning'
     ]
 
@@ -70,10 +70,10 @@ STAR_STATES_H_RICH = [
     'H-rich_Core_H_burning',
     'H-rich_Core_He_burning',
     'H-rich_Shell_H_burning',
-    'H-rich_Central_He_depleted',
+    'H-rich_Core_He_depleted',
     'H-rich_Shell_He_burning',
     'H-rich_Core_C_burning',
-    'H-rich_Central_C_depleted',
+    'H-rich_Core_C_depleted',
     'H-rich_non_burning',
     'accreted_He_Core_H_burning',
     'accreted_He_Shell_H_burning',

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -52,7 +52,7 @@ LIST_ACCEPTABLE_STATES_FOR_postMS = [
     "H-rich_Core_He_burning",
     "H-rich_Central_He_depleted",
     "H-rich_Core_C_burning",
-    "H-rich_Central_C_depletion",
+    "H-rich_Central_C_depleted",
     "H-rich_non_burning",
     "accreted_He_Shell_H_burning",
     "accreted_He_non_burning"]
@@ -62,7 +62,7 @@ LIST_ACCEPTABLE_STATES_FOR_HeStar = [
     'stripped_He_Core_He_burning',
     'stripped_He_Shell_He_burning',     # includes stars burning C in core
     'stripped_He_Central_He_depleted',  # includes stars burning C in core
-    'stripped_He_Central_C_depletion',
+    'stripped_He_Central_C_depleted',
     'stripped_He_non_burning'
     ]
 
@@ -73,7 +73,7 @@ STAR_STATES_H_RICH = [
     'H-rich_Central_He_depleted',
     'H-rich_Shell_He_burning',
     'H-rich_Core_C_burning',
-    'H-rich_Central_C_depletion',
+    'H-rich_Central_C_depleted',
     'H-rich_non_burning',
     'accreted_He_Core_H_burning',
     'accreted_He_Shell_H_burning',

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -1314,11 +1314,11 @@ class MS_MS_step(MesaGridStep):
             raise GridError(f'The mass of m2 ({m2}) is outside the grid,'
                              'while the period is inside the grid.')
         # redirect if CC1
-        elif (state_1 == 'H-rich_Central_C_depleted'):
+        elif (state_1 == 'H-rich_Core_C_depleted'):
             self.binary.event = 'CC1'
             return
         # redirect if CC2
-        elif (state_2 == 'H-rich_Central_C_depleted'):
+        elif (state_2 == 'H-rich_Core_C_depleted'):
             self.binary.event = 'CC2'
             return
         else:
@@ -1363,10 +1363,10 @@ class CO_HMS_RLO_step(MesaGridStep):
         FOR_RLO_STATES = ["H-rich_Core_H_burning",
                           "H-rich_Shell_H_burning",
                           "H-rich_Core_He_burning",
-                          "H-rich_Central_He_depleted",
+                          "H-rich_Core_He_depleted",
                           "H-rich_Core_C_burning",
                           "accreted_He_Core_H_burning",
-                          "H-rich_Central_C_depleted",  # filtered out below
+                          "H-rich_Core_C_depleted",  # filtered out below
                           "H-rich_non_burning",
                           "accreted_He_non_burning"]
 
@@ -1376,7 +1376,7 @@ class CO_HMS_RLO_step(MesaGridStep):
                 and (state_1 in FOR_RLO_STATES) and event == "oRLO1"):
             self.flip_stars_before_step = False
             # catch and redirect double core collapse, this happens if q=1:
-            if self.binary.star_1.state == 'H-rich_Central_C_depleted':
+            if self.binary.star_1.state == 'H-rich_Core_C_depleted':
                 self.binary.event = 'CC1'
                 return
         # TODO: import states from flow_chart.py
@@ -1384,7 +1384,7 @@ class CO_HMS_RLO_step(MesaGridStep):
                 and event == "oRLO2"):
             self.flip_stars_before_step = True
             # catch and redirect double core collapse, this happens if q=1:
-            if self.binary.star_2.state == 'H-rich_Central_C_depleted':
+            if self.binary.star_2.state == 'H-rich_Core_C_depleted':
                 self.binary.event = 'CC2'
                 return
         else:
@@ -1479,8 +1479,8 @@ class CO_HeMS_RLO_step(MesaGridStep):
             'accreted_He_Core_He_burning',
             'stripped_He_Core_He_burning',
             'stripped_He_Shell_He_burning',
-            'stripped_He_Central_He_depleted',
-            'stripped_He_Central_C_depleted',  # filtered out below
+            'stripped_He_Core_He_depleted',
+            'stripped_He_Core_C_depleted',  # filtered out below
             # include systems that are on the brink of He exhaustion
             'stripped_He_non_burning',
             # include systems post CE with core_definition_H_fraction=0.1
@@ -1494,7 +1494,7 @@ class CO_HeMS_RLO_step(MesaGridStep):
                 and (state_1 in CO_He_STATES) and event == "oRLO1"):
             self.flip_stars_before_step = False
             # catch and redirect double core collapse, this happens if q=1:
-            if self.binary.star_1.state == 'stripped_He_Central_C_depleted':
+            if self.binary.star_1.state == 'stripped_He_Core_C_depleted':
                 self.binary.event = 'CC1'
                 return
         # TODO: import states from flow_chart.py
@@ -1502,7 +1502,7 @@ class CO_HeMS_RLO_step(MesaGridStep):
                 and event == "oRLO2"):
             self.flip_stars_before_step = True
             # catch and redirect double core collapse, this happens if q=1:
-            if self.binary.star_2.state == 'stripped_He_Central_C_depleted':
+            if self.binary.star_2.state == 'stripped_He_Core_C_depleted':
                 self.binary.event = 'CC2'
                 return
         else:
@@ -1593,8 +1593,8 @@ class CO_HeMS_step(MesaGridStep):
             'accreted_He_Core_He_burning',
             'stripped_He_Core_He_burning',
             'stripped_He_Shell_He_burning',
-            'stripped_He_Central_He_depleted',
-            'stripped_He_Central_C_depleted',  # filtered out below
+            'stripped_He_Core_He_depleted',
+            'stripped_He_Core_C_depleted',  # filtered out below
             # include systems that are on the brink of He exhaustion
             'stripped_He_non_burning',
             # include systems post CE with core_definition_H_fraction=0.1
@@ -1606,7 +1606,7 @@ class CO_HeMS_step(MesaGridStep):
                 and state_1 in CO_He_STATES and event is None):
             self.flip_stars_before_step = False
             # catch and redirect double core collapse, this happens if q=1:
-            if self.binary.star_1.state == 'stripped_He_Central_C_depleted':
+            if self.binary.star_1.state == 'stripped_He_Core_C_depleted':
                 self.binary.event = 'CC1'
                 return
         # TODO: import states from flow_chart.py
@@ -1614,7 +1614,7 @@ class CO_HeMS_step(MesaGridStep):
                 and state_2 in CO_He_STATES and event is None):
             self.flip_stars_before_step = True
             # catch and redirect double core collapse, this happens if q=1:
-            if self.binary.star_2.state == 'stripped_He_Central_C_depleted':
+            if self.binary.star_2.state == 'stripped_He_Core_C_depleted':
                 self.binary.event = 'CC2'
                 return
         else:
@@ -1708,10 +1708,10 @@ class HMS_HMS_RLO_step(MesaGridStep):
         FOR_RLO_STATES = ["H-rich_Core_H_burning",
                           "H-rich_Shell_H_burning",
                           "H-rich_Core_He_burning",
-                          "H-rich_Central_He_depleted",
+                          "H-rich_Core_He_depleted",
                           "H-rich_Core_C_burning",
                           "accreted_He_Core_H_burning",
-                          "H-rich_Central_C_depleted",  # filtered out below
+                          "H-rich_Core_C_depleted",  # filtered out below
                           "H-rich_non_burning",
                           "accreted_He_non_burning"]
 
@@ -1721,7 +1721,7 @@ class HMS_HMS_RLO_step(MesaGridStep):
                 and event == "oRLO1"):
             self.flip_stars_before_step = False
             # catch and redirect double core collapse, this happens if q=1:
-            if state_1 == 'H-rich_Central_C_depleted':
+            if state_1 == 'H-rich_Core_C_depleted':
                 self.binary.event = 'CC1'
                 return
         # TODO: import states from flow_chart.py
@@ -1729,7 +1729,7 @@ class HMS_HMS_RLO_step(MesaGridStep):
                 and event == "oRLO2"):
             self.flip_stars_before_step = False
             # catch and redirect double core collapse, this happens if q=1:
-            if state_2 == 'H-rich_Central_C_depleted':
+            if state_2 == 'H-rich_Core_C_depleted':
                 self.binary.event = 'CC2'
                 return
         else:

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -1314,11 +1314,11 @@ class MS_MS_step(MesaGridStep):
             raise GridError(f'The mass of m2 ({m2}) is outside the grid,'
                              'while the period is inside the grid.')
         # redirect if CC1
-        elif (state_1 == 'H-rich_Central_C_depletion'):
+        elif (state_1 == 'H-rich_Central_C_depleted'):
             self.binary.event = 'CC1'
             return
         # redirect if CC2
-        elif (state_2 == 'H-rich_Central_C_depletion'):
+        elif (state_2 == 'H-rich_Central_C_depleted'):
             self.binary.event = 'CC2'
             return
         else:
@@ -1366,7 +1366,7 @@ class CO_HMS_RLO_step(MesaGridStep):
                           "H-rich_Central_He_depleted",
                           "H-rich_Core_C_burning",
                           "accreted_He_Core_H_burning",
-                          "H-rich_Central_C_depletion",  # filtered out below
+                          "H-rich_Central_C_depleted",  # filtered out below
                           "H-rich_non_burning",
                           "accreted_He_non_burning"]
 
@@ -1376,7 +1376,7 @@ class CO_HMS_RLO_step(MesaGridStep):
                 and (state_1 in FOR_RLO_STATES) and event == "oRLO1"):
             self.flip_stars_before_step = False
             # catch and redirect double core collapse, this happens if q=1:
-            if self.binary.star_1.state == 'H-rich_Central_C_depletion':
+            if self.binary.star_1.state == 'H-rich_Central_C_depleted':
                 self.binary.event = 'CC1'
                 return
         # TODO: import states from flow_chart.py
@@ -1384,7 +1384,7 @@ class CO_HMS_RLO_step(MesaGridStep):
                 and event == "oRLO2"):
             self.flip_stars_before_step = True
             # catch and redirect double core collapse, this happens if q=1:
-            if self.binary.star_2.state == 'H-rich_Central_C_depletion':
+            if self.binary.star_2.state == 'H-rich_Central_C_depleted':
                 self.binary.event = 'CC2'
                 return
         else:
@@ -1480,7 +1480,7 @@ class CO_HeMS_RLO_step(MesaGridStep):
             'stripped_He_Core_He_burning',
             'stripped_He_Shell_He_burning',
             'stripped_He_Central_He_depleted',
-            'stripped_He_Central_C_depletion',  # filtered out below
+            'stripped_He_Central_C_depleted',  # filtered out below
             # include systems that are on the brink of He exhaustion
             'stripped_He_non_burning',
             # include systems post CE with core_definition_H_fraction=0.1
@@ -1494,7 +1494,7 @@ class CO_HeMS_RLO_step(MesaGridStep):
                 and (state_1 in CO_He_STATES) and event == "oRLO1"):
             self.flip_stars_before_step = False
             # catch and redirect double core collapse, this happens if q=1:
-            if self.binary.star_1.state == 'stripped_He_Central_C_depletion':
+            if self.binary.star_1.state == 'stripped_He_Central_C_depleted':
                 self.binary.event = 'CC1'
                 return
         # TODO: import states from flow_chart.py
@@ -1502,7 +1502,7 @@ class CO_HeMS_RLO_step(MesaGridStep):
                 and event == "oRLO2"):
             self.flip_stars_before_step = True
             # catch and redirect double core collapse, this happens if q=1:
-            if self.binary.star_2.state == 'stripped_He_Central_C_depletion':
+            if self.binary.star_2.state == 'stripped_He_Central_C_depleted':
                 self.binary.event = 'CC2'
                 return
         else:
@@ -1594,7 +1594,7 @@ class CO_HeMS_step(MesaGridStep):
             'stripped_He_Core_He_burning',
             'stripped_He_Shell_He_burning',
             'stripped_He_Central_He_depleted',
-            'stripped_He_Central_C_depletion',  # filtered out below
+            'stripped_He_Central_C_depleted',  # filtered out below
             # include systems that are on the brink of He exhaustion
             'stripped_He_non_burning',
             # include systems post CE with core_definition_H_fraction=0.1
@@ -1606,7 +1606,7 @@ class CO_HeMS_step(MesaGridStep):
                 and state_1 in CO_He_STATES and event is None):
             self.flip_stars_before_step = False
             # catch and redirect double core collapse, this happens if q=1:
-            if self.binary.star_1.state == 'stripped_He_Central_C_depletion':
+            if self.binary.star_1.state == 'stripped_He_Central_C_depleted':
                 self.binary.event = 'CC1'
                 return
         # TODO: import states from flow_chart.py
@@ -1614,7 +1614,7 @@ class CO_HeMS_step(MesaGridStep):
                 and state_2 in CO_He_STATES and event is None):
             self.flip_stars_before_step = True
             # catch and redirect double core collapse, this happens if q=1:
-            if self.binary.star_2.state == 'stripped_He_Central_C_depletion':
+            if self.binary.star_2.state == 'stripped_He_Central_C_depleted':
                 self.binary.event = 'CC2'
                 return
         else:
@@ -1711,7 +1711,7 @@ class HMS_HMS_RLO_step(MesaGridStep):
                           "H-rich_Central_He_depleted",
                           "H-rich_Core_C_burning",
                           "accreted_He_Core_H_burning",
-                          "H-rich_Central_C_depletion",  # filtered out below
+                          "H-rich_Central_C_depleted",  # filtered out below
                           "H-rich_non_burning",
                           "accreted_He_non_burning"]
 
@@ -1721,7 +1721,7 @@ class HMS_HMS_RLO_step(MesaGridStep):
                 and event == "oRLO1"):
             self.flip_stars_before_step = False
             # catch and redirect double core collapse, this happens if q=1:
-            if state_1 == 'H-rich_Central_C_depletion':
+            if state_1 == 'H-rich_Central_C_depleted':
                 self.binary.event = 'CC1'
                 return
         # TODO: import states from flow_chart.py
@@ -1729,7 +1729,7 @@ class HMS_HMS_RLO_step(MesaGridStep):
                 and event == "oRLO2"):
             self.flip_stars_before_step = False
             # catch and redirect double core collapse, this happens if q=1:
-            if state_2 == 'H-rich_Central_C_depletion':
+            if state_2 == 'H-rich_Central_C_depleted':
                 self.binary.event = 'CC2'
                 return
         else:

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -51,7 +51,7 @@ from posydon.binary_evol.singlestar import STARPROPERTIES, convert_star_to_massl
 from posydon.binary_evol.SN.profile_collapse import (do_core_collapse_BH,
                                         get_ejecta_element_mass_at_collapse)
 from posydon.binary_evol.flow_chart import (STAR_STATES_CO, STAR_STATES_CC,
-                                            STAR_STATES_C_DEPLETION)
+                                            STAR_STATES_C_depleted)
 
 from posydon.grids.SN_MODELS import get_SN_MODEL_NAME, DEFAULT_SN_MODEL
 from posydon.utils.posydonerror import ModelError
@@ -436,9 +436,9 @@ class StepSN(object):
                 binary.eccentricity,
             )
         # Cover the case where CC of the companion is immediately followed
-        elif state1 in STAR_STATES_CO and state2 in STAR_STATES_C_DEPLETION:
+        elif state1 in STAR_STATES_CO and state2 in STAR_STATES_C_depleted:
             binary.event = "CC2"
-        elif state1 in STAR_STATES_C_DEPLETION and state2 in STAR_STATES_CO:
+        elif state1 in STAR_STATES_C_depleted and state2 in STAR_STATES_CO:
             binary.event = "CC1"
 
         if self.verbose:

--- a/posydon/binary_evol/SN/step_SN.py
+++ b/posydon/binary_evol/SN/step_SN.py
@@ -51,7 +51,7 @@ from posydon.binary_evol.singlestar import STARPROPERTIES, convert_star_to_massl
 from posydon.binary_evol.SN.profile_collapse import (do_core_collapse_BH,
                                         get_ejecta_element_mass_at_collapse)
 from posydon.binary_evol.flow_chart import (STAR_STATES_CO, STAR_STATES_CC,
-                                            STAR_STATES_C_depleted)
+                                            STAR_STATES_C_DEPLETED)
 
 from posydon.grids.SN_MODELS import get_SN_MODEL_NAME, DEFAULT_SN_MODEL
 from posydon.utils.posydonerror import ModelError
@@ -436,9 +436,9 @@ class StepSN(object):
                 binary.eccentricity,
             )
         # Cover the case where CC of the companion is immediately followed
-        elif state1 in STAR_STATES_CO and state2 in STAR_STATES_C_depleted:
+        elif state1 in STAR_STATES_CO and state2 in STAR_STATES_C_DEPLETED:
             binary.event = "CC2"
-        elif state1 in STAR_STATES_C_depleted and state2 in STAR_STATES_CO:
+        elif state1 in STAR_STATES_C_DEPLETED and state2 in STAR_STATES_CO:
             binary.event = "CC1"
 
         if self.verbose:

--- a/posydon/binary_evol/flow_chart.py
+++ b/posydon/binary_evol/flow_chart.py
@@ -24,18 +24,18 @@ STAR_STATES_ALL = [
     'H-rich_Core_H_burning',
     'H-rich_Core_He_burning',
     'H-rich_Shell_H_burning',
-    'H-rich_Central_He_depleted',
+    'H-rich_Core_He_depleted',
     'H-rich_Shell_He_burning',
     'H-rich_Core_C_burning',
-    'H-rich_Central_C_depleted',
+    'H-rich_Core_C_depleted',
     'H-rich_non_burning',
     'accreted_He_Core_H_burning',
     'accreted_He_Shell_H_burning',
     'accreted_He_non_burning',
     'accreted_He_Core_He_burning',
     'stripped_He_Core_He_burning',
-    'stripped_He_Central_He_depleted',
-    'stripped_He_Central_C_depleted',
+    'stripped_He_Core_He_depleted',
+    'stripped_He_Core_C_depleted',
     'stripped_He_non_burning'
 ]
 
@@ -51,8 +51,8 @@ STAR_STATES_NORMALSTAR = STAR_STATES_ALL.copy()
 
 STAR_STATES_H_RICH = STAR_STATES_NORMALSTAR.copy()
 [STAR_STATES_H_RICH.remove(x) for x in ['stripped_He_Core_He_burning',
-                                        'stripped_He_Central_He_depleted',
-                                        'stripped_He_Central_C_depleted',
+                                        'stripped_He_Core_He_depleted',
+                                        'stripped_He_Core_C_depleted',
                                         'stripped_He_non_burning',
                                         'accreted_He_Core_He_burning']]
 
@@ -60,10 +60,10 @@ STAR_STATES_HE_RICH = STAR_STATES_NORMALSTAR.copy()
 [STAR_STATES_HE_RICH.remove(x) for x in ['H-rich_Core_H_burning',
                                          'H-rich_Core_He_burning',
                                          'H-rich_Shell_H_burning',
-                                         'H-rich_Central_He_depleted',
+                                         'H-rich_Core_He_depleted',
                                          'H-rich_Shell_He_burning',
                                          'H-rich_Core_C_burning',
-                                         'H-rich_Central_C_depleted',
+                                         'H-rich_Core_C_depleted',
                                          'accreted_He_Core_H_burning',
                                          'accreted_He_Shell_H_burning']]
 
@@ -73,8 +73,8 @@ STAR_STATES_POST_MS = [
     "H-rich_Core_H_burning",
     "H-rich_Shell_H_burning",
     "H-rich_Core_He_burning",
-    "H-rich_Central_He_depleted",
-    "H-rich_Central_C_depleted",
+    "H-rich_Core_He_depleted",
+    "H-rich_Core_C_depleted",
     "H-rich_non_burning",
     "accreted_He_non_burning"
 ]
@@ -83,8 +83,8 @@ STAR_STATES_POST_MS = [
 STAR_STATES_POST_HeMS = [
     'accreted_He_Core_He_burning',
     'stripped_He_Core_He_burning',
-    'stripped_He_Central_He_depleted',
-    'stripped_He_Central_C_depleted',
+    'stripped_He_Core_He_depleted',
+    'stripped_He_Core_C_depleted',
     'stripped_He_non_burning'
 ]
 
@@ -103,10 +103,10 @@ STAR_STATES_HE_RICH_EVOLVABLE.extend(['H-rich_non_burning'])
 
 # core collapse
 STAR_STATES_CC = [
-    'H-rich_Central_C_depleted',
-    'H-rich_Central_He_depleted',
-    'stripped_He_Central_He_depleted',
-    'stripped_He_Central_C_depleted',
+    'H-rich_Core_C_depleted',
+    'H-rich_Core_He_depleted',
+    'stripped_He_Core_He_depleted',
+    'stripped_He_Core_C_depleted',
     # catch runs with gamma center limit which map to WD
     'stripped_He_non_burning',
     'H-rich_non_burning',

--- a/posydon/binary_evol/flow_chart.py
+++ b/posydon/binary_evol/flow_chart.py
@@ -27,7 +27,7 @@ STAR_STATES_ALL = [
     'H-rich_Central_He_depleted',
     'H-rich_Shell_He_burning',
     'H-rich_Core_C_burning',
-    'H-rich_Central_C_depletion',
+    'H-rich_Central_C_depleted',
     'H-rich_non_burning',
     'accreted_He_Core_H_burning',
     'accreted_He_Shell_H_burning',
@@ -35,7 +35,7 @@ STAR_STATES_ALL = [
     'accreted_He_Core_He_burning',
     'stripped_He_Core_He_burning',
     'stripped_He_Central_He_depleted',
-    'stripped_He_Central_C_depletion',
+    'stripped_He_Central_C_depleted',
     'stripped_He_non_burning'
 ]
 
@@ -52,7 +52,7 @@ STAR_STATES_NORMALSTAR = STAR_STATES_ALL.copy()
 STAR_STATES_H_RICH = STAR_STATES_NORMALSTAR.copy()
 [STAR_STATES_H_RICH.remove(x) for x in ['stripped_He_Core_He_burning',
                                         'stripped_He_Central_He_depleted',
-                                        'stripped_He_Central_C_depletion',
+                                        'stripped_He_Central_C_depleted',
                                         'stripped_He_non_burning',
                                         'accreted_He_Core_He_burning']]
 
@@ -63,18 +63,37 @@ STAR_STATES_HE_RICH = STAR_STATES_NORMALSTAR.copy()
                                          'H-rich_Central_He_depleted',
                                          'H-rich_Shell_He_burning',
                                          'H-rich_Core_C_burning',
-                                         'H-rich_Central_C_depletion',
+                                         'H-rich_Central_C_depleted',
                                          'accreted_He_Core_H_burning',
                                          'accreted_He_Shell_H_burning']]
 
-STAR_STATES_C_DEPLETION = [st for st in STAR_STATES_ALL if "C_depletion" in st]
+STAR_STATES_C_DEPLETED = [st for st in STAR_STATES_ALL if "C_depleted" in st]
+
+STAR_STATES_POST_MS = [
+    "H-rich_Core_H_burning",
+    "H-rich_Shell_H_burning",
+    "H-rich_Core_He_burning",
+    "H-rich_Central_He_depleted",
+    "H-rich_Central_C_depleted",
+    "H-rich_non_burning",
+    "accreted_He_non_burning"
+]
+
+
+STAR_STATES_POST_HeMS = [
+    'accreted_He_Core_He_burning',
+    'stripped_He_Core_He_burning',
+    'stripped_He_Central_He_depleted',
+    'stripped_He_Central_C_depleted',
+    'stripped_He_non_burning'
+]
 
 # these states can be evolved through MESA grids
 STAR_STATES_H_RICH_EVOLVABLE = list(set(STAR_STATES_H_RICH)
-                                    - set(STAR_STATES_C_DEPLETION))
+                                    - set(STAR_STATES_C_DEPLETED))
 
 STAR_STATES_HE_RICH_EVOLVABLE = list(set(STAR_STATES_HE_RICH)
-                                     - set(STAR_STATES_C_DEPLETION))
+                                     - set(STAR_STATES_C_DEPLETED))
 
 # CE ejection happens instantanously, so the star does not readjust before
 # we infer the state. If core_definition_H_fraction=0.1, then surface_h1=0.1,
@@ -84,10 +103,10 @@ STAR_STATES_HE_RICH_EVOLVABLE.extend(['H-rich_non_burning'])
 
 # core collapse
 STAR_STATES_CC = [
-    'H-rich_Central_C_depletion',
+    'H-rich_Central_C_depleted',
     'H-rich_Central_He_depleted',
     'stripped_He_Central_He_depleted',
-    'stripped_He_Central_C_depletion',
+    'stripped_He_Central_C_depleted',
     # catch runs with gamma center limit which map to WD
     'stripped_He_non_burning',
     'H-rich_non_burning',

--- a/posydon/interpolation/profile_interpolation.py
+++ b/posydon/interpolation/profile_interpolation.py
@@ -561,10 +561,10 @@ class Composition:
                              'stripped_He_Core_He_burning',
                              'stripped_He_Core_C_burning',
                              'stripped_He_Central_He_depleted',
-                             'stripped_He_Central_C_depletion',
+                             'stripped_He_Central_C_depleted',
                              'H-rich_non_burning',
                              'H-rich_Central_He_depleted',
-                             'H-rich_Central_C_depletion',
+                             'H-rich_Central_C_depleted',
                              'H-rich_Shell_H_burning',
                              'H-rich_Core_H_burning',
                              'H-rich_Core_He_burning',
@@ -616,9 +616,9 @@ class Composition:
         for state in ['stripped_He_Core_He_burning',
                       'stripped_He_Core_C_burning',
                       'stripped_He_Central_He_depleted',
-                      'stripped_He_Central_C_depletion',
+                      'stripped_He_Central_C_depleted',
                       'H-rich_Central_He_depleted',
-                      'H-rich_Central_C_depletion',
+                      'H-rich_Central_C_depleted',
                       'H-rich_Shell_H_burning',
                       'H-rich_Core_H_burning',
                       'H-rich_Core_He_burning',
@@ -671,7 +671,7 @@ class Composition:
                 
                         
                 elif state in ['H-rich_Central_He_depleted',
-                               'H-rich_Central_C_depletion']: # H profiles with 1 boundary point
+                               'H-rich_Central_C_depleted']: # H profiles with 1 boundary point
                     outs=3
                     # calculate the point in each H profile with the largest increase
                     hbound = (np.argmax(h_prof[:,1:]-h_prof[:,:-1],axis=1)+1)/200
@@ -685,7 +685,7 @@ class Composition:
                 elif state in ['stripped_He_Core_He_burning',
                              'stripped_He_Core_C_burning',
                              'stripped_He_Central_He_depleted',
-                             'stripped_He_Central_C_depletion']:
+                             'stripped_He_Central_C_depleted']:
                     outs=2
                     # calculate first and points in each profile with large increases
                     bounds,nonflat = calc_bevel_bounds(he_prof)
@@ -762,7 +762,7 @@ class Composition:
         
         # construct step-shaped profile - H and He profiles have symmetrical shapes
         elif star_state in ["H-rich_Central_He_depleted",
-                  "H-rich_Central_C_depletion"]:
+                  "H-rich_Central_C_depleted"]:
             # predicting profile shape parameters 
             b = self.bounds_models[star_state](tf.convert_to_tensor([initial])).numpy()[0]            
             H = np.ones(200)*center_H

--- a/posydon/interpolation/profile_interpolation.py
+++ b/posydon/interpolation/profile_interpolation.py
@@ -560,11 +560,11 @@ class Composition:
                              'stripped_He_non_burning',
                              'stripped_He_Core_He_burning',
                              'stripped_He_Core_C_burning',
-                             'stripped_He_Central_He_depleted',
-                             'stripped_He_Central_C_depleted',
+                             'stripped_He_Core_He_depleted',
+                             'stripped_He_Core_C_depleted',
                              'H-rich_non_burning',
-                             'H-rich_Central_He_depleted',
-                             'H-rich_Central_C_depleted',
+                             'H-rich_Core_He_depleted',
+                             'H-rich_Core_C_depleted',
                              'H-rich_Shell_H_burning',
                              'H-rich_Core_H_burning',
                              'H-rich_Core_He_burning',
@@ -615,10 +615,10 @@ class Composition:
         
         for state in ['stripped_He_Core_He_burning',
                       'stripped_He_Core_C_burning',
-                      'stripped_He_Central_He_depleted',
-                      'stripped_He_Central_C_depleted',
-                      'H-rich_Central_He_depleted',
-                      'H-rich_Central_C_depleted',
+                      'stripped_He_Core_He_depleted',
+                      'stripped_He_Core_C_depleted',
+                      'H-rich_Core_He_depleted',
+                      'H-rich_Core_C_depleted',
                       'H-rich_Shell_H_burning',
                       'H-rich_Core_H_burning',
                       'H-rich_Core_He_burning',
@@ -670,8 +670,8 @@ class Composition:
                                                  valid_pbounds[:,0],valid_pbounds[:,1]])
                 
                         
-                elif state in ['H-rich_Central_He_depleted',
-                               'H-rich_Central_C_depleted']: # H profiles with 1 boundary point
+                elif state in ['H-rich_Core_He_depleted',
+                               'H-rich_Core_C_depleted']: # H profiles with 1 boundary point
                     outs=3
                     # calculate the point in each H profile with the largest increase
                     hbound = (np.argmax(h_prof[:,1:]-h_prof[:,:-1],axis=1)+1)/200
@@ -684,8 +684,8 @@ class Composition:
             
                 elif state in ['stripped_He_Core_He_burning',
                              'stripped_He_Core_C_burning',
-                             'stripped_He_Central_He_depleted',
-                             'stripped_He_Central_C_depleted']:
+                             'stripped_He_Core_He_depleted',
+                             'stripped_He_Core_C_depleted']:
                     outs=2
                     # calculate first and points in each profile with large increases
                     bounds,nonflat = calc_bevel_bounds(he_prof)
@@ -761,8 +761,8 @@ class Composition:
             He = np.ones(200)*np.nan
         
         # construct step-shaped profile - H and He profiles have symmetrical shapes
-        elif star_state in ["H-rich_Central_He_depleted",
-                  "H-rich_Central_C_depleted"]:
+        elif star_state in ["H-rich_Core_He_depleted",
+                  "H-rich_Core_C_depleted"]:
             # predicting profile shape parameters 
             b = self.bounds_models[star_state](tf.convert_to_tensor([initial])).numpy()[0]            
             H = np.ones(200)*center_H

--- a/posydon/tests/binary_evol/SN/test_step_SN.py
+++ b/posydon/tests/binary_evol/SN/test_step_SN.py
@@ -39,7 +39,7 @@ class TestStepSN(unittest.TestCase):
             star_prop = {'mass': M_CO / 0.7638113015667961,
                             'co_core_mass': M_CO ,
                             'he_core_mass': M_CO / 0.7638113015667961,
-                            'state':'stripped_He_Central_C_depleted',
+                            'state':'stripped_He_Core_C_depleted',
                             'profile':None ,
                             'spin': 0.0}
             star = SingleStar(**star_prop)
@@ -67,7 +67,7 @@ class TestStepSN(unittest.TestCase):
             star_prop = {'mass': M_CO / 0.7638113015667961,
                             'co_core_mass': M_CO ,
                             'he_core_mass': M_CO / 0.7638113015667961,
-                            'state':'stripped_He_Central_C_depleted',
+                            'state':'stripped_He_Core_C_depleted',
                             'profile':None ,
                             'spin': 0.0}
             star = SingleStar(**star_prop)
@@ -96,7 +96,7 @@ class TestStepSN(unittest.TestCase):
             star_prop = {'mass': M_CO / 0.7638113015667961,
                             'co_core_mass': M_CO ,
                             'he_core_mass': M_CO / 0.7638113015667961,
-                            'state':'stripped_He_Central_C_depleted',
+                            'state':'stripped_He_Core_C_depleted',
                             'profile':None ,
                             'spin': 0.0}
             star = SingleStar(**star_prop)
@@ -128,7 +128,7 @@ class TestStepSN(unittest.TestCase):
             star_prop = {'mass': M_CO / 0.7638113015667961,
                             'co_core_mass': M_CO ,
                             'he_core_mass': M_CO / 0.7638113015667961,
-                            'state':'stripped_He_Central_C_depleted',
+                            'state':'stripped_He_Core_C_depleted',
                             'profile':None ,
                             'spin': 0.0}
             star = SingleStar(**star_prop)
@@ -156,7 +156,7 @@ class TestStepSN(unittest.TestCase):
             star_prop = {'mass': M_CO / 0.7638113015667961,
                             'co_core_mass': M_CO ,
                             'he_core_mass': M_CO / 0.7638113015667961,
-                            'state':'stripped_He_Central_C_depleted',
+                            'state':'stripped_He_Core_C_depleted',
                             'profile':None ,
                             'spin': 0.0}
             star = SingleStar(**star_prop)
@@ -185,7 +185,7 @@ class TestStepSN(unittest.TestCase):
             star_prop = {'mass': M_CO / 0.7638113015667961,
                             'co_core_mass': M_CO ,
                             'he_core_mass': M_CO / 0.7638113015667961,
-                            'state':'stripped_He_Central_C_depleted',
+                            'state':'stripped_He_Core_C_depleted',
                             'profile':None ,
                             'spin': 0.0}
             star = SingleStar(**star_prop)
@@ -217,7 +217,7 @@ class TestStepSN(unittest.TestCase):
             star_prop = {'mass': M_CO / 0.7638113015667961,
                             'co_core_mass': M_CO ,
                             'he_core_mass': M_CO / 0.7638113015667961,
-                            'state':'stripped_He_Central_C_depleted',
+                            'state':'stripped_He_Core_C_depleted',
                             'profile':None ,
                             'spin': 0.0}
             star = SingleStar(**star_prop)
@@ -244,7 +244,7 @@ class TestStepSN(unittest.TestCase):
             star_prop = {'mass': M_CO / 0.7638113015667961,
                             'co_core_mass': M_CO ,
                             'he_core_mass': M_CO / 0.7638113015667961,
-                            'state':'stripped_He_Central_C_depleted',
+                            'state':'stripped_He_Core_C_depleted',
                             'profile':None ,
                             'spin': 0.0}
             star = SingleStar(**star_prop)
@@ -272,7 +272,7 @@ class TestStepSN(unittest.TestCase):
             star_prop = {'mass': M_CO / 0.7638113015667961,
                             'co_core_mass': M_CO ,
                             'he_core_mass': M_CO / 0.7638113015667961,
-                            'state':'stripped_He_Central_C_depleted',
+                            'state':'stripped_He_Core_C_depleted',
                             'profile':None ,
                             'spin': 0.0}
             star = SingleStar(**star_prop)
@@ -303,7 +303,7 @@ class TestStepSN(unittest.TestCase):
             star_prop = {'mass': M_He,
                             'co_core_mass': M_He * 0.7638113015667961 ,
                             'he_core_mass': M_He ,
-                            'state':'stripped_He_Central_C_depleted',
+                            'state':'stripped_He_Core_C_depleted',
                             'profile':None ,
                             'spin': 0.0}
 
@@ -337,7 +337,7 @@ class TestStepSN(unittest.TestCase):
             star_prop = {'mass': M_He,
                             'co_core_mass': M_He * 0.7638113015667961 ,
                             'he_core_mass': M_He ,
-                            'state':'stripped_He_Central_C_depleted',
+                            'state':'stripped_He_Core_C_depleted',
                             'profile':None ,
                             'spin': 0.0}
 
@@ -374,7 +374,7 @@ class TestStepSN(unittest.TestCase):
                 star_prop = {'mass':m_co / 0.7638113015667961,
                         'co_core_mass':m_co,
                         'he_core_mass':m_co / 0.7638113015667961,
-                        'state':'stripped_He_Central_C_depleted',
+                        'state':'stripped_He_Core_C_depleted',
                         'profile':None ,
                         'spin': 0.0}
 
@@ -438,7 +438,7 @@ class TestStepSN(unittest.TestCase):
                 star_prop = {'mass':m_co / 0.7638113015667961,
                         'co_core_mass':m_co,
                         'he_core_mass':m_co / 0.7638113015667961,
-                        'state':'stripped_He_Central_C_depleted',
+                        'state':'stripped_He_Core_C_depleted',
                         'profile':None ,
                         'spin': 0.0}
 
@@ -509,7 +509,7 @@ class TestStepSN(unittest.TestCase):
 
             properties_star1 = {"mass": 16.200984100257546, "state": "BH", "profile": None}
             properties_star2 = {"mass": 5.497560636139926,
-                                "state": "stripped_He_Central_C_depleted",
+                                "state": "stripped_He_Core_C_depleted",
                                 "profile": None,
                                 'he_core_mass': 5.497560636139926,
                                 'co_core_mass': 4.1990989449324205}

--- a/posydon/tests/binary_evol/SN/test_step_SN.py
+++ b/posydon/tests/binary_evol/SN/test_step_SN.py
@@ -39,7 +39,7 @@ class TestStepSN(unittest.TestCase):
             star_prop = {'mass': M_CO / 0.7638113015667961,
                             'co_core_mass': M_CO ,
                             'he_core_mass': M_CO / 0.7638113015667961,
-                            'state':'stripped_He_Central_C_depletion',
+                            'state':'stripped_He_Central_C_depleted',
                             'profile':None ,
                             'spin': 0.0}
             star = SingleStar(**star_prop)
@@ -67,7 +67,7 @@ class TestStepSN(unittest.TestCase):
             star_prop = {'mass': M_CO / 0.7638113015667961,
                             'co_core_mass': M_CO ,
                             'he_core_mass': M_CO / 0.7638113015667961,
-                            'state':'stripped_He_Central_C_depletion',
+                            'state':'stripped_He_Central_C_depleted',
                             'profile':None ,
                             'spin': 0.0}
             star = SingleStar(**star_prop)
@@ -96,7 +96,7 @@ class TestStepSN(unittest.TestCase):
             star_prop = {'mass': M_CO / 0.7638113015667961,
                             'co_core_mass': M_CO ,
                             'he_core_mass': M_CO / 0.7638113015667961,
-                            'state':'stripped_He_Central_C_depletion',
+                            'state':'stripped_He_Central_C_depleted',
                             'profile':None ,
                             'spin': 0.0}
             star = SingleStar(**star_prop)
@@ -128,7 +128,7 @@ class TestStepSN(unittest.TestCase):
             star_prop = {'mass': M_CO / 0.7638113015667961,
                             'co_core_mass': M_CO ,
                             'he_core_mass': M_CO / 0.7638113015667961,
-                            'state':'stripped_He_Central_C_depletion',
+                            'state':'stripped_He_Central_C_depleted',
                             'profile':None ,
                             'spin': 0.0}
             star = SingleStar(**star_prop)
@@ -156,7 +156,7 @@ class TestStepSN(unittest.TestCase):
             star_prop = {'mass': M_CO / 0.7638113015667961,
                             'co_core_mass': M_CO ,
                             'he_core_mass': M_CO / 0.7638113015667961,
-                            'state':'stripped_He_Central_C_depletion',
+                            'state':'stripped_He_Central_C_depleted',
                             'profile':None ,
                             'spin': 0.0}
             star = SingleStar(**star_prop)
@@ -185,7 +185,7 @@ class TestStepSN(unittest.TestCase):
             star_prop = {'mass': M_CO / 0.7638113015667961,
                             'co_core_mass': M_CO ,
                             'he_core_mass': M_CO / 0.7638113015667961,
-                            'state':'stripped_He_Central_C_depletion',
+                            'state':'stripped_He_Central_C_depleted',
                             'profile':None ,
                             'spin': 0.0}
             star = SingleStar(**star_prop)
@@ -217,7 +217,7 @@ class TestStepSN(unittest.TestCase):
             star_prop = {'mass': M_CO / 0.7638113015667961,
                             'co_core_mass': M_CO ,
                             'he_core_mass': M_CO / 0.7638113015667961,
-                            'state':'stripped_He_Central_C_depletion',
+                            'state':'stripped_He_Central_C_depleted',
                             'profile':None ,
                             'spin': 0.0}
             star = SingleStar(**star_prop)
@@ -244,7 +244,7 @@ class TestStepSN(unittest.TestCase):
             star_prop = {'mass': M_CO / 0.7638113015667961,
                             'co_core_mass': M_CO ,
                             'he_core_mass': M_CO / 0.7638113015667961,
-                            'state':'stripped_He_Central_C_depletion',
+                            'state':'stripped_He_Central_C_depleted',
                             'profile':None ,
                             'spin': 0.0}
             star = SingleStar(**star_prop)
@@ -272,7 +272,7 @@ class TestStepSN(unittest.TestCase):
             star_prop = {'mass': M_CO / 0.7638113015667961,
                             'co_core_mass': M_CO ,
                             'he_core_mass': M_CO / 0.7638113015667961,
-                            'state':'stripped_He_Central_C_depletion',
+                            'state':'stripped_He_Central_C_depleted',
                             'profile':None ,
                             'spin': 0.0}
             star = SingleStar(**star_prop)
@@ -303,7 +303,7 @@ class TestStepSN(unittest.TestCase):
             star_prop = {'mass': M_He,
                             'co_core_mass': M_He * 0.7638113015667961 ,
                             'he_core_mass': M_He ,
-                            'state':'stripped_He_Central_C_depletion',
+                            'state':'stripped_He_Central_C_depleted',
                             'profile':None ,
                             'spin': 0.0}
 
@@ -337,7 +337,7 @@ class TestStepSN(unittest.TestCase):
             star_prop = {'mass': M_He,
                             'co_core_mass': M_He * 0.7638113015667961 ,
                             'he_core_mass': M_He ,
-                            'state':'stripped_He_Central_C_depletion',
+                            'state':'stripped_He_Central_C_depleted',
                             'profile':None ,
                             'spin': 0.0}
 
@@ -374,7 +374,7 @@ class TestStepSN(unittest.TestCase):
                 star_prop = {'mass':m_co / 0.7638113015667961,
                         'co_core_mass':m_co,
                         'he_core_mass':m_co / 0.7638113015667961,
-                        'state':'stripped_He_Central_C_depletion',
+                        'state':'stripped_He_Central_C_depleted',
                         'profile':None ,
                         'spin': 0.0}
 
@@ -438,7 +438,7 @@ class TestStepSN(unittest.TestCase):
                 star_prop = {'mass':m_co / 0.7638113015667961,
                         'co_core_mass':m_co,
                         'he_core_mass':m_co / 0.7638113015667961,
-                        'state':'stripped_He_Central_C_depletion',
+                        'state':'stripped_He_Central_C_depleted',
                         'profile':None ,
                         'spin': 0.0}
 
@@ -509,7 +509,7 @@ class TestStepSN(unittest.TestCase):
 
             properties_star1 = {"mass": 16.200984100257546, "state": "BH", "profile": None}
             properties_star2 = {"mass": 5.497560636139926,
-                                "state": "stripped_He_Central_C_depletion",
+                                "state": "stripped_He_Central_C_depleted",
                                 "profile": None,
                                 'he_core_mass': 5.497560636139926,
                                 'co_core_mass': 4.1990989449324205}

--- a/posydon/tests/binary_evol/test_BinaryStar.py
+++ b/posydon/tests/binary_evol/test_BinaryStar.py
@@ -25,7 +25,7 @@ class TestSingleStar(unittest.TestCase):
         i = 42
 
         kwargs1 = {
-            'state': 'stripped_He_Central_C_depleted',
+            'state': 'stripped_He_Core_C_depleted',
             'metallicity': grid[i].initial_values['Z'],
             'mass': grid[i].history1['star_mass'][-1],
             'log_R': np.nan,
@@ -63,7 +63,7 @@ class TestSingleStar(unittest.TestCase):
         star_1 = SingleStar(**kwargs1)
 
         kwargs2 = {
-            'state': 'stripped_He_Central_C_depleted',
+            'state': 'stripped_He_Core_C_depleted',
             'metallicity': grid[i].initial_values['Z'],
             'mass': grid[i].initial_values['star_2_mass'],
             'log_R': np.nan,

--- a/posydon/tests/binary_evol/test_BinaryStar.py
+++ b/posydon/tests/binary_evol/test_BinaryStar.py
@@ -25,7 +25,7 @@ class TestSingleStar(unittest.TestCase):
         i = 42
 
         kwargs1 = {
-            'state': 'stripped_He_Central_C_depletion',
+            'state': 'stripped_He_Central_C_depleted',
             'metallicity': grid[i].initial_values['Z'],
             'mass': grid[i].history1['star_mass'][-1],
             'log_R': np.nan,
@@ -63,7 +63,7 @@ class TestSingleStar(unittest.TestCase):
         star_1 = SingleStar(**kwargs1)
 
         kwargs2 = {
-            'state': 'stripped_He_Central_C_depletion',
+            'state': 'stripped_He_Central_C_depleted',
             'metallicity': grid[i].initial_values['Z'],
             'mass': grid[i].initial_values['star_2_mass'],
             'log_R': np.nan,

--- a/posydon/unit_tests/utils/test_common_functions.py
+++ b/posydon/unit_tests/utils/test_common_functions.py
@@ -339,7 +339,7 @@ class TestValues:
 
     def test_value_BURNING_STATES(self):
         for v in ["Core_H_burning", "Core_He_burning", "Shell_H_burning",\
-                  "Central_He_depleted", "Central_C_depletion"]:
+                  "Central_He_depleted", "Central_C_depleted"]:
             # check required values
             assert v in totest.BURNING_STATES, "missing entry"
 
@@ -1397,7 +1397,7 @@ class TestFunctions:
                                     rich = "stripped_He"
                                 if ((cH1<=TCA) and (cHe4<=TCA) and\
                                     (cC12<=TCA)):
-                                    burn = "Central_C_depletion"
+                                    burn = "Central_C_depleted"
                                 elif ((cH1<=TCA) and (cHe4<=TCA) and\
                                       (cC12>TCA)):
                                     burn = "Central_He_depleted"
@@ -1452,11 +1452,11 @@ class TestFunctions:
                  ("H-rich_Core_He_burning", totest.MT_CASE_B),\
                  ("H-rich_Shell_H_burning", totest.MT_CASE_B),\
                  ("H-rich_Central_He_depleted", totest.MT_CASE_C),\
-                 ("H-rich_Central_C_depletion", totest.MT_CASE_C),\
+                 ("H-rich_Central_C_depleted", totest.MT_CASE_C),\
                  ("H-rich_undetermined", totest.MT_CASE_UNDETERMINED),\
                  ("stripped_He_Core_He_burning", totest.MT_CASE_BA),\
                  ("stripped_He_Central_He_depleted", totest.MT_CASE_BB),\
-                 ("stripped_He_Central_C_depletion", totest.MT_CASE_BB),\
+                 ("stripped_He_Central_C_depleted", totest.MT_CASE_BB),\
                  ("stripped_He_undetermined", totest.MT_CASE_UNDETERMINED),\
                  ("test_undetermined", totest.MT_CASE_UNDETERMINED)]
         for (ds, c) in tests:
@@ -1644,9 +1644,9 @@ class TestFunctions:
         star.co_core_mass_at_He_depletion = 0.5
         star.avg_c_in_c_core_at_He_depletion = 0.5
         for s in ["test", "H-rich_Core_H_burning", "H-rich_Core_He_burning",\
-                  "H-rich_Shell_H_burning", "H-rich_Central_C_depletion",\
+                  "H-rich_Shell_H_burning", "H-rich_Central_C_depleted",\
                   "H-rich_undetermined", "stripped_He_Core_He_burning",\
-                  "stripped_He_Central_C_depletion",\
+                  "stripped_He_Central_C_depleted",\
                   "stripped_He_undetermined"]:
             star.state_history = [s]
             totest.calculate_Patton20_values_at_He_depl(star)

--- a/posydon/unit_tests/utils/test_common_functions.py
+++ b/posydon/unit_tests/utils/test_common_functions.py
@@ -110,7 +110,8 @@ class TestElements:
                     'roche_lobe_radius', 'check_for_RLO', 'rotate',\
                     'rzams', 'separation_evol_wind_loss',\
                     'set_binary_to_failed', 'spin_stable_mass_transfer',\
-                    'stefan_boltzmann_law'}
+                    'stefan_boltzmann_law', 'STAR_STATES_H_RICH',\
+                    'STAR_STATES_HE_RICH'}
         totest_elements = set(dir(totest))
         missing_in_test = elements - totest_elements
         assert len(missing_in_test) == 0, "There are missing objects in "\

--- a/posydon/unit_tests/utils/test_common_functions.py
+++ b/posydon/unit_tests/utils/test_common_functions.py
@@ -340,7 +340,7 @@ class TestValues:
 
     def test_value_BURNING_STATES(self):
         for v in ["Core_H_burning", "Core_He_burning", "Shell_H_burning",\
-                  "Central_He_depleted", "Central_C_depleted"]:
+                  "Core_He_depleted", "Core_C_depleted"]:
             # check required values
             assert v in totest.BURNING_STATES, "missing entry"
 
@@ -1398,10 +1398,10 @@ class TestFunctions:
                                     rich = "stripped_He"
                                 if ((cH1<=TCA) and (cHe4<=TCA) and\
                                     (cC12<=TCA)):
-                                    burn = "Central_C_depleted"
+                                    burn = "Core_C_depleted"
                                 elif ((cH1<=TCA) and (cHe4<=TCA) and\
                                       (cC12>TCA)):
-                                    burn = "Central_He_depleted"
+                                    burn = "Core_He_depleted"
                                 elif ((cH1>TCA) and (lgLH>LBT)):
                                     burn = "Core_H_burning"
                                 elif ((cH1>TCA) and (lgLH<=LBT)):

--- a/posydon/unit_tests/utils/test_common_functions.py
+++ b/posydon/unit_tests/utils/test_common_functions.py
@@ -1452,12 +1452,12 @@ class TestFunctions:
                  ("H-rich_Core_H_burning", totest.MT_CASE_A),\
                  ("H-rich_Core_He_burning", totest.MT_CASE_B),\
                  ("H-rich_Shell_H_burning", totest.MT_CASE_B),\
-                 ("H-rich_Central_He_depleted", totest.MT_CASE_C),\
-                 ("H-rich_Central_C_depleted", totest.MT_CASE_C),\
+                 ("H-rich_Core_He_depleted", totest.MT_CASE_C),\
+                 ("H-rich_Core_C_depleted", totest.MT_CASE_C),\
                  ("H-rich_undetermined", totest.MT_CASE_UNDETERMINED),\
                  ("stripped_He_Core_He_burning", totest.MT_CASE_BA),\
-                 ("stripped_He_Central_He_depleted", totest.MT_CASE_BB),\
-                 ("stripped_He_Central_C_depleted", totest.MT_CASE_BB),\
+                 ("stripped_He_Core_He_depleted", totest.MT_CASE_BB),\
+                 ("stripped_He_Core_C_depleted", totest.MT_CASE_BB),\
                  ("stripped_He_undetermined", totest.MT_CASE_UNDETERMINED),\
                  ("test_undetermined", totest.MT_CASE_UNDETERMINED)]
         for (ds, c) in tests:
@@ -1645,17 +1645,17 @@ class TestFunctions:
         star.co_core_mass_at_He_depletion = 0.5
         star.avg_c_in_c_core_at_He_depletion = 0.5
         for s in ["test", "H-rich_Core_H_burning", "H-rich_Core_He_burning",\
-                  "H-rich_Shell_H_burning", "H-rich_Central_C_depleted",\
+                  "H-rich_Shell_H_burning", "H-rich_Core_C_depleted",\
                   "H-rich_undetermined", "stripped_He_Core_He_burning",\
-                  "stripped_He_Central_C_depleted",\
+                  "stripped_He_Core_C_depleted",\
                   "stripped_He_undetermined"]:
             star.state_history = [s]
             totest.calculate_Patton20_values_at_He_depl(star)
             assert star.co_core_mass_at_He_depletion is None
             assert star.avg_c_in_c_core_at_He_depletion is None
         # examples: loop through star types with He depletion
-        tests = [("H-rich_Central_He_depleted", 0.1),\
-                 ("stripped_He_Central_He_depleted", 0.2)]
+        tests = [("H-rich_Core_He_depleted", 0.1),\
+                 ("stripped_He_Core_He_depleted", 0.2)]
         for (s, v) in tests:
             star.state_history = ["test", s, s]
             star.co_core_mass_history = [0.0, v, 1.0]

--- a/posydon/unit_tests/utils/test_gridutils.py
+++ b/posydon/unit_tests/utils/test_gridutils.py
@@ -333,7 +333,7 @@ class TestFunctions:
         return path
 
     @fixture
-    def out_path_C_depletion(self, tmp_path):
+    def out_path_C_depleted(self, tmp_path):
         # a temporary path of out file for testing
         # it contains 5 header lines and the statement of carbon depletion
         path = os.path.join(tmp_path, "out5.txt")
@@ -344,7 +344,7 @@ class TestFunctions:
         return path
 
     @fixture
-    def out_path_CE_C_depletion(self, tmp_path):
+    def out_path_CE_C_depleted(self, tmp_path):
         # a temporary path of out file for testing
         # it contains 5 header lines and the statement of entering CE and
         # carbon depletion
@@ -610,8 +610,8 @@ class TestFunctions:
                                      out_gz_path, out_path_CE,\
                                      out_path_strong_RLO,\
                                      out_path_CE_strong_RLO,\
-                                     out_path_C_depletion,\
-                                     out_path_CE_C_depletion):
+                                     out_path_C_depleted,\
+                                     out_path_CE_C_depleted):
         # missing argument
         with raises(TypeError, match="missing 1 required positional "\
                                      +"argument: 'output_file'"):
@@ -684,7 +684,7 @@ class TestFunctions:
                pd.DataFrame({'CE_flag': [1], 'result': ["CE_merger"],\
                              'Test': ["-"]}))
         # check carbon depletion: stable_MT_to_merger
-        out_table = totest.convert_output_to_table(out_path_C_depletion,\
+        out_table = totest.convert_output_to_table(out_path_C_depleted,\
                                                    binary_history_file=\
                                                    BH_path_tight_orbit,\
                                                    star1_history_file=H1_path,\
@@ -709,7 +709,7 @@ class TestFunctions:
                MESA_BH_data_tight_orbit['period_days'][-1]
         assert 'tmerge(Gyr)' in out_table.columns
         # check carbon depletion: no_interaction
-        out_table = totest.convert_output_to_table(out_path_CE_C_depletion,\
+        out_table = totest.convert_output_to_table(out_path_CE_C_depleted,\
                                                    column_names=["Test"])
         assert out_table.at[0, 'CE_flag'] == 1
         assert out_table.at[0, 'result'] == "no_interaction"
@@ -724,7 +724,7 @@ class TestFunctions:
         assert 'Porb_f(d)' not in out_table.columns
         assert 'tmerge(Gyr)' not in out_table.columns
         # check carbon depletion: CE_ejection_m
-        out_table = totest.convert_output_to_table(out_path_CE_C_depletion,\
+        out_table = totest.convert_output_to_table(out_path_CE_C_depleted,\
                                                    binary_history_file=\
                                                    BH_path_tight_orbit,\
                                                    column_names=["Test"])
@@ -739,7 +739,7 @@ class TestFunctions:
                MESA_BH_data_tight_orbit['period_days'][-1]
         assert 'tmerge(Gyr)' in out_table.columns
         # check carbon depletion: stable_MT_to_wide_binary
-        out_table = totest.convert_output_to_table(out_path_C_depletion,\
+        out_table = totest.convert_output_to_table(out_path_C_depleted,\
                                                    binary_history_file=\
                                                    BH_path_wide_orbit,\
                                                    column_names=["Test"])
@@ -754,7 +754,7 @@ class TestFunctions:
                MESA_BH_data_wide_orbit['period_days'][-1]
         assert 'tmerge(Gyr)' in out_table.columns
         # check carbon depletion: CE_ejection
-        out_table = totest.convert_output_to_table(out_path_CE_C_depletion,\
+        out_table = totest.convert_output_to_table(out_path_CE_C_depleted,\
                                                    binary_history_file=\
                                                    BH_path_wide_orbit,\
                                                    column_names=["Test"])

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -40,7 +40,7 @@ STATE_UNDETERMINED = "undetermined_evolutionary_state"
 # ALL POSSIBLE STAR STATES
 BURNING_STATES = ["Core_H_burning", "Core_He_burning",
                   "Shell_H_burning", "Central_He_depleted",
-                  "Central_C_depletion"]
+                  "Central_C_depleted"]
 RICHNESS_STATES = ["H-rich", "stripped_He", "accreted_He"]
 COMPACT_OBJECTS = ["WD", "NS", "BH","massless_remnant"]
 
@@ -1180,11 +1180,11 @@ def get_binary_state_and_event_and_mt_case(binary, interpolation_class=None,
     else:                                           # undetermined in any star
         result = ["undefined", None, 'None']
 
-    if ("Central_C_depletion" in state1
+    if ("Central_C_depleted" in state1
             or "Central_He_depleted" in state1
             or (gamma1 is not None and gamma1 >= 10.0)):    # WD formation
         result[1] = "CC1"
-    elif ("Central_C_depletion" in state2
+    elif ("Central_C_depleted" in state2
           or "Central_He_depleted" in state2
           or (gamma2 is not None and gamma2 >= 10.0)):      # WD formation
         result[1] = "CC2"
@@ -1440,7 +1440,7 @@ def infer_star_state(star_mass=None, surface_h1=None,
 
     if not (H_in_core or He_in_core):   # H and He are depleted
         if not C_in_core:
-            burning = "Central_C_depletion"
+            burning = "Central_C_depleted"
         else:
             burning = "Central_He_depleted"
         # from now on, either H or He in core
@@ -1506,13 +1506,13 @@ def infer_mass_transfer_case(rl_relative_overflow,
                 or "Shell_H_burning" in donor_state):
             return MT_CASE_B
         if ("Central_He_depleted" in donor_state
-                or "Central_C_depletion" in donor_state):
+                or "Central_C_depleted" in donor_state):
             return MT_CASE_C
     elif "stripped_He" in donor_state:
         if "Core_He_burning" in donor_state:
             return MT_CASE_BA
         if ("Central_He_depleted" in donor_state
-                or "Central_C_depletion" in donor_state):
+                or "Central_C_depleted" in donor_state):
             return MT_CASE_BB
     return MT_CASE_UNDETERMINED
 
@@ -2001,7 +2001,7 @@ def calculate_core_boundary(donor_mass,
         "H-rich_Core_He_burning",
         "H-rich_Central_He_depleted",
         "H-rich_Core_C_burning",
-        "H-rich_Central_C_depletion",
+        "H-rich_Central_C_depleted",
         "H-rich_non_burning",
         "accreted_He_Core_H_burning",
         "accreted_He_non_burning"
@@ -2011,7 +2011,7 @@ def calculate_core_boundary(donor_mass,
         'accreted_He_Core_He_burning',
         'stripped_He_Core_He_burning',
         'stripped_He_Central_He_depleted',
-        'stripped_He_Central_C_depletion',
+        'stripped_He_Central_C_depleted',
         'stripped_He_non_burning'
     ]
 

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -41,8 +41,8 @@ STATE_UNDETERMINED = "undetermined_evolutionary_state"
 
 # ALL POSSIBLE STAR STATES
 BURNING_STATES = ["Core_H_burning", "Core_He_burning",
-                  "Shell_H_burning", "Central_He_depleted",
-                  "Central_C_depleted"]
+                  "Shell_H_burning", "Core_He_depleted",
+                  "Core_C_depleted"]
 RICHNESS_STATES = ["H-rich", "stripped_He", "accreted_He"]
 COMPACT_OBJECTS = ["WD", "NS", "BH","massless_remnant"]
 
@@ -1182,12 +1182,12 @@ def get_binary_state_and_event_and_mt_case(binary, interpolation_class=None,
     else:                                           # undetermined in any star
         result = ["undefined", None, 'None']
 
-    if ("Central_C_depleted" in state1
-            or "Central_He_depleted" in state1
+    if ("Core_C_depleted" in state1
+            or "Core_He_depleted" in state1
             or (gamma1 is not None and gamma1 >= 10.0)):    # WD formation
         result[1] = "CC1"
-    elif ("Central_C_depleted" in state2
-          or "Central_He_depleted" in state2
+    elif ("Core_C_depleted" in state2
+          or "Core_He_depleted" in state2
           or (gamma2 is not None and gamma2 >= 10.0)):      # WD formation
         result[1] = "CC2"
 
@@ -1442,9 +1442,9 @@ def infer_star_state(star_mass=None, surface_h1=None,
 
     if not (H_in_core or He_in_core):   # H and He are depleted
         if not C_in_core:
-            burning = "Central_C_depleted"
+            burning = "Core_C_depleted"
         else:
-            burning = "Central_He_depleted"
+            burning = "Core_He_depleted"
         # from now on, either H or He in core
     elif H_in_core:                     # no matter what the He abundance is
         if burning_H:
@@ -1507,14 +1507,14 @@ def infer_mass_transfer_case(rl_relative_overflow,
         if ("Core_He_burning" in donor_state
                 or "Shell_H_burning" in donor_state):
             return MT_CASE_B
-        if ("Central_He_depleted" in donor_state
-                or "Central_C_depleted" in donor_state):
+        if ("Core_He_depleted" in donor_state
+                or "Core_C_depleted" in donor_state):
             return MT_CASE_C
     elif "stripped_He" in donor_state:
         if "Core_He_burning" in donor_state:
             return MT_CASE_BA
-        if ("Central_He_depleted" in donor_state
-                or "Central_C_depleted" in donor_state):
+        if ("Core_He_depleted" in donor_state
+                or "Core_C_depleted" in donor_state):
             return MT_CASE_BB
     return MT_CASE_UNDETERMINED
 
@@ -1711,7 +1711,7 @@ def get_i_He_depl(history):
                                      log_LHe=history['log_LHe'][i],
                                      log_Lnuc=history['log_Lnuc'][i],
                                      star_CO=False)
-            if "Central_He_depleted" in state:
+            if "Core_He_depleted" in state:
                 return i 
     return -1
 

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -32,6 +32,8 @@ from posydon.utils.limits_thresholds import (THRESHOLD_CENTRAL_ABUNDANCE,
     RL_RELATIVE_OVERFLOW_THRESHOLD, LG_MTRANSFER_RATE_THRESHOLD
 )
 from posydon.utils.interpolators import interp1d
+from posydon.binary_evol.flow_chart import (STAR_STATES_H_RICH,
+                                            STAR_STATES_HE_RICH)
 
 
 # Constants related to inferring star states
@@ -1994,26 +1996,6 @@ def calculate_core_boundary(donor_mass,
     """
     # the threshold of the elements that need to be high in the core
     core_element_high_fraction_definition = 0.1
-    # ENHANCEMENT: this list needs to be imported from e.g. flow_chart.py
-    STAR_STATES_H_RICH = [
-        "H-rich_Core_H_burning",
-        "H-rich_Shell_H_burning",
-        "H-rich_Core_He_burning",
-        "H-rich_Central_He_depleted",
-        "H-rich_Core_C_burning",
-        "H-rich_Central_C_depleted",
-        "H-rich_non_burning",
-        "accreted_He_Core_H_burning",
-        "accreted_He_non_burning"
-    ]
-    # ENHANCEMENT: this list needs to be imported from e.g. flow_chart.py
-    STAR_STATE_He = [
-        'accreted_He_Core_He_burning',
-        'stripped_He_Core_He_burning',
-        'stripped_He_Central_He_depleted',
-        'stripped_He_Central_C_depleted',
-        'stripped_He_non_burning'
-    ]
 
     if core_element_fraction_definition is not None:
         if ((donor_star_state in STAR_STATES_H_RICH)
@@ -2028,7 +2010,7 @@ def calculate_core_boundary(donor_mass,
                 element = np.add(profile['x_mass_fraction_H'],
                                  profile['y_mass_fraction_He'])
                 element_core = profile['z_mass_fraction_metals']
-        elif (donor_star_state in STAR_STATE_He
+        elif (donor_star_state in STAR_STATES_HE_RICH
               and 'x_mass_fraction_H' in profile.dtype.names
               and 'y_mass_fraction_He' in profile.dtype.names
               and 'z_mass_fraction_metals' in profile.dtype.names):

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -1741,15 +1741,15 @@ def calculate_Patton20_values_at_He_depl(star):
     co_core_mass_at_He_depletion = None
     avg_c_in_c_core_at_He_depletion = None
     if star.state_history is not None:
-        if ("H-rich_Central_He_depleted" in star.state_history):
+        if ("H-rich_Core_He_depleted" in star.state_history):
             i_He_depl = np.argmax(
-                np.array(star.state_history) == "H-rich_Central_He_depleted")
+                np.array(star.state_history) == "H-rich_Core_He_depleted")
             co_core_mass_at_He_depletion = star.co_core_mass_history[i_He_depl]
             avg_c_in_c_core_at_He_depletion = star.avg_c_in_c_core_history[
                 i_He_depl]
-        elif ("stripped_He_Central_He_depleted" in star.state_history):
+        elif ("stripped_He_Core_He_depleted" in star.state_history):
             i_He_depl = np.argmax(np.array(star.state_history)
-                                  == "stripped_He_Central_He_depleted")
+                                  == "stripped_He_Core_He_depleted")
             co_core_mass_at_He_depletion = star.co_core_mass_history[i_He_depl]
             avg_c_in_c_core_at_He_depletion = star.avg_c_in_c_core_history[
                 i_He_depl]

--- a/posydon/visualization/plot1D.py
+++ b/posydon/visualization/plot1D.py
@@ -563,13 +563,13 @@ class plot1D(object):
                 # the code does not work plus the majority of stars do not have
                 # the points in the EEPs
                 # end = np.logical_or(self.star_states[j] ==
-                #                     'H-rich_Central_C_depletion',
+                #                     'H-rich_Central_C_depleted',
                 #                     self.star_states[j]
-                #                     == 'stripped_He_Central_C_depletion')
+                #                     == 'stripped_He_Central_C_depleted')
                 # end_x = self.history[j]["log_Teff"][end]
                 # end_y = self.history[j]["log_L"][end]
                 # ax.plot(end_x, end_y, marker='o', markersize=10,
-                #         color=convention['H-rich_Central_C_depletion'][2])
+                #         color=convention['H-rich_Central_C_depleted'][2])
                 if j == 0:
                     custom_lines = []
                     custom_legend = []

--- a/posydon/visualization/plot1D.py
+++ b/posydon/visualization/plot1D.py
@@ -563,13 +563,13 @@ class plot1D(object):
                 # the code does not work plus the majority of stars do not have
                 # the points in the EEPs
                 # end = np.logical_or(self.star_states[j] ==
-                #                     'H-rich_Central_C_depleted',
+                #                     'H-rich_Core_C_depleted',
                 #                     self.star_states[j]
-                #                     == 'stripped_He_Central_C_depleted')
+                #                     == 'stripped_He_Core_C_depleted')
                 # end_x = self.history[j]["log_Teff"][end]
                 # end_y = self.history[j]["log_L"][end]
                 # ax.plot(end_x, end_y, marker='o', markersize=10,
-                #         color=convention['H-rich_Central_C_depleted'][2])
+                #         color=convention['H-rich_Core_C_depleted'][2])
                 if j == 0:
                     custom_lines = []
                     custom_legend = []

--- a/posydon/visualization/plot_defaults.py
+++ b/posydon/visualization/plot_defaults.py
@@ -391,19 +391,19 @@ DEFAULT_MARKERS_COLORS_LEGENDS = {
             ['s', 2, 'tab:red', 'H-rich shell H burning'],
         'H-rich_Core_C_burning':
             ['s', 2, 'tab:pink', 'H-rich core C burning'],
-        'H-rich_Central_C_depleted':
+        'H-rich_Core_C_depleted':
             ['s', 2, 'tab:brown', 'H-rich central C depletion'],
         'H-rich_Core_He_burning':
             ['s', 2, 'tab:blue', 'H-rich core He burning'],
-        'H-rich_Central_He_depleted':
+        'H-rich_Core_He_depleted':
             ['s', 2, 'tab:green', 'H-rich shell He burning'],
         'stripped_He_Core_He_burning':
             ['o', 2, 'tab:blue', 'stripped He-star core He burning'],
-        'stripped_He_Central_He_depleted':
+        'stripped_He_Core_He_depleted':
             ['o', 2, 'tab:green', 'stripped He-star shell He burning'],
         'stripped_He_Core_C_burning':
             ['o', 2, 'tab:pink', 'stripped He-star core C burning'],
-        'stripped_He_Central_C_depleted':
+        'stripped_He_Core_C_depleted':
             ['o', 2, 'tab:brown', 'stripped He-star C depletion'],
         'stripped_He_non_burning':
             ['o', 2, 'gray', 'stripped He-star non burning'],
@@ -433,21 +433,21 @@ DEFAULT_MARKERS_COLORS_LEGENDS = {
             ['s', 2, 'tab:red', 'H-rich shell H burning'],
         'H-rich_Core_C_burning':
             ['s', 2, 'tab:pink', 'H-rich core C burning'],
-        'H-rich_Central_C_depleted':
+        'H-rich_Core_C_depleted':
             ['s', 2, 'tab:brown', 'H-rich central C depletion'],
         'H-rich_Core_He_burning':
             ['s', 2, 'tab:blue', 'H-rich core He burning'],
-        'H-rich_Near_Central_C_depleted':
+        'H-rich_Near_Core_C_depleted':
             ['s', 2, 'tab:purple', 'H-rich near central C depletion'],
-        'H-rich_Central_He_depleted':
+        'H-rich_Core_He_depleted':
             ['s', 2, 'tab:green', 'H-rich shell He burning'],
         'stripped_He_Core_He_burning':
             ['o', 2, 'tab:blue', 'stripped He-star core He burning'],
-        'stripped_He_Central_He_depleted':
+        'stripped_He_Core_He_depleted':
             ['o', 2, 'tab:green', 'stripped He-star shell He burning'],
         'stripped_He_Core_C_burning':
             ['o', 2, 'tab:pink', 'stripped He-star core C burning'],
-        'stripped_He_Central_C_depleted':
+        'stripped_He_Core_C_depleted':
             ['o', 2, 'tab:brown', 'stripped He-star C depletion'],
         'stripped_He_non_burning':
             ['o', 2, 'gray', 'stripped He-star non burning'],

--- a/posydon/visualization/plot_defaults.py
+++ b/posydon/visualization/plot_defaults.py
@@ -391,7 +391,7 @@ DEFAULT_MARKERS_COLORS_LEGENDS = {
             ['s', 2, 'tab:red', 'H-rich shell H burning'],
         'H-rich_Core_C_burning':
             ['s', 2, 'tab:pink', 'H-rich core C burning'],
-        'H-rich_Central_C_depletion':
+        'H-rich_Central_C_depleted':
             ['s', 2, 'tab:brown', 'H-rich central C depletion'],
         'H-rich_Core_He_burning':
             ['s', 2, 'tab:blue', 'H-rich core He burning'],
@@ -403,7 +403,7 @@ DEFAULT_MARKERS_COLORS_LEGENDS = {
             ['o', 2, 'tab:green', 'stripped He-star shell He burning'],
         'stripped_He_Core_C_burning':
             ['o', 2, 'tab:pink', 'stripped He-star core C burning'],
-        'stripped_He_Central_C_depletion':
+        'stripped_He_Central_C_depleted':
             ['o', 2, 'tab:brown', 'stripped He-star C depletion'],
         'stripped_He_non_burning':
             ['o', 2, 'gray', 'stripped He-star non burning'],
@@ -433,11 +433,11 @@ DEFAULT_MARKERS_COLORS_LEGENDS = {
             ['s', 2, 'tab:red', 'H-rich shell H burning'],
         'H-rich_Core_C_burning':
             ['s', 2, 'tab:pink', 'H-rich core C burning'],
-        'H-rich_Central_C_depletion':
+        'H-rich_Central_C_depleted':
             ['s', 2, 'tab:brown', 'H-rich central C depletion'],
         'H-rich_Core_He_burning':
             ['s', 2, 'tab:blue', 'H-rich core He burning'],
-        'H-rich_Near_Central_C_depletion':
+        'H-rich_Near_Central_C_depleted':
             ['s', 2, 'tab:purple', 'H-rich near central C depletion'],
         'H-rich_Central_He_depleted':
             ['s', 2, 'tab:green', 'H-rich shell He burning'],
@@ -447,7 +447,7 @@ DEFAULT_MARKERS_COLORS_LEGENDS = {
             ['o', 2, 'tab:green', 'stripped He-star shell He burning'],
         'stripped_He_Core_C_burning':
             ['o', 2, 'tab:pink', 'stripped He-star core C burning'],
-        'stripped_He_Central_C_depletion':
+        'stripped_He_Central_C_depleted':
             ['o', 2, 'tab:brown', 'stripped He-star C depletion'],
         'stripped_He_non_burning':
             ['o', 2, 'gray', 'stripped He-star non burning'],


### PR DESCRIPTION
1. We have star states `*_He_depleted` and `*_C_depletion`. This changes it so all states are `*_depleted` for consistency.
2. Additionally, we have states `*_Core_burning` and `*_Central_depleted`. This renames `*_Central_depleted` to `*_Core_depleted` to have consistent naming.
3. Updates docs to reflect changes.

Also right now `calculate_core_boundary` in `common_functions.py` uses its own lists for `STAR_STATES_H_RICH` and `STAR_STATE_He`:

```
    # ENHANCEMENT: this list needs to be imported from e.g. flow_chart.py
    STAR_STATES_H_RICH = [
        "H-rich_Core_H_burning",
        "H-rich_Shell_H_burning",
        "H-rich_Core_He_burning",
        "H-rich_Central_He_depleted",
        "H-rich_Core_C_burning",
        "H-rich_Central_C_depleted",
        "H-rich_non_burning",
        "accreted_He_Core_H_burning",
        "accreted_He_non_burning"
    ]
    # ENHANCEMENT: this list needs to be imported from e.g. flow_chart.py
    STAR_STATE_He = [
        'accreted_He_Core_He_burning',
        'stripped_He_Core_He_burning',
        'stripped_He_Central_He_depleted',
        'stripped_He_Central_C_depleted',
        'stripped_He_non_burning'
    ]
```

These have been updated to import the existing lists from `flow_chart.py`, which are slightly different:

```
>>> print(STAR_STATES_H_RICH)
['H-rich_Core_H_burning', 'H-rich_Core_He_burning', 'H-rich_Shell_H_burning', 'H-rich_Central_He_depleted', 'H-rich_Shell_He_burning', 'H-rich_Core_C_burning', 'H-rich_Central_C_depleted', 'H-rich_non_burning', 'accreted_He_Core_H_burning', 'accreted_He_Shell_H_burning', 'accreted_He_non_burning']

>>> print(STAR_STATES_HE_RICH)
['H-rich_non_burning', 'accreted_He_non_burning', 'accreted_He_Core_He_burning', 'stripped_He_Core_He_burning', 'stripped_He_Central_He_depleted', 'stripped_He_Central_C_depleted', 'stripped_He_non_burning']
```

I'm not sure if this difference will have affected prior population runs.