### PR TITLE
[v2.1.3] Initialize `SingleStar` properties

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "posydon" %}
-{% set version = "2.1.2" %}
+{% set version = "2.1.3" %}
 
 package:
   name: "{{ name|lower }}"

--- a/posydon/binary_evol/DT/step_detached.py
+++ b/posydon/binary_evol/DT/step_detached.py
@@ -655,9 +655,9 @@ class detached_step:
                 # key  = 'effective_omega' # in rad/sec
                 # current = s.y[2][-1] / 3.1558149984e7
                 # history_of_attribute = s.y[2][:-1] / 3.1558149984e7
-                elif (key in ["surf_avg_omega_div_omega_crit"] and obj != binary):#primary):
-                    if obj.co: #primary.co:
-                        current = None
+                elif (key in ["surf_avg_omega_div_omega_crit"] and obj != binary):
+                    if obj.co:
+                        current = getattr(obj, key)
                         history = [current] * len(t[:-1])
 
                     else:
@@ -679,7 +679,7 @@ class detached_step:
 
                 elif (key in ["surf_avg_omega"] and obj != binary):
                     if obj.co:
-                        current = None
+                        current = getattr(obj, key)
                         history = [current] * len(t[:-1])
                     else:
                         current = interp1d["omega"][-1] / const.secyer
@@ -692,7 +692,7 @@ class detached_step:
                     s = binary.star_1 if "_1" in key[-2:] else binary.star_2
                     s_alt = binary.star_2 if "_1" in key[-2:] else binary.star_1
                     if s.state in ("BH", "NS", "WD","massless_remnant"):
-                        current = None
+                        current = getattr(obj, key)
                         history = [current] * len(t[:-1])
 
                     elif secondary == s:
@@ -764,7 +764,7 @@ class detached_step:
 
                 elif (key in ["lg_mdot", "lg_wind_mdot"] and obj != binary):
                     if obj.co:
-                        current = None
+                        current = getattr(obj, key)
                         history = [current] * len(t[:-1])
                     else:
                         if interp1d[self.translate[key]](t[-1]) == 0:

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -662,6 +662,8 @@ class MesaGridStep:
                             getattr(star, key_h).append(cb_bh[key_p][0])
                         if track_interpolation:
                             getattr(star, key_h).extend(cb_bh[key_p][:-1])
+                    elif key in ['state', 'lg_mdot']:
+                        continue
                     else:
                         if self.save_initial_conditions:
                             getattr(star, key_h).append(old_h[0])
@@ -915,6 +917,8 @@ class MesaGridStep:
                     elif key in ['lg_mdot', 'lg_system_mdot', 'lg_wind_mdot']:
                         key_p = POSYDON_TO_MESA['star'][key]+'_%d' % (k+1)
                         setattr(star, key, fv[key_p])
+                    elif key == 'state':
+                        continue
 
         # infer stellar states
         interpolation_class = self.classes['interpolation_class']

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -465,7 +465,7 @@ class MesaGridStep:
             length_binary_hist = len(cb_bh['age']) - 1
             length_star_hist = len(cb_hs[0]['center_he4']) - 1
             length_hist = min(length_binary_hist, length_star_hist)
-            empy_h = [None] * length_hist
+            empty_h = [None] * length_hist
             MESA_history_bug_fix = False
             if length_binary_hist != length_star_hist:
                 MESA_history_bug_fix = True
@@ -481,12 +481,13 @@ class MesaGridStep:
         # update properties
         for key in BINARYPROPERTIES:
             key_h = key + "_history"
+            old_h = [getattr(binary, key)] * length_hist
             if POSYDON_TO_MESA['binary'][key] is None:
                 setattr(binary, key, None)
                 if self.save_initial_conditions:
-                    getattr(binary, key_h).append(empy_h[0])
+                    getattr(binary, key_h).append(empty_h[0])
                 if track_interpolation:
-                    getattr(binary, key_h).extend(empy_h)
+                    getattr(binary, key_h).extend(empty_h)
             elif key == 'time':
                 key_p = POSYDON_TO_MESA['binary'][key]
                 current = getattr(self.binary, key)
@@ -533,13 +534,14 @@ class MesaGridStep:
         for k, star in enumerate(stars):
             for key in STARPROPERTIES:
                 key_h = key + "_history"
+                old_h = [getattr(star, key)] * length_hist
                 if not stars_CO[k]:
                     if POSYDON_TO_MESA['star'][key] is None:
                         setattr(star, key, None)
                         if self.save_initial_conditions:
-                            getattr(star, key_h).append(empy_h[0])
+                            getattr(star, key_h).append(empty_h[0])
                         if track_interpolation:
-                            getattr(star, key_h).extend(empy_h)
+                            getattr(star, key_h).extend(empty_h)
                     elif key == 'mass':
                         key_p = 'star_%d_mass' % (k+1)
                         setattr(star, key, cb_bh[key_p][-1])
@@ -560,9 +562,9 @@ class MesaGridStep:
                     elif key == 'profile':
                         setattr(star, key, cb_fps[k])
                         if self.save_initial_conditions:
-                            getattr(star, key_h).append(empy_h[0])
+                            getattr(star, key_h).append(empty_h[0])
                         if track_interpolation:
-                            getattr(star, key_h).extend(empy_h)
+                            getattr(star, key_h).extend(empty_h)
                     elif key in ['lg_mdot', 'lg_system_mdot', 'lg_wind_mdot']:
                         key_p = POSYDON_TO_MESA['star'][key]+'_%d' % (k+1)
                         setattr(star, key, cb_bh[key_p][-1])
@@ -654,17 +656,11 @@ class MesaGridStep:
                             getattr(star, key_h).append(cb_bh[key_p][0])
                         if track_interpolation:
                             getattr(star, key_h).extend(cb_bh[key_p][:-1])
-                    elif key in ['state', 'lg_mdot']:
-                        continue
-                    # DEBUG: commenting out
-                    #elif star.state == 'WD' and key in ['co_core_mass','he_core_mass','center_h1','center_he4','center_c12','center_n14','center_o16']:
-                    #    continue
                     else:
-                        setattr(star, key, None)
                         if self.save_initial_conditions:
-                            getattr(star, key_h).append(empy_h[0])
+                            getattr(star, key_h).append(old_h[0])
                         if track_interpolation:
-                            getattr(star, key_h).extend(empy_h)
+                            getattr(star, key_h).extend(old_h)
 
 
                 if track_interpolation:
@@ -735,16 +731,16 @@ class MesaGridStep:
             else:
                 # the history is going to be flushed in self.stop
                 # append None for a faster computation
-                state1_hist = empy_h
-                state2_hist = empy_h
+                state1_hist = empty_h
+                state2_hist = empty_h
                 self.flush_entries = len_binary_hist
                 # this is to prevent the flushin of the initial value which is
                 # appended twice
                 if self.save_initial_conditions:
                     self.flush_entries += 1
-                binary_state = empy_h
-                binary_event = empy_h
-                MT_case = empy_h
+                binary_state = empty_h
+                binary_event = empty_h
+                MT_case = empty_h
                 getattr(stars[0], "state_history").extend(state1_hist)
                 getattr(stars[1], "state_history").extend(state2_hist)
                 getattr(binary, "state_history").extend(binary_state)
@@ -909,12 +905,6 @@ class MesaGridStep:
                     elif key in ['lg_mdot', 'lg_system_mdot', 'lg_wind_mdot']:
                         key_p = POSYDON_TO_MESA['star'][key]+'_%d' % (k+1)
                         setattr(star, key, fv[key_p])
-                    elif key == 'state':
-                        continue
-                    elif star.state == 'WD' and key in ['co_core_mass','he_core_mass','center_h1','center_he4','center_c12','center_n14','center_o16']:
-                        continue
-                    else:
-                        setattr(star, key, None)
 
         # infer stellar states
         interpolation_class = self.classes['interpolation_class']

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -656,8 +656,9 @@ class MesaGridStep:
                             getattr(star, key_h).extend(cb_bh[key_p][:-1])
                     elif key in ['state', 'lg_mdot']:
                         continue
-                    elif star.state == 'WD' and key in ['co_core_mass','he_core_mass','center_h1','center_he4','center_c12','center_n14','center_o16']:
-                        continue
+                    # DEBUG: commenting out
+                    #elif star.state == 'WD' and key in ['co_core_mass','he_core_mass','center_h1','center_he4','center_c12','center_n14','center_o16']:
+                    #    continue
                     else:
                         setattr(star, key, None)
                         if self.save_initial_conditions:

--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -16,6 +16,7 @@ __authors__ = [
 
 import os
 import numpy as np
+import pandas as pd
 
 from posydon.interpolation.interpolation import psyTrackInterp
 from posydon.binary_evol.binarystar import BINARYPROPERTIES
@@ -328,7 +329,7 @@ class MesaGridStep:
             flip_stars(binary)
         max_MESA_sim_time = self.get_final_MESA_step_time()
 
-        if max_MESA_sim_time is None:
+        if pd.isna(max_MESA_sim_time):
             if self.flip_stars_before_step:
                 flip_stars(binary)
             binary.state = 'initial_RLOF'

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -182,13 +182,13 @@ class BinaryStar:
             setattr(self, key, val)
             setattr(self, key + '_history', [val])
 
-        if ~pd.isna(getattr(self.star_1, "mass")) and ~pd.isna(getattr(self.star_2, "mass")):
-            if pd.isna(getattr(self, "separation")) and ~pd.isna(getattr(self, "orbital_period")):
+        if pd.notna(getattr(self.star_1, "mass")) and pd.notna(getattr(self.star_2, "mass")):
+            if pd.isna(getattr(self, "separation")) and pd.notna(getattr(self, "orbital_period")):
                 setattr(self, "separation", 
                         orbital_separation_from_period(self.orbital_period, self.star_1.mass, self.star_2.mass))
                 setattr(self, "separation_history", [getattr(self, "separation")])
 
-            elif pd.isna(getattr(self, "orbital_period")) and ~pd.isna(getattr(self, "separation")):
+            elif pd.isna(getattr(self, "orbital_period")) and pd.notna(getattr(self, "separation")):
                 setattr(self, "orbital_period", 
                         orbital_period_from_separation(self.separation, self.star_1.mass, self.star_2.mass))
                 setattr(self, "orbital_period_history", [getattr(self, "orbital_period")])

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -165,17 +165,7 @@ class BinaryStar:
                                                              0.0,
                                                              0.0]))
             else:
-
-                dtype = BINARYPROPERTIES_DTYPES.get(item, '')
-                if dtype == 'float64' or dtype == 'int':
-                    default = np.nan
-                elif dtype == 'string':
-                    default = ''
-                else:
-                    # if we haven't defined a dtype for this prop
-                    default = None
-
-                setattr(self, item, binary_kwargs.pop(item, default))
+                setattr(self, item, binary_kwargs.pop(item, None))
 
             setattr(self, item + '_history', [getattr(self, item)])
 

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -165,19 +165,34 @@ class BinaryStar:
                                                              0.0,
                                                              0.0]))
             else:
-                setattr(self, item, binary_kwargs.pop(item, None))
+
+                dtype = BINARYPROPERTIES_DTYPES.get(item, '')
+                if dtype == 'float64' or dtype == 'int':
+                    default = np.nan
+                elif dtype == 'string':
+                    default = ''
+                else:
+                    # if we haven't defined a dtype for this prop
+                    default = None
+
+                setattr(self, item, binary_kwargs.pop(item, default))
+
             setattr(self, item + '_history', [getattr(self, item)])
 
         for key, val in binary_kwargs.items():
             setattr(self, key, val)
+            setattr(self, key + '_history', [val])
 
-        if getattr(self.star_1, "mass") is not None and getattr(self.star_2, "mass") is not None:
-            if getattr(self, "separation") is None and getattr(self, "orbital_period") is not None:
+        if ~pd.isna(getattr(self.star_1, "mass")) and ~pd.isna(getattr(self.star_2, "mass")):
+            if pd.isna(getattr(self, "separation")) and ~pd.isna(getattr(self, "orbital_period")):
                 setattr(self, "separation", 
                         orbital_separation_from_period(self.orbital_period, self.star_1.mass, self.star_2.mass))
-            elif getattr(self, "orbital_period") is None and getattr(self, "separation") is not None:
+                setattr(self, "separation_history", [getattr(self, "separation")])
+
+            elif pd.isna(getattr(self, "orbital_period")) and ~pd.isna(getattr(self, "separation")):
                 setattr(self, "orbital_period", 
                         orbital_period_from_separation(self.separation, self.star_1.mass, self.star_2.mass))
+                setattr(self, "orbital_period_history", [getattr(self, "orbital_period")])
 
         if not hasattr(self, 'inspiral_time'):
             self.inspiral_time = None

--- a/posydon/binary_evol/singlestar.py
+++ b/posydon/binary_evol/singlestar.py
@@ -15,6 +15,7 @@ __authors__ = [
     "Jeffrey Andrews <jeffrey.andrews@northwestern.edu>",
     "Emmanouil Zapartas <ezapartas@gmail.com>",
     "Devina Misra <devina.misra@unige.ch>",
+    "Seth Gossage <seth.gossage@northwestern.edu>"
 ]
 
 
@@ -22,6 +23,7 @@ import numpy as np
 import pandas as pd
 from posydon.utils.common_functions import check_state_of_star
 from posydon.grids.SN_MODELS import SN_MODELS
+from posydon.popsyn.io import STARPROPERTIES_DTYPES
 
 
 
@@ -133,7 +135,15 @@ class SingleStar:
         """
         # Set the initial star properties
         for item in STARPROPERTIES:
-            setattr(self, item, kwargs.pop(item, None))
+            # set default values when a kwarg is absent
+            dtype = STARPROPERTIES_DTYPES.get(item, '')
+            if dtype == 'float64' or dtype == 'int':
+                default = np.nan
+            elif dtype == 'string':
+                default = ''
+            else:
+                default = None
+            setattr(self, item, kwargs.pop(item, default))
             setattr(self, item + '_history', [getattr(self, item)])
         for item, val in kwargs.items():
             setattr(self, item, val)

--- a/posydon/binary_evol/singlestar.py
+++ b/posydon/binary_evol/singlestar.py
@@ -213,7 +213,7 @@ class SingleStar:
         elif (state == "BH") or (state == "NS") or (state == "WD"):
             default_core_X = np.nan
             default_core_Y = np.nan
-            default_log_R = CO_radius(kwargs.get('mass'), state)
+            default_log_R = np.log10(CO_radius(kwargs.get('mass'), state))
             # If a user gives a mass that does not comply with our 
             # CO star state logic, you can get weird stuff like a
             # BH or NS turning into a WD.

--- a/posydon/binary_evol/singlestar.py
+++ b/posydon/binary_evol/singlestar.py
@@ -269,8 +269,9 @@ class SingleStar:
 
             setattr(self, item + '_history', [getattr(self, item)])
 
-        for item, val in kwargs.items():
-            setattr(self, item, val)
+        for key, val in kwargs.items():
+            setattr(self, key, val)
+            setattr(self, key + '_history', [val])
 
         # store extra values in the star object without a history
 

--- a/posydon/binary_evol/singlestar.py
+++ b/posydon/binary_evol/singlestar.py
@@ -171,8 +171,8 @@ class SingleStar:
             default_core_X = X
             default_core_Y = Y
         # POST-MS
-        elif "_non_burning" in state:
-            # default TAMS, either accreted He or H-rich
+        elif "burning" in state and ("_Shell_" in state or "_non_" in state):
+            # default TAMS, either accreted He or H-rich, low core X, high Y
             default_core_X = THRESHOLD_CENTRAL_ABUNDANCE
             default_core_Y = 1.0 - default_core_X - Z
             if "stripped_He" in state:
@@ -225,6 +225,15 @@ class SingleStar:
                              star_CO=True)
             if state != inferred_state:
                 kwargs['state'] = inferred_state
+        else:
+            # some state not caught above, default HMS ZAMS
+            Pwarn(f"The initial state {state} was not caught in "
+                  "SingleStar.__init__() so it was initialized " \
+                  "as an H-rich_Core_H_burning star.", 
+                  "InitializationWarning")
+            default_core_X = X
+            default_core_Y = Y
+
 
         # Done setting initial values, assign everything to SingleStar next
 

--- a/posydon/binary_evol/singlestar.py
+++ b/posydon/binary_evol/singlestar.py
@@ -136,8 +136,6 @@ class SingleStar:
         **kwargs : dict
           List of initialization parameters for a star.
         """
-        # Set the initial star properties
-        non_numerical_props = ['state', 'profile']
 
         # initialize composition at least
         # this is needed to match to a star in 
@@ -169,34 +167,39 @@ class SingleStar:
             default_core_X = np.nan
             default_core_Y = np.nan
 
-        """
-                    if item in non_numerical_props:
-                        setattr(self, item, kwargs.pop(item, None))
-                    elif item == 'center_h1':
-                        # initialize surface and center h1
-                        setattr(self, item, kwargs.pop(item, default_core_X))
-                    elif item == 'center_he4':
-                        # initialize surface and center he4
-                        setattr(self, item, kwargs.pop(item, default_core_Y))
-                    elif 'core_mass' in item:
-                        # intiailize all core_mass values to 0
-                        # they are used in matching, but we will rely on 
-                        # abundances set above to find a good match
-                        setattr(self, item, kwargs.pop(item, 0.0))
-        """
-
-
         for item in STARPROPERTIES:
+ 
             # set default values when a kwarg is absent
-            dtype = STARPROPERTIES_DTYPES.get(item, '')
-            if dtype == 'float64' or dtype == 'int':
-                default = np.nan
-            elif dtype == 'string':
-                default = ''
+            # matching at least needs these initiailized to non-null values
+            if item == 'center_h1':
+                # initialize surface and center h1
+                setattr(self, item, kwargs.pop(item, default_core_X))
+            elif item == 'center_he4':
+                # initialize surface and center he4
+                setattr(self, item, kwargs.pop(item, default_core_Y))
+            elif 'core_mass' in item:
+                # intiailize all core_mass values to 0
+                # they are used in matching, but we will rely on 
+                # abundances set above to find a good match
+                setattr(self, item, kwargs.pop(item, 0.0))
+            elif item == 'metallicity':
+                # already set
+                pass
+
+            # everything else, set it according to stored dtype:
             else:
-                default = None
-            setattr(self, item, kwargs.pop(item, default))
+                dtype = STARPROPERTIES_DTYPES.get(item, '')
+                if dtype == 'float64' or dtype == 'int':
+                    default = np.nan
+                elif dtype == 'string':
+                    default = ''
+                else:
+                    # if we haven't defined a dtype for this prop
+                    default = None
+                setattr(self, item, kwargs.pop(item, default))
+
             setattr(self, item + '_history', [getattr(self, item)])
+
         for item, val in kwargs.items():
             setattr(self, item, val)
 

--- a/posydon/grids/post_processing.py
+++ b/posydon/grids/post_processing.py
@@ -245,18 +245,26 @@ def post_process_grid(grid, index=None, star_2_CO=True, SN_MODELS=SN_MODELS,
                     for val in [1, 10, 30, 'pure_He_star_10']:
                         EXTRA_COLUMNS[f'S{j+1}_{quantity}_{val}cent'].append(
                                             getattr(star, f'{quantity}_{val}cent'))
-                # aboundances
-                try:
-                    s_o = (1. - star.surface_h1 - star.surface_he4 - star.surface_c12
+                
+                # abundances
+                # now that np.nan is used as default, this won't throw TypeError
+                #try:
+                s_o = (1. - star.surface_h1 - star.surface_he4 - star.surface_c12
                            - star.surface_n14 - star.surface_o16)
-                    c_o = (1. - star.center_h1 - star.center_he4 - star.center_c12
+                c_o = (1. - star.center_h1 - star.center_he4 - star.center_c12
                            - star.center_n14 - star.center_o16)
-                except TypeError as ex:
+
+                if np.isnan(s_o):
                     s_o = 0.
+                    Pwarn(f'While accessing abundances in star_{j+1}, surface abundances'+\
+                      f'were NaN. We have set s_o to 0.', 
+                      "ReplaceValueWarning")
+                if np.isnan(c_o):
                     c_o = 0.
-                    print(ex)
-                    print(f'The error was raised by {grid.MESA_dirs[i]} '
-                           f'while accessing aboundances in star_{j+1}.')
+                    Pwarn(f'While accessing abundances in star_{j+1}, central abundances'+\
+                      f'were NaN. We have set c_o to 0.', 
+                      "ReplaceValueWarning")
+
                 EXTRA_COLUMNS['S%s_surface_other' % (j+1)].append(s_o)
                 EXTRA_COLUMNS['S%s_center_other' % (j+1)].append(c_o)
             else:

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -50,7 +50,6 @@ from posydon.popsyn.sample_from_file import (get_samples_from_file,
 from posydon.popsyn.defaults import default_kwargs
 
 from posydon.popsyn.io import binarypop_kwargs_from_ini
-from posydon.utils.constants import Zsun
 from posydon.utils.posydonerror import POSYDONError
 from posydon.utils.posydonwarning import (Pwarn, Catch_POSYDON_Warnings)
 from posydon.utils.common_functions import (orbital_period_from_separation, orbital_separation_from_period, 

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -1061,31 +1061,12 @@ class BinaryGenerator:
 
         formation_time = output['time'].item()
         m1 = output['S1_mass'].item()
-        Z_div_Zsun = kwargs.get('metallicity', 1.)
-        zams_table = {2.: 2.915e-01,
-                      1.: 2.703e-01,
-                      0.45: 2.586e-01,
-                      0.2: 2.533e-01,
-                      0.1: 2.511e-01,
-                      0.01: 2.492e-01,
-                      0.001: 2.49e-01,
-                      0.0001: 2.49e-01}
-        
-        Z_div_Zsun = self.Z_div_Zsun
-        Z = Z_div_Zsun*Zsun
-        if Z_div_Zsun in zams_table.keys():
-            Y = zams_table[Z_div_Zsun]
-        else:
-            raise KeyError(f"{Z_div_Zsun} is a not defined metallicity")
-        X = 1. - Z - Y
         kick1 = output['S1_natal_kick_array'][0]
         
         star1_params = dict(
                 mass=m1,
                 state="H-rich_Core_H_burning",
-                metallicity=Z,
-                center_h1=X,
-                center_he4=Y,
+                metallicity=kwargs.get('metallicity', 1.0),
                 natal_kick_array=kick1,
             )
 
@@ -1110,9 +1091,7 @@ class BinaryGenerator:
             star2_params = dict(
                 mass=m2,
                 state="H-rich_Core_H_burning",
-                metallicity=Z,
-                center_h1=X,
-                center_he4=Y,
+                metallicity=kwargs.get('metallicity', 1.0),
                 natal_kick_array=kick2,
             )
         #If binary_fraction not default a initially single star binary is created.

--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -164,13 +164,10 @@
   absolute_import = None
     # if given, use an absolute filepath to user defined step:
     # ['<PATH_TO_PY_FILE>', '<NAME>']
-<<<<<<< HEAD
   record_matching = False
     # True, False
   verbose = False
     # True, False
-=======
->>>>>>> 0fb90735 (Jeff moe di stefanov2.1 (#648))
 
 [step_merged]
   import = ['posydon.binary_evol.DT.step_merged','MergedStep']
@@ -185,13 +182,10 @@
   absolute_import = None
     # if given, use an absolute filepath to user defined step:
     # ['<PATH_TO_PY_FILE>', '<NAME>']
-<<<<<<< HEAD
   record_matching = False
     # True, False
   verbose = False
     # True, False
-=======
->>>>>>> 0fb90735 (Jeff moe di stefanov2.1 (#648))
 
 [step_CE]
   import = ['posydon.binary_evol.CE.step_CEE', 'StepCEE']

--- a/posydon/popsyn/population_params_default.ini
+++ b/posydon/popsyn/population_params_default.ini
@@ -164,10 +164,13 @@
   absolute_import = None
     # if given, use an absolute filepath to user defined step:
     # ['<PATH_TO_PY_FILE>', '<NAME>']
+<<<<<<< HEAD
   record_matching = False
     # True, False
   verbose = False
     # True, False
+=======
+>>>>>>> 0fb90735 (Jeff moe di stefanov2.1 (#648))
 
 [step_merged]
   import = ['posydon.binary_evol.DT.step_merged','MergedStep']
@@ -182,10 +185,13 @@
   absolute_import = None
     # if given, use an absolute filepath to user defined step:
     # ['<PATH_TO_PY_FILE>', '<NAME>']
+<<<<<<< HEAD
   record_matching = False
     # True, False
   verbose = False
     # True, False
+=======
+>>>>>>> 0fb90735 (Jeff moe di stefanov2.1 (#648))
 
 [step_CE]
   import = ['posydon.binary_evol.CE.step_CEE', 'StepCEE']

--- a/posydon/unit_tests/grids/test_post_processing.py
+++ b/posydon/unit_tests/grids/test_post_processing.py
@@ -18,6 +18,7 @@ import h5py
 import json
 import os
 from posydon.utils.posydonwarning import InappropriateValueWarning,\
+                                         ReplaceValueWarning,\
                                          POSYDONWarning
 from posydon.grids.psygrid import PSyGrid
 from posydon.config import PATH_TO_POSYDON, PATH_TO_POSYDON_DATA
@@ -492,7 +493,13 @@ class TestFunctions:
         assert "The error was raised by" in output
         assert "in CEE_parameters_from_core_abundance_thresholds" in output
         assert "The exception was raised by" in output
-        assert "while accessing aboundances in star" in output
+        with warns(POSYDONWarning): 
+            with warns(ReplaceValueWarning, match="While accessing "
+                                                   +"abundances in star"):
+                MESA_dirs, EXTRA_COLUMNS = totest.post_process_grid(\
+                                            test_PSyGrid,\
+                                            verbose=True)
+                
         assert "in check_state_of_star(star_2) with IC=" in output
         # examples: single and verbose
         with warns(POSYDONWarning): # warnings from SN
@@ -506,10 +513,14 @@ class TestFunctions:
         check_EXTRA_COLUMNS_single(EXTRA_COLUMNS, 7, keys)
         assert "Error during" in output
         assert "core collapse prescrition!" in output
-        assert "The error was raised by" in output
         assert "in CEE_parameters_from_core_abundance_thresholds" in output
         assert "The exception was raised by" in output
-        assert "while accessing aboundances in star" in output
+        with warns(POSYDONWarning): 
+            with warns(ReplaceValueWarning, match="While accessing "
+                                                   +"abundances in star"):
+                MESA_dirs, EXTRA_COLUMNS = totest.post_process_grid(\
+                                            test_PSyGrid, single_star=True,\
+                                            verbose=True)
 
     def test_add_post_processed_quantities(self, grid, monkeypatch):
         def mock_add_column(colname, array, where="final_values",\

--- a/posydon/unit_tests/utils/test_common_functions.py
+++ b/posydon/unit_tests/utils/test_common_functions.py
@@ -1203,10 +1203,6 @@ class TestFunctions:
         with raises(TypeError, match="missing 1 required positional "\
                                      +"argument: 'binary'"):
             totest.get_binary_state_and_event_and_mt_case_array()
-        # bad input
-        with raises(TypeError, match="argument of type 'NoneType' is not "\
-                                     +"iterable"):
-            totest.get_binary_state_and_event_and_mt_case_array(binary)
         with raises(IndexError, match="list index out of range"):
             totest.get_binary_state_and_event_and_mt_case_array(binary, N=10)
         # examples: no binary
@@ -1694,17 +1690,14 @@ class TestFunctions:
         with raises(AttributeError, match="'NoneType' object has no "\
                                           +"attribute 'mass'"):
             totest.CEE_parameters_from_core_abundance_thresholds(None)
-        with raises(TypeError) as error_info:
-            totest.CEE_parameters_from_core_abundance_thresholds(star)
-        assert error_info.value.args[0] == "unsupported operand type(s) for "\
-                                           + "** or pow(): 'float' and "\
-                                           + "'NoneType'"
+
+        totest.CEE_parameters_from_core_abundance_thresholds(star)
+        assert np.isnan(star.m_core_CE_1cent)
         star.log_R = 0.0
         star.profile = np.array([(1.0), (1.0), (1.0)],\
                                 dtype=([('mass', 'f8')]))
-        with raises(TypeError, match="argument of type 'NoneType' is not "\
-                                     +"iterable"):
-            totest.CEE_parameters_from_core_abundance_thresholds(star)
+        
+        assert np.isnan(star.m_core_CE_1cent)
         # examples: missing state with profile and verbose
         star.state = "test_state"
         totest.CEE_parameters_from_core_abundance_thresholds(star,\
@@ -1744,7 +1737,7 @@ class TestFunctions:
                     assert np.isnan(getattr(star, attr))
                 elif (("stripped_He" in s) and ("pure_He" not in attr) and\
                       ("m_core" in attr)):
-                    assert getattr(star, attr) == star.mass
+                    assert np.isnan(getattr(star, attr)) and np.isnan(star.mass)
                 elif (("stripped_He" in s) and ("pure_He" not in attr) and\
                       ("r_core" in attr)):
                     assert getattr(star, attr) == 10 ** star.log_R

--- a/posydon/unit_tests/utils/test_common_functions.py
+++ b/posydon/unit_tests/utils/test_common_functions.py
@@ -1100,10 +1100,6 @@ class TestFunctions:
         with raises(TypeError, match="missing 1 required positional "\
                                      +"argument: 'binary'"):
             totest.get_binary_state_and_event_and_mt_case()
-        # bad input
-        with raises(TypeError, match="argument of type 'NoneType' is not "\
-                                     +"iterable"):
-            totest.get_binary_state_and_event_and_mt_case(binary)
         # examples: no binary
         assert totest.get_binary_state_and_event_and_mt_case(None) ==\
                [None, None, 'None']

--- a/posydon/unit_tests/utils/test_constants.py
+++ b/posydon/unit_tests/utils/test_constants.py
@@ -30,7 +30,7 @@ class TestElements:
                     'mn', 'mp', 'msol', 'pc', 'pi', 'planck_h', 'qe',\
                     'r_earth', 'r_jupiter', 'rad2a', 'rbohr', 'rhonuc',\
                     'rsol', 'secyer', 'semimajor_axis_jupiter', 'ssol',\
-                    'standard_cgrav', 'weinfre', 'weinlam'}
+                    'standard_cgrav', 'weinfre', 'weinlam', 'zams_table'}
         totest_elements = set(dir(totest))
         missing_in_test = elements - totest_elements
         assert len(missing_in_test) == 0, "There are missing objects in "\

--- a/posydon/unit_tests/utils/test_posydonwarning.py
+++ b/posydon/unit_tests/utils/test_posydonwarning.py
@@ -29,7 +29,7 @@ class TestElements:
                     'InterpolationWarning', 'MissingFilesWarning',\
                     'NoPOSYDONWarnings', 'OverwriteWarning', 'SFHModelWarning',\
                     'POSYDONWarning','Pwarn', 'ReplaceValueWarning',\
-                    'SetPOSYDONWarnings', 'ValueWarning',\
+                    'SetPOSYDONWarnings', 'ValueWarning', 'InitializationWarning',\
                     'UnsupportedModelWarning', '_CAUGHT_POSYDON_WARNINGS',\
                     '_Caught_POSYDON_Warnings', '_POSYDONWarning_subclasses',\
                     '_POSYDON_WARNINGS_REGISTRY', '__authors__',\
@@ -533,6 +533,21 @@ class TestUnsupportedModelWarning:
         assert isinstance(UnsupportedModelWarning,\
                           totest.UnsupportedModelWarning)
         assert UnsupportedModelWarning.message == ''
+
+class TestInitializationWarning:
+    @fixture
+    def StepWarning(self):
+        # initialize an instance of the class with defaults
+        return totest.InitializationWarning()
+
+    # test the UnsupportedModelWarning class
+    def test_init(self, InitializationWarning):
+        assert isroutine(InitializationWarning.__init__)
+        # check that the instance is of correct type and all code in the
+        # __init__ got executed: the elements are created and initialized
+        assert isinstance(InitializationWarning,\
+                          totest.InitializationWarning)
+        assert InitializationWarning.message == ''
 
 
 class Test_Caught_POSYDON_Warnings:

--- a/posydon/unit_tests/utils/test_posydonwarning.py
+++ b/posydon/unit_tests/utils/test_posydonwarning.py
@@ -536,7 +536,7 @@ class TestUnsupportedModelWarning:
 
 class TestInitializationWarning:
     @fixture
-    def StepWarning(self):
+    def InitializationWarning(self):
         # initialize an instance of the class with defaults
         return totest.InitializationWarning()
 

--- a/posydon/utils/common_functions.py
+++ b/posydon/utils/common_functions.py
@@ -1437,12 +1437,12 @@ def infer_star_state(star_mass=None, surface_h1=None,
                      log_LH=None, log_LHe=None, log_Lnuc=None, star_CO=False):
     """Infer the star state (corresponding to termination flags 2 and 3)."""
     if star_CO:
-        if ((star_mass is None) or (star_mass<=0)):
+        if ((pd.isna(star_mass)) or (star_mass<=0)):
             return "massless_remnant"
-        elif ((((surface_h1 is not None) and (surface_h1>0)) or
-               ((center_h1 is not None) and (center_h1>0)) or
-               ((center_he4 is not None) and (center_he4>0)) or
-               ((center_c12 is not None) and (center_c12>0)) or
+        elif ((((not pd.isna(surface_h1)) and (surface_h1>0)) or
+               ((not pd.isna(center_h1)) and (center_h1>0)) or
+               ((not pd.isna(center_he4)) and (center_he4>0)) or
+               ((not pd.isna(center_c12)) and (center_c12>0)) or
                (star_mass < STATE_NS_STARMASS_LOWER_LIMIT)) and
               (star_mass <= STATE_WD_STARMASS_UPPER_LIMIT)):
             return "WD"
@@ -1451,7 +1451,7 @@ def infer_star_state(star_mass=None, surface_h1=None,
         else:
             return "BH"
 
-    if surface_h1 is None:
+    if pd.isna(surface_h1):
         return STATE_UNDETERMINED
 
     rich_in = ("H-rich" if surface_h1 > THRESHOLD_HE_NAKED_ABUNDANCE

--- a/posydon/utils/constants.py
+++ b/posydon/utils/constants.py
@@ -60,6 +60,15 @@ rhonuc = 2.342e14                   # density of nucleus (g cm^3)
 # Solar age, L, and R values from Bahcall et al, ApJ 618 (2005) 1049-1056.
 
 Zsun = 0.0142                   # Asplund+09
+# Y abundances @ ZAMS given Aplund+09 scaling, w/ keys as Z/Zsun
+zams_table = {2.: 2.915e-01,
+              1.: 2.703e-01,
+              0.45: 2.586e-01,
+              0.2: 2.533e-01,
+              0.1: 2.511e-01,
+              0.01: 2.492e-01,
+              0.001: 2.49e-01,
+              0.0001: 2.49e-01}
 msol = 1.9892e33                # solar mass, gravitational not baryonic (g)
 rsol = 6.9598e10                # solar radius (cm)
 lsol = 3.8418e33                # solar luminosity (erg s^-1)

--- a/posydon/utils/posydonwarning.py
+++ b/posydon/utils/posydonwarning.py
@@ -124,6 +124,11 @@ class ValueWarning(POSYDONWarning):
     def __init__(self, message=''):
         super().__init__(message)
 
+class InitializationWarning(POSYDONWarning):
+    """Warnings related to intializing things."""
+    def __init__(self, message=''):
+        super().__init__(message)
+
 
 # All POSYDON warnings subclasses should be defined beforehand
 _POSYDONWarning_subclasses = {cls.__name__: cls for cls in\


### PR DESCRIPTION
Initialize star properties with null values.

In the course of `BinaryPopulation.evolve()`, these properties are initialized, however when evolving a `BinaryStar` outside of that framework, things can fail because the current `None` null value causes trouble with math operations, so this introduces `np.nan` where possible/appropriate as the new null value. So, if a user isn't careful to initialize certain things in `SingleStar` that are required by the track matching process, the evolution is likely to fail. This is moreso the case when creating binaries where the stars are either initially CO or evolved stars.

This is a cherry picked remake of [PR#613](https://github.com/POSYDON-code/POSYDON/pull/613).

- Implements `SingleStar` initialization in cases where the star's state is not `H-rich_Core_H_burning`. `SingleStar.__init__()` now sets initial values for `SingleStar` that can be used by `track_matcher` to find an initial model. Previously if e.g., `center_h1`, `center_he4`, `log_R`, `he_core_mass` were not set, the star could not match to an initial model and could not be evolved.
- Many of the `float64` data type star properties are now initialized with `np.nan`, rather than `None` to avoid arithmetic `TypeError` occuring.
- The unit tests had to to be modified because of the new null values -- previously related tests checked for `None`, which is no longer relevant.
- It is now possible to evolve a `BinaryStar` with stars from arbitrary states. like `NS`, `stripped_He_Core_He_burning`. However, it is possible for a user to give initial conditions for a CO that does not fit within our internal classifications for COs. The CO type is inferred at initialization, given the initial conditions and POSYDON's inferred state replaces the user's given state. This is to avoid e.g., a WD becoming a NS midway through evolution, simply because POSYDON checks the state and reassigns it. TODO: warn that this happens.
- Previously, the `_history` of `SingleStar` and `BinaryStar` properties were not properly updated during `__init__`. This has been fixed for properties in `STARPROPERTIES` and `BINARYPROPERTIES` and for those properties supplied by a user.
- In `step_mesa` and `step_detached`, most property histories of a CO would be reset to `None`. Now just the old values from the last step are used instead (which are often null values anyways, unless modified by a custom hook in a step).