### PR TITLE
[v2.1.5] Fix load_a_step user supplied metallicity functionality

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "posydon" %}
-{% set version = "2.1.4" %}
+{% set version = "2.1.5" %}
 
 package:
   name: "{{ name|lower }}"

--- a/posydon/binary_evol/simulationproperties.py
+++ b/posydon/binary_evol/simulationproperties.py
@@ -250,7 +250,7 @@ class SimulationProperties:
         for name, tup in self.kwargs.items():
             if isinstance(tup, tuple):
                 step_kwargs = tup[1]
-                metallicity = step_kwargs.get('metallicity', None)
+                metallicity = step_kwargs.get('metallicity', metallicity)
                 self.load_a_step(name, tup, metallicity=metallicity, verbose=verbose)
 
         # track that all steps have been loaded
@@ -296,7 +296,7 @@ class SimulationProperties:
 
         if (metallicity is None) and (step_name not in ignore_for_met):
             step_kwargs = step_tup[1]
-            metallicity = step_kwargs.get('metallicity', None)
+            metallicity = step_kwargs.get('metallicity', metallicity)
             if metallicity is not None:
                 pass
             # if still None:


### PR DESCRIPTION
Restores ability to give your own metallicity for `SimulationProperties.load_a_step()`