### PR TITLE
[docs/enhancement/fix] Natal kick info + fixes a table

### DIFF
--- a/docs/_source/components-overview/pop_syn/single_star.rst
+++ b/docs/_source/components-overview/pop_syn/single_star.rst
@@ -119,7 +119,7 @@ Additional scalar properties are added during the evolution depending on which s
       * mean anomaly (radians)
 
   * - ``natal_kick_velocity``
-    - The natal kick velocity in km/s.
+    - The magnitude of the natal kick velocity in km/s.
   * - ``natal_kick_phi``
     - The natal kick azimuthal angle phi in radians.
   * - ``natal_kick_theta``

--- a/docs/_source/components-overview/pop_syn/single_star.rst
+++ b/docs/_source/components-overview/pop_syn/single_star.rst
@@ -103,20 +103,29 @@ The star properties are defined as follows
 Additional scalar properties are added during the evolution depending on which steps the star has undergone. These properties are not stored in the history.
 
 .. list-table:: Additional output
-   :header-rows: 1
-   :widths: 50 150
+  :header-rows: 1
+  :widths: 50 150
 
   * - Properties
     - Descriptions
   * - ``natal_kick_array``
     - | The natal kick array for the star if it has undergone a SN.
-      | contains:
+      | This has been replaced with the individual properties below.
+      | ``natal_kick_array`` contains:
 
-      * velocity
-      * theta
-      * phi
-      * mean anomaly
+      * velocity (km/s)
+      * azimuthal angle phi (radians)
+      * polar angle theta (radians)
+      * mean anomaly (radians)
 
+  * - ``natal_kick_velocity``
+    - The natal kick velocity in km/s.
+  * - ``natal_kick_phi``
+    - The natal kick azimuthal angle phi in radians.
+  * - ``natal_kick_theta``
+    - The natal kick polar angle theta in radians.
+  * - ``natal_kick_mean_anomaly``
+    - The natal kick mean anomaly in radians.
   * - ``SN_type``
     - The supernova type of the star.
   * - ``f_fb``


### PR DESCRIPTION
1. Fixes an issue with the "Additional Output" table rendering on the website.
2. Adds the unit + new values to the "Additional Output" table for the natal_kicks.
3. Flips the angles `phi` and `theta` in the list to represent the order the actual list used to be. $\phi$ used to be at index 1, and $\theta$ at 2. See here: https://github.com/POSYDON-code/POSYDON/blob/dd0429ba697800ba2554f084fc7d45ebdd4ff1fe/posydon/binary_evol/SN/step_SN.py#L1496-L1506