### PR TITLE
Fix indent error caused by merge resolution

### DIFF
--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -759,8 +759,8 @@ class detached_step:
                             / (const.standard_cgrav * (interp1d[self.translate["mass"]](t[:-1]) \
                             * const.msol)**2))
     
-                            current = zero_negative_values([current], key)[0]
-                            history = zero_negative_values(history, key)
+                        current = zero_negative_values([current], key)[0]
+                        history = zero_negative_values(history, key)
 
                 elif (key in ["lg_mdot", "lg_wind_mdot"] and obj != binary):
                     if obj.co:


### PR DESCRIPTION
This just fixes an indent error I introduced when resolving a previous merge conflict.