### PR TITLE
[fix] change solver interval

### DIFF
--- a/dev-tools/script_data/1Zsun_binaries_suite.py
+++ b/dev-tools/script_data/1Zsun_binaries_suite.py
@@ -19,7 +19,7 @@ from posydon.utils.common_functions import orbital_separation_from_period
 
 target_rows = 12
 line_length = 140
-columns_to_show = ['step_names', 'state', 'event', 'S1_state', 'S1_mass', 'S2_state', 'S2_mass', 'orbital_period']
+columns_to_show = ['step_names', 'state', 'event', 'S1_state', 'S1_mass', 'S2_state', 'S2_mass', 'orbital_period', 'time']
 
 def load_inlist(verbose):
 

--- a/dev-tools/script_data/1Zsun_binaries_suite.py
+++ b/dev-tools/script_data/1Zsun_binaries_suite.py
@@ -815,6 +815,20 @@ def evolve_binaries(verbose):
                         properties = sim_prop)
     evolve_binary(binary)
 
+    # BH + BH
+    star1 = SingleStar(**{'mass': 31.077951593283725,
+                        'state': 'H-rich_Core_H_burning',
+                        'natal_kick_array': [0.0, 1.9047595342945016, 0.7097181927314352, 2.892753852818733]})
+    star2 = SingleStar(**{'mass': 27.8239810278115,
+                        'state': 'H-rich_Core_H_burning',
+                        'natal_kick_array': [0.0, 4.004970175991886, 2.2544428565691472, 3.420828590003044]})
+
+    binary = BinaryStar(star1, star2,
+                        **{'time': 0.0, 'state': 'detached', 'event': 'ZAMS',
+                        'orbital_period': 27.429155057946318, 'eccentricity': 0.0},
+                        properties = sim_prop)
+    evolve_binary(binary)
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Evolve binaries for validation.')
     parser.add_argument('--verbose', '-v', action='store_true', default=False,

--- a/dev-tools/script_data/1Zsun_binaries_suite.py
+++ b/dev-tools/script_data/1Zsun_binaries_suite.py
@@ -759,6 +759,62 @@ def evolve_binaries(verbose):
                         properties = sim_prop)
     evolve_binary(binary)
 
+    ########################################
+    # double CO step
+    ########################################
+    # NS + WD example
+    star1 = SingleStar(**{'mass': 7.939736047577677,
+                        'state': 'H-rich_Core_H_burning',
+                        'natal_kick_array': [0.0, 0.0, 0.0, 0.0]})
+    star1 = SingleStar(**{'mass': 6.661421823348241,
+                        'state': 'H-rich_Core_H_burning',
+                        'natal_kick_array': [0.0, 0.0, 0.0, 0.0]})
+
+    binary = BinaryStar(star1, star2,
+                        **{'time': 0.0, 'state': 'detached', 'event': 'ZAMS',
+                        'orbital_period': 28.576933942881404, 'eccentricity': 0.0},
+                        properties = sim_prop)
+    evolve_binary(binary)
+    # BH + NS example
+    star1 = SingleStar(**{'mass': 22.69609546427504,
+                        'state': 'H-rich_Core_H_burning',
+                        'natal_kick_array': [0.0, 2.051704135150374, 1.73468853754093, 3.299716078528058]})
+    star2 = SingleStar(**{'mass': 16.39690317352072,
+                        'state': 'H-rich_Core_H_burning',
+                        'natal_kick_array': [0.0, 5.934599002039066, 2.4331072903106974, 1.9933166215820504]})
+
+    binary = BinaryStar(star1, star2,
+                        **{'time': 0.0, 'state': 'detached', 'event': 'ZAMS',
+                        'orbital_period': 70.37960820393167, 'eccentricity': 0.0},
+                        properties = sim_prop)
+    evolve_binary(binary)
+    # WD + WD example
+    star1 = SingleStar(**{'mass': 6.661421823348241,
+                        'state': 'H-rich_Core_H_burning',
+                        'natal_kick_array': [0.0, 0.0, 0.0, 0.0]})
+    star2 = SingleStar(**{'mass': 6.661421823348241,
+                        'state': 'H-rich_Core_H_burning',
+                        'natal_kick_array': [0.0, 0.0, 0.0, 0.0]})
+
+    binary = BinaryStar(star1, star2,
+                        **{'time': 0.0, 'state': 'detached', 'event': 'ZAMS',
+                        'orbital_period': 28.576933942881404, 'eccentricity': 0.0},
+                        properties = sim_prop)
+    evolve_binary(binary)
+    # NS + NS example
+    star1 = SingleStar(**{'mass': 16.458995075687447,
+                        'state': 'H-rich_Core_H_burning',
+                        'natal_kick_array': [0.0, 3.661376360771944, 0.7219969332243381, 4.919284439555057]})
+    star2 = SingleStar(**{'mass': 12.580980419413521,
+                        'state': 'H-rich_Core_H_burning',
+                        'natal_kick_array': [0.0, 4.944467687452352, 1.2845384190953326, 1.6806849171480245]})
+
+    binary = BinaryStar(star1, star2,
+                        **{'time': 0.0, 'state': 'detached', 'event': 'ZAMS',
+                        'orbital_period': 247.4244399689946, 'eccentricity': 0.0},
+                        properties = sim_prop)
+    evolve_binary(binary)
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Evolve binaries for validation.')
     parser.add_argument('--verbose', '-v', action='store_true', default=False,

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -92,11 +92,11 @@ class DoubleCO(detached_step):
                 res = solve_ivp(self.evo,
                                 events=self.evo.ev_contact,
                                 method="BDF",
-                            t_span=(t0, self.max_time),
+                            t_span=(0, self.max_time-t0),
                             y0=[a, e,
                                 secondary.omega0, primary.omega0],
-                            rtol=1e-6,
-                            atol=1e-9,
+                            rtol=1e-10,
+                            atol=1e-10,
                             dense_output=True)
 
             except Exception as e:
@@ -110,6 +110,9 @@ class DoubleCO(detached_step):
             e = res.y[1][-1]
             time_sol.append(res.t)
             sol.append(res)
+
+        # shift final time array of solution to account for previous binary lifetime
+        res.t += binary.time
 
         return res
 

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -66,6 +66,7 @@ class DoubleCO(detached_step):
         # contact event triggered
         if self.res.status == 1:
             binary.eccentricity = 0.0
+            binary.orbital_period = 0.0
             binary.state = "contact"
             binary.event = "CO_contact"
         # max time reached

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -94,8 +94,8 @@ class DoubleCO(detached_step):
                             t_span=(t0, self.max_time),
                             y0=[a, e,
                                 secondary.omega0, primary.omega0],
-                            rtol=1e-10,
-                            atol=1e-10,
+                            rtol=1e-6,
+                            atol=1e-9,
                             dense_output=True)
 
             except Exception as e:


### PR DESCRIPTION
With our change of integrator range from 0->max_time-t0 to t0->max_time,
we have increased the "numbers" involved in the solver.
We end up with systems getting close but not "solving" in step double_CO.
The system ends up in a loop close to CO_contact.

Changing the tolerances of in `double_CO` solve the issue. Additionally, I would suggest we change the final `orbital_period` to 0.0 when CO_contact occurs.

# Current main:

| event | time | state | S1_state | S2_state | S1_mass | S2_mass | orbital_period |
|-------|------|-------|----------|----------|---------|---------|----------------|
| ZAMS | 0.000000e+00 | detached | H-rich_Core_H_burning | H-rich_Core_H_burning | 7.939736 | 6.661422 | 28.576934 |
| CC1 | 4.515790e+07 | detached | stripped_He_Core_C_depleted | H-rich_Core_H_burning | 2.221293 | 6.763270 | 90.754663 |
| \<NA\> | 4.515790e+07 | detached | NS | H-rich_Core_H_burning | 1.296084 | 6.763270 | 115.071847 |
| oRLO2 | 5.724196e+07 | RLO2 | NS | H-rich_Shell_H_burning | 1.296084 | 6.950535 | 96.809886 |
| oCE2 | 5.724246e+07 | RLO2 | NS | H-rich_Shell_H_burning | 1.296094 | 6.564556 | 47.034104 |
| ... | ... | ... | ... | ... | ... | ... | ... |
| \<NA\> | 6.606830e+07 | detached | NS | WD | 1.406728 | 0.787347 | 0.000042 |
| \<NA\> | 6.606830e+07 | detached | NS | WD | 1.406728 | 0.787347 | 0.000042 |
| \<NA\> | 6.606830e+07 | detached | NS | WD | 1.406728 | 0.787347 | 0.000042 |
| \<NA\> | 6.606830e+07 | detached | NS | WD | 1.406728 | 0.787347 | 0.000042 |
| \<NA\> | 6.606830e+07 | detached | NS | WD | 1.406728 | 0.787347 | 0.000042 |


# version with changed solver tolerances:

event | time | state | S1_state | S2_state | S1_mass | S2_mass | orbital_period
-- | -- | -- | -- | -- | -- | -- | --
ZAMS | 0.000000e+00 | detached | H-rich_Core_H_burning | H-rich_Core_H_burning | 7.939736 | 6.661422 | 28.576934
CC1 | 4.515790e+07 | detached | stripped_He_Core_C_depleted | H-rich_Core_H_burning | 2.221293 | 6.763270 | 90.754663
<NA> | 4.515790e+07 | detached | NS | H-rich_Core_H_burning | 1.296084 | 6.763270 | 115.071847
oRLO2 | 5.724196e+07 | RLO2 | NS | H-rich_Shell_H_burning | 1.296084 | 6.950535 | 96.809886
oCE2 | 5.724246e+07 | RLO2 | NS | H-rich_Shell_H_burning | 1.296094 | 6.564556 | 47.034104
<NA> | 5.724246e+07 | detached | NS | stripped_He_non_burning | 1.296094 | 1.473505 | 0.063654
CC2 | 6.606830e+07 | detached | NS | stripped_He_Core_He_depleted | 1.406728 | 0.788686 | 0.098100
<NA> | 6.606830e+07 | detached | NS | WD | 1.406728 | 0.787347 | 0.098234
CO_contact | 1.794851e+08 | contact | NS | WD | 1.406728 | 0.787347 | 0.000024
END | 1.794851e+08 | contact | NS | WD | 1.406728 | 0.787347 | 0.000024

# version with forced orbital_period = 0.0

event | time | state | S1_state | S2_state | S1_mass | S2_mass | orbital_period
-- | -- | -- | -- | -- | -- | -- | --
ZAMS | 0.000000e+00 | detached | H-rich_Core_H_burning | H-rich_Core_H_burning | 7.939736 | 6.661422 | 28.576934
CC1 | 4.515790e+07 | detached | stripped_He_Core_C_depleted | H-rich_Core_H_burning | 2.221293 | 6.763270 | 90.754663
<NA> | 4.515790e+07 | detached | NS | H-rich_Core_H_burning | 1.296084 | 6.763270 | 115.071847
oRLO2 | 5.724196e+07 | RLO2 | NS | H-rich_Shell_H_burning | 1.296084 | 6.950535 | 96.809886
oCE2 | 5.724246e+07 | RLO2 | NS | H-rich_Shell_H_burning | 1.296094 | 6.564556 | 47.034104
<NA> | 5.724246e+07 | detached | NS | stripped_He_non_burning | 1.296094 | 1.473505 | 0.063654
CC2 | 6.606830e+07 | detached | NS | stripped_He_Core_He_depleted | 1.406728 | 0.788686 | 0.098100
<NA> | 6.606830e+07 | detached | NS | WD | 1.406728 | 0.787347 | 0.098234
CO_contact | 1.794851e+08 | contact | NS | WD | 1.406728 | 0.787347 | 0.000000
END | 1.794851e+08 | contact | NS | WD | 1.406728 | 0.787347 | 0.000000