### PR TITLE
Fix: posydon_github_root to skipped parameters

### DIFF
--- a/bin/posydon-setup-grid
+++ b/bin/posydon-setup-grid
@@ -920,6 +920,8 @@ def make_executables(mesa_extras, working_directory=os.getcwd()):
                     f.write('make -f {0}\n'.format(k))
                 elif 'mesa_dir' == k:
                     continue
+                elif 'posydon_github_root' == k:
+                    continue
                 else:
                     shutil.copy(v, working_directory)
 


### PR DESCRIPTION
I want to be able to use this parameter as part of the `mesa_extras` in the grid configuration files.
This can either be achieved by placing this parameter also in the `[mesa_extras]` section or creating a `[DEFAULT]` section and placing `posydon_github_root` there. 

Either way, `posydon_github_root` becomes part of the `[mesa_extras]` section and becomes one of the keys. It should be skipped, when one of the keys.

This is not the best fix, but at least allows `posydon_github_root` to be globally defined (since it's used in multiple section in the configuration file).


