### PR TITLE
[2.1.4] Fix massless remnant metallicity assignment

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "posydon" %}
-{% set version = "2.1.3" %}
+{% set version = "2.1.4" %}
 
 package:
   name: "{{ name|lower }}"

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -249,7 +249,7 @@ class SimulationProperties:
         # for every other step, give it a metallicity and load each step
         for name, tup in self.kwargs.items():
             if isinstance(tup, tuple):
-                step_kwargs = step_tup[1]
+                step_kwargs = tup[1]
                 metallicity = step_kwargs.get('metallicity', None)
                 self.load_a_step(name, tup, metallicity=metallicity, verbose=verbose)
 

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -249,7 +249,9 @@ class SimulationProperties:
         # for every other step, give it a metallicity and load each step
         for name, tup in self.kwargs.items():
             if isinstance(tup, tuple):
-                self.load_a_step(name, tup, metallicity, verbose=verbose)
+                step_kwargs = step_tup[1]
+                metallicity = step_kwargs.get('metallicity', None)
+                self.load_a_step(name, tup, metallicity=metallicity, verbose=verbose)
 
         # track that all steps have been loaded
         self.steps_loaded = True
@@ -293,9 +295,15 @@ class SimulationProperties:
             step_tup = simprop_kwargs_from_ini(from_ini, only=step_name)[step_name]
 
         if (metallicity is None) and (step_name not in ignore_for_met):
-            Pwarn(f"{step_name} not assigned a metallicity. Defaulting to Z = Zsun (solar).", 
-                    "MissingValueWarning")
-            metallicity = 1.0
+            step_kwargs = step_tup[1]
+            metallicity = step_kwargs.get('metallicity', None)
+            if metallicity is not None:
+                pass
+            # if still None:
+            else:
+                Pwarn(f"{step_name} not assigned a metallicity. Defaulting to Z = Zsun (solar).", 
+                        "MissingValueWarning")
+                metallicity = 1.0
 
         # This if should never trigger after __init__, unless the step is 
         # entirely new and non-standard

--- a/posydon/binary_evol/singlestar.py
+++ b/posydon/binary_evol/singlestar.py
@@ -226,7 +226,7 @@ class SingleStar:
             # This stays big after He core forms
             default_He_core_mass = kwargs.get('mass')
         # COMPACT OBJECT
-        elif (state == "BH") or (state == "NS") or (state == "WD"):
+        elif state in CO_states:
             default_core_X = np.nan
             default_core_Y = np.nan
             default_log_R = np.log10(CO_radius(kwargs.get('mass'), state))

--- a/posydon/binary_evol/singlestar.py
+++ b/posydon/binary_evol/singlestar.py
@@ -230,6 +230,7 @@ class SingleStar:
             default_core_X = np.nan
             default_core_Y = np.nan
             default_log_R = np.log10(CO_radius(kwargs.get('mass'), state))
+            default_He_core_mass = np.nan
             # If a user gives a mass that does not comply with our 
             # CO star state logic, you can get weird stuff like a
             # BH or NS turning into a WD.
@@ -242,7 +243,10 @@ class SingleStar:
             if state != inferred_state:
                 kwargs['state'] = inferred_state
         elif state == 'massless_remnant':
-            pass
+            default_core_X = np.nan
+            default_core_Y = np.nan
+            default_log_R = np.nan
+            default_He_core_mass = np.nan
         else:
             # some state not caught above, default HMS ZAMS
             Pwarn(f"The initial state {state} was not caught in "
@@ -275,7 +279,10 @@ class SingleStar:
                 if item == 'he_core_mass':
                     default_core_mass = default_He_core_mass 
                 else:
-                    default_core_mass = 0.0
+                    if state in CO_states:
+                        default_core_mass = 0.0
+                    else:
+                        default_core_mass = np.nan
 
                 setattr(self, item, kwargs.pop(item, default_core_mass))
             elif item == 'metallicity':

--- a/posydon/binary_evol/singlestar.py
+++ b/posydon/binary_evol/singlestar.py
@@ -241,6 +241,8 @@ class SingleStar:
                              star_CO=True)
             if state != inferred_state:
                 kwargs['state'] = inferred_state
+        elif state == 'massless_remnant':
+            pass
         else:
             # some state not caught above, default HMS ZAMS
             Pwarn(f"The initial state {state} was not caught in "

--- a/posydon/binary_evol/singlestar.py
+++ b/posydon/binary_evol/singlestar.py
@@ -148,23 +148,39 @@ class SingleStar:
 
         # (This only comes into play if a user doesn't set these)
         setattr(self, 'metallicity', kwargs.pop('metallicity', 1.0))
-        Z_div_Zsun = self.metallicity
-        if Z_div_Zsun in zams_table.keys():
-            Y = zams_table[Z_div_Zsun]
-        else:
-            raise KeyError(f"{Z_div_Zsun} is a not defined metallicity")
-        Z = Z_div_Zsun*Zsun        
-        X = 1.0 - Y - Z
-        LOW_ABUNDANCE = 1e-6
-        # a low/high value to guess with, seems to work well
-        LOW_LOGR_GUESS = 0.0
-        HIGH_LOGR_GUESS = 4.0
-
         state = kwargs.get('state', 'H-rich_Core_H_burning')
+        CO_states = ['massless_remnant', 'WD', 'NS', 'BH']
+        
+        if state in CO_states:
+            Z_div_Zsun = self.metallicity
+            Y = np.nan
+            Z = np.nan     
+            X = np.nan
+            LOW_ABUNDANCE = np.nan
+            # a low/high value to guess with, seems to work well
+            LOW_LOGR_GUESS = np.nan
+            HIGH_LOGR_GUESS = np.nan
+    
+            # start by guessing a smallish radius and no He core
+            default_log_R = np.nan
+            default_He_core_mass = np.nan
+        else:
+            Z_div_Zsun = self.metallicity
+            if Z_div_Zsun in zams_table.keys():
+                Y = zams_table[Z_div_Zsun]
+            else:
+                raise KeyError(f"{Z_div_Zsun} is a not defined metallicity")
+            Z = Z_div_Zsun*Zsun        
+            X = 1.0 - Y - Z
+            LOW_ABUNDANCE = 1e-6
+            # a low/high value to guess with, seems to work well
+            LOW_LOGR_GUESS = 0.0
+            HIGH_LOGR_GUESS = 4.0
 
-        # start by guessing a smallish radius and no He core
-        default_log_R = LOW_LOGR_GUESS
-        default_He_core_mass = 0.0
+            # start by guessing a smallish radius and no He core
+            default_log_R = LOW_LOGR_GUESS
+            default_He_core_mass = 0.0
+        
         # MAIN SEQUENCE
         if "Core_H_burning" in state:
             # default HMS ZAMS

--- a/posydon/binary_evol/singlestar.py
+++ b/posydon/binary_evol/singlestar.py
@@ -226,7 +226,7 @@ class SingleStar:
             # This stays big after He core forms
             default_He_core_mass = kwargs.get('mass')
         # COMPACT OBJECT
-        elif state in CO_states:
+        elif state in ['WD', 'NS', 'BH']:
             default_core_X = np.nan
             default_core_Y = np.nan
             default_log_R = np.log10(CO_radius(kwargs.get('mass'), state))

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -1119,6 +1119,7 @@ class BinaryGenerator:
                 history_verbose=self.kwargs.get("history_verbose", False)
             )
             star2_params = properties_massless_remnant()
+            star2_params.update(dict(metallicity=kwargs.get('metallicity', 1.0)))
 
 
         binary = BinaryStar(**binary_params,

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -1119,7 +1119,6 @@ class BinaryGenerator:
                 history_verbose=self.kwargs.get("history_verbose", False)
             )
             star2_params = properties_massless_remnant()
-            star2_params.update(dict(metallicity=kwargs.get('metallicity', 1.0)))
 
 
         binary = BinaryStar(**binary_params,


### PR DESCRIPTION
Massless remnants are given a null metallicity in BinaryPopulation which causes the new SingleStar initialization to fail. This edits the initialization to skip the check on metallicity for compact objects. It also adds more safeguards to make sure steps pick a metallicity.