### PR TITLE
[fix] Change solver interval to align with the evolution time

### DIFF
--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -65,7 +65,6 @@ class DoubleCO(detached_step):
         #                         f"{self.res.message}")
         # contact event triggered
         if self.res.status == 1:
-            binary.time += self.res.t[-1]
             binary.eccentricity = 0.0
             binary.state = "contact"
             binary.event = "CO_contact"
@@ -92,7 +91,7 @@ class DoubleCO(detached_step):
                 res = solve_ivp(self.evo,
                                 events=self.evo.ev_contact,
                                 method="BDF",
-                            t_span=(0, self.max_time - t0),
+                            t_span=(t0, self.max_time),
                             y0=[a, e,
                                 secondary.omega0, primary.omega0],
                             rtol=1e-10,

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -65,7 +65,7 @@ class DoubleCO(detached_step):
         #                         f"{self.res.message}")
         # contact event triggered
         if self.res.status == 1:
-            binary.time = self.res.t[-1]
+            binary.time += self.res.t[-1]
             binary.eccentricity = 0.0
             binary.state = "contact"
             binary.event = "CO_contact"


### PR DESCRIPTION
Related to issue #794.

The time from the solver was not correctly added to the `binary.time`.
The solver here runs from 0 to max_time-binary.time.
This solution adds the final solver time to the binary.time

Alternative solution is to change the solver from binary.time -> max-time. This would be more in-line with the normal detached step.