### PR TITLE
[fix] Update OS matrix in install_extras.yml

### DIFF
--- a/.github/workflows/install_extras.yml
+++ b/.github/workflows/install_extras.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-13, macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest]
         python-version: ['3.11']  # can add more if we want to support
 
     steps:


### PR DESCRIPTION
Removed macOS 13 from the OS matrix in the workflow, because it's no longer supported.