### PR TITLE
[PATCH v2.0.5] General fixes for population saving, binary failed state storage, MESA grid single star user inlist functionality

### DIFF
--- a/bin/posydon-setup-grid
+++ b/bin/posydon-setup-grid
@@ -278,7 +278,7 @@ def find_inlist_from_scenario(source, gitcommit, system_type):
         / ! end of star1_controls namelist
 
         """)
-            mesa_inlists['star1_controls_user'] = special_single_star_user_inlist
+            mesa_inlists['star1_controls_special'] = special_single_star_user_inlist
         elif system_type == "CO-He_star" and mesa_inlists['single_star_grid']:
             inlists_location = '{0}/{1}/{2}/'.format(inlists_dir, 'r11701', system_type)
             print("Based on system_type {0} "

--- a/bin/posydon-setup-grid
+++ b/bin/posydon-setup-grid
@@ -317,7 +317,7 @@ def find_inlist_from_scenario(source, gitcommit, system_type):
         / / ! end of star_job namelist
 
         """)
-            mesa_inlists['star1_controls_user'].append(special_single_star_user_inlist)
+            mesa_inlists['star1_controls_special'].append(special_single_star_user_inlist)
 
     # change back to where I was
     os.chdir(where_am_i_now)

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "posydon" %}
-{% set version = "2.0.4" %}
+{% set version = "2.0.5" %}
 
 package:
   name: "{{ name|lower }}"

--- a/docs/_source/components-overview/pop_syn/binary_population.rst
+++ b/docs/_source/components-overview/pop_syn/binary_population.rst
@@ -196,7 +196,7 @@ Depending on the initialization parameters, the evolved population can be access
     first_binary = population.manager.binaries[0]
     print(first_binary)
 
-   Additionally you can show turn the binary into a history DataFrame or create a oneline summary DataFrame:
+  Additionally you can turn the binary into a history ``DataFrame`` or create a ``oneline`` summary ``DataFrame``:
 
   .. code-block:: python
 
@@ -213,7 +213,7 @@ Depending on the initialization parameters, the evolved population can be access
    .. code-block:: python
     
     from posydon.popsyn.synthetic_population import Population
-    population = Population('./population.h5')
+    population = Population('./batches/evolution.combined.h5')
 
 
 

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -689,6 +689,9 @@ class BinaryStar:
                                             extra_binary_dtypes_user=extra_binary_cols_dict,
                                             extra_S1_dtypes_user=extra_s1_cols_dict,
                                             extra_S2_dtypes_user=extra_s2_cols_dict)
+        
+        # remove any columns duplicated from user keys/full star properties
+        oneline_df = oneline_df.loc[:,~oneline_df.columns.duplicated()].copy()
 
         return oneline_df
 

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -632,8 +632,6 @@ class BinaryStar:
         """Convert binary into a single row DataFrame."""
         if history:
             bin_kwargs = kwargs.copy()
-            bin_kwargs['include_S1'] = False
-            bin_kwargs['include_S2'] = False
             output_df = self.to_df(**bin_kwargs)
             initial_final_data = output_df.values[[0, -1], :]  # first/last row
             col_names = list(output_df.columns)

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -514,7 +514,7 @@ class BinaryPopulation:
         oneline_min_itemsize = {key: val for key, val in
                                 ONELINE_MIN_ITEMSIZE.items()
                                 if key in oneline_cols}
-        mode = kwargs.get('mode', 'a')
+        mode = kwargs.get('mode', 'w')
         complib = kwargs.get('complib', 'zlib')
         complevel = kwargs.get('complevel', 9)
         

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -536,10 +536,10 @@ class BinaryPopulation:
                     oneline = pd.read_hdf(f, key='oneline')
                     
                     # split weight between single and binary stars
-                    ZAMS_mask = history["event"] == "ZAMS"
-                    singles_mask = history[ZAMS_mask]["state"] == "initially_single_star"
-                    filtered_data_single = history[ZAMS_mask][singles_mask]
-                    filtered_data_binaries = history[ZAMS_mask][~singles_mask]
+                    init_step_mask = ~history.index.duplicated(keep="first")  # indices that are NOT duplicates of the first
+                    singles_mask = history["state"] == "initially_single_star"
+                    filtered_data_single = history[init_step_mask & singles_mask]
+                    filtered_data_binaries = history[init_step_mask & ~singles_mask]
                     
                     simulated_mass_binaries += np.nansum(filtered_data_binaries[["S1_mass", "S2_mass"]].to_numpy())
                     simulated_mass_single += np.nansum(filtered_data_single[["S1_mass"]].to_numpy())
@@ -875,10 +875,10 @@ class PopulationManager:
             try:
 
                 # split weight between single and binary stars
-                ZAMS_mask = history_df["event"] == "ZAMS"
-                singles_mask = history_df[ZAMS_mask]["state"] == "initially_single_star"
-                filtered_data_single = history_df[ZAMS_mask][singles_mask]
-                filtered_data_binaries = history_df[ZAMS_mask][~singles_mask]
+                init_step_mask = ~history_df.index.duplicated(keep="first") # indices that are NOT duplicates of the first
+                singles_mask = history_df["state"] == "initially_single_star"
+                filtered_data_single = history_df[init_step_mask & singles_mask]
+                filtered_data_binaries = history_df[init_step_mask & ~singles_mask]
 
                 simulated_mass_binaries += np.nansum(filtered_data_binaries[["S1_mass", "S2_mass"]].to_numpy())
                 simulated_mass_single += np.nansum(filtered_data_single[["S1_mass"]].to_numpy())

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -432,7 +432,7 @@ class BinaryPopulation:
                 self.manager.remove(self.manager.binaries.copy())
 
         # save by either combining dump files if optimize_ram = True...
-        if (optimize_ram and not breakdown_to_df):
+        if optimize_ram:
             # combining files
             if self.JOB_ID is None and self.comm is None:
                 self.combine_saved_files(os.path.join(temp_directory,
@@ -444,8 +444,8 @@ class BinaryPopulation:
                                  f"evolution.combined.{self.rank}.h5"),
                     filenames, mode = "w")
 
-        # ...or just save the population to a single file (if breakdown_to_df = False)
-        elif (not breakdown_to_df):
+        # ...or just save the population to a single file
+        else:
             if self.JOB_ID is None and self.comm is None:
                 self.manager.save(os.path.join(temp_directory,
                                                "evolution.combined.h5"),

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -688,6 +688,8 @@ class PopulationManager:
 
     def to_df(self, selection_function=None, **kwargs):
         """Convert all binaries to dataframe."""
+
+        kwargs = {**self.kwargs, **kwargs}
         
         if len(self.binaries) == 0 and len(self.history_dfs) == 0:
             return
@@ -709,6 +711,9 @@ class PopulationManager:
 
     def to_oneline_df(self, selection_function=None, **kwargs):
         """Convert all binaries to oneline dataframe."""
+
+        kwargs = {**self.kwargs, **kwargs}
+
         if len(self.binaries) == 0 and len(self.oneline_dfs) == 0:
             return
         is_callable = callable(selection_function)
@@ -725,7 +730,7 @@ class PopulationManager:
         if len(holder) > 0:
             return pd.concat(holder, axis=0, ignore_index=False)
 
-    def find_failed(self,):
+    def find_failed(self):
         """Find any failed binaries in the population."""
         if len(self) > 0:
             return [b for b in self if b.event == 'FAILED']
@@ -839,6 +844,9 @@ class PopulationManager:
         -------
         None
         """
+        
+        kwargs = {**self.kwargs, **kwargs}
+
         # needed for metadata
         self.metallicity = self.binary_generator.Z_div_Zsun
 

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -230,7 +230,7 @@ class BinaryPopulation:
         # combine kw defined at init and any passed here
         kw = {**self.kwargs, **kwargs}
         tqdm_bool = kw.get('tqdm', False)
-        breakdown_to_df_bool = kw.get('breakdown_to_df', True)
+        breakdown_to_df_bool = kw.get('breakdown_to_df', False)
         optimize_ram = kw.get('optimize_ram', False)
         from_hdf_bool = kw.get('from_hdf', False)
 
@@ -281,7 +281,7 @@ class BinaryPopulation:
 
         indices_for_iter = (tqdm(indices) if kwargs.get('tqdm', False)
                             else indices)
-        breakdown_to_df = kwargs.get('breakdown_to_df', True)
+        breakdown_to_df = kwargs.get('breakdown_to_df', False)
         optimize_ram = kwargs.get("optimize_ram", True)
         ram_per_cpu = kwargs.get("ram_per_cpu", None)
 
@@ -444,8 +444,8 @@ class BinaryPopulation:
                                  f"evolution.combined.{self.rank}.h5"),
                     filenames, mode = "w")
 
-        # ...or just save the population to a single file
-        else:
+        # ...or just save the population to a single file if breakdown_to_df is True
+        elif breakdown_to_df:
             if self.JOB_ID is None and self.comm is None:
                 self.manager.save(os.path.join(temp_directory,
                                                "evolution.combined.h5"),

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -215,7 +215,7 @@ class BinaryPopulation:
         indices : list, optional
             Custom binary indices to use. Default is range(number_of_binaries).
             If running with MPI, indices are split between processes if given.
-        breakdown_to_df : bool, True
+        breakdown_to_df : bool, False
             Breakdown a binary after evolution, converting to dataframe and
             removing the binary instance from memory.
         tqdm : bool, False

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -675,6 +675,9 @@ class PopulationManager:
         remove the BinaryStar instance from self.
 
         """
+
+        kwargs = {**self.kwargs, **kwargs}
+
         try:
             history = binary.to_df(**kwargs)
             self.history_dfs.append(history)

--- a/posydon/popsyn/synthetic_population.py
+++ b/posydon/popsyn/synthetic_population.py
@@ -211,13 +211,13 @@ class PopulationRunner:
         if self.verbose:
             print(f"Merging {len(tmp_files)} files...")
         
-        pop.combine_saved_files(fname, tmp_files)
+        pop.combine_saved_files(fname, tmp_files, mode='w')
 
         if self.verbose:
             print("Files merged!")
             print(f"Saved merged files to {fname}...")
             print(f"Removing files in {path_to_batch}...")
-            
+
         # remove files
         if len(os.listdir(path_to_batch)) == 0:
             os.rmdir(path_to_batch)

--- a/posydon/popsyn/synthetic_population.py
+++ b/posydon/popsyn/synthetic_population.py
@@ -36,6 +36,7 @@ import numpy as np
 import pandas as pd
 from tqdm import tqdm
 import os
+import shutil
 from matplotlib import pyplot as plt
 
 from posydon.utils.constants import Zsun
@@ -172,14 +173,14 @@ class PopulationRunner:
                 raise FileExistsError(f"The {pop.kwargs['temp_directory']} directory already exists! Please remove it or rename it before running the population.") 
             elif os.path.exists(pop.kwargs["temp_directory"]) and overwrite:
                 if self.verbose:
-                    print(f"Removing {pop.kwargs['temp_directory']} directory...")
-                os.removedirs(pop.kwargs["temp_directory"])    
+                    print(f"Removing pre-existing {pop.kwargs['temp_directory']} directory...")
+                shutil.rmtree(pop.kwargs["temp_directory"])    
                 
             pop.evolve(optimize_ram=True)
             if pop.comm is None:
-                self.merge_parallel_runs(pop)
+                self.merge_parallel_runs(pop, overwrite)
 
-    def merge_parallel_runs(self, pop):
+    def merge_parallel_runs(self, pop, overwrite=False):
         """Merge the parallel runs of the population.
 
         Parameters
@@ -188,11 +189,17 @@ class PopulationRunner:
             The binary population whose files have to be merged.
 
         """
-        if os.path.exists(convert_metallicity_to_string(pop.metallicity) + "_Zsun_population.h5"):
+        Zstr = convert_metallicity_to_string(pop.metallicity)
+        fname = Zstr + "_Zsun_population.h5"
+        if os.path.exists(fname) and not overwrite:
             raise FileExistsError(
-                f"{convert_metallicity_to_string(pop.metallicity)}_Zsun_population.h5 already exists!\n"
+                f"{Zstr}_Zsun_population.h5 already exists!\n"
                 +"Files were not merged. You can use PopulationRunner.merge_parallel_runs() to merge the files manually."
             )
+        elif os.path.exists(fname) and overwrite:
+            if self.verbose:
+                print(f"Removing pre-exisiting {fname}...")
+            os.remove(fname)                
                 
         path_to_batch = pop.kwargs["temp_directory"]
         
@@ -204,13 +211,13 @@ class PopulationRunner:
         if self.verbose:
             print(f"Merging {len(tmp_files)} files...")
         
-        pop.combine_saved_files(
-            convert_metallicity_to_string(pop.metallicity) + "_Zsun_population.h5",
-            tmp_files,
-        )
+        pop.combine_saved_files(fname, tmp_files)
+
         if self.verbose:
             print("Files merged!")
+            print(f"Saved merged files to {fname}...")
             print(f"Removing files in {path_to_batch}...")
+            
         # remove files
         if len(os.listdir(path_to_batch)) == 0:
             os.rmdir(path_to_batch)

--- a/posydon/popsyn/synthetic_population.py
+++ b/posydon/popsyn/synthetic_population.py
@@ -211,7 +211,7 @@ class PopulationRunner:
         if self.verbose:
             print(f"Merging {len(tmp_files)} files...")
         
-        pop.combine_saved_files(fname, tmp_files, mode='w')
+        pop.combine_saved_files(fname, tmp_files)
 
         if self.verbose:
             print("Files merged!")

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -1404,6 +1404,7 @@ def set_binary_to_failed(binary):
     '''
     binary.state = "ERR"
     binary.event = "FAILED"
+    binary.append_state()
 
 
 def infer_star_state(star_mass=None, surface_h1=None,


### PR DESCRIPTION
- Use the `history` instead of the `oneline` to get simulated mass, because the `oneline` does not always have masses in it. 
- Set default saving mode of `BinaryPopulation.PopulationManager.save` to `w`, not `a`.
- Also remove an extra `mode` keyword argument that is passed to `PopulationManager.save()`. This `kwarg` is searched for within the arbitrary `**kwargs`, so this extra kwarg prevents explicitly supplying your own `mode`.
- `PopulationManager.save` previously did not store the history columns, preventing functionalities like `loaded_population.history.select()` from working because there were no columns. Now the columns are saved and files saved this way can interacted with using e.g., `select()`.
- Appends the failed state to binary history in case of failed binaries.
- Fixes to the `overwrite` ability of `PopulationRunner.merge_parallel_runs()`.
- Prevents override of user supplied inlist controls in `posydon-setup-grid` when using `posydon` as the source

Tested with multi-metallicity population runs and sub-unity binary fractions to appropriately calculate and store the simulated mass.