### PR TITLE
[v2.0.6] Rescue script fix

### DIFF
--- a/bin/posydon-popsyn
+++ b/bin/posydon-popsyn
@@ -468,7 +468,7 @@ def check_batches(run_folder, metallicity, batch_folder_name):
         for batch_file in batch_files:
             file_name = os.path.basename(batch_file)
             if 'evolution.combined' in file_name:
-                idx_str = file_name.split('.')[-1]
+                idx_str = file_name.split('.')[-2]
                 found_indices.add(int(idx_str))
         
         missing_indices = set(range(expected_batch_count)) - found_indices

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "posydon" %}
-{% set version = "2.0.5" %}
+{% set version = "2.0.6" %}
 
 package:
   name: "{{ name|lower }}"


### PR DESCRIPTION
The rescue script was expecting the temporary batch files to end on their 'run' number. However, with PR #676 the `.h5` extension is added. This patch makes the rescue script grab the correct index again.
