### PR TITLE
[fix] plot grid slice of `termination_flag_1` without z_var_str

### DIFF
--- a/posydon/visualization/plot2D.py
+++ b/posydon/visualization/plot2D.py
@@ -633,6 +633,63 @@ class plot2D(object):
                                   'likely all values are NaN.',
                                   "InappropriateValueWarning")
                     sc_last = sc
+                else:
+                    # Plot with default color when z_var is None and color is None
+                    if self.slice_at_RLO:
+                        for i in range(len(self.x_var[selection])):
+                            if not isinstance(self.x_var_oRLO[selection][i],
+                                              float):
+                                if not any(
+                                    pd.isna(self.x_var_oRLO[selection][i])
+                                ) and not any(pd.isna(
+                                        self.y_var_oRLO[selection][i])):
+                                    plt.plot(
+                                        self.x_var[selection][i],
+                                        self.y_var[selection][i],
+                                        marker=".",
+                                        color="black",
+                                    )
+                                    plt.plot(
+                                        self.x_var_oRLO[selection][i],
+                                        self.y_var_oRLO[selection][i],
+                                        color="black",
+                                    )
+                                sc = ax.scatter(
+                                    self.x_var_oRLO[selection][i][-1],
+                                    self.y_var_oRLO[selection][i][-1],
+                                    marker=self.MARKERS_COLORS_LEGENDS[
+                                        flag][0],
+                                    linewidths=self.MARKERS_COLORS_LEGENDS[
+                                        flag][1],
+                                    c='gray',
+                                    s=self.marker_size,
+                                )
+                            else:
+                                plt.plot(
+                                    self.x_var[selection][i],
+                                    self.y_var[selection][i],
+                                    marker=".",
+                                    color="black",
+                                )
+                                sc = ax.scatter(
+                                    self.x_var[selection][i],
+                                    self.y_var[selection][i],
+                                    marker=self.MARKERS_COLORS_LEGENDS[
+                                        flag][0],
+                                    linewidths=self.MARKERS_COLORS_LEGENDS[
+                                        flag][1],
+                                    c='gray',
+                                    s=self.marker_size,
+                                )
+                    else:
+                        sc = ax.scatter(
+                            self.x_var[selection],
+                            self.y_var[selection],
+                            marker=self.MARKERS_COLORS_LEGENDS[flag][0],
+                            linewidths=self.MARKERS_COLORS_LEGENDS[flag][1],
+                            c='gray',
+                            s=self.marker_size,
+                        )
             # collect scatters for legend
             if self.MARKERS_COLORS_LEGENDS[flag][3] not in scatters_legend:
                 scatters.append(sc)


### PR DESCRIPTION
When no `z_var_str` is given, many entries in `termination_flag_1` are not plotted because their default plotting colour is `None`. This make it that these are still plotted but as grey squares.

We can also change the default colours for these values, if we prefer that.

# Plot before the change
<img width="2003" height="1624" alt="test_tf1_plot_BEFORE" src="https://github.com/user-attachments/assets/4de96e98-5022-4691-8c9b-ab2453857871" />

# Plot with this PR
<img width="2003" height="1624" alt="test_tf1_plot_AFTER" src="https://github.com/user-attachments/assets/34350907-3dd1-4a4c-8851-3c029f906492" />


Closes Issue #692 