### PR TITLE
[fix] Combine solver solution with time offset

### DIFF
--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -132,7 +132,9 @@ class DoubleCO(detached_step):
         else:
             output_solution = CombinedSolution()
             output_solution.t = np.concatenate([t0+t.t for t, t0 in zip(sol, time_sol)])
-            output_solution.y = np.hstack([s.y for s in sol])
+            combined_y = np.hstack([s.y for s in sol])
+            combined_y[0] = combined_y[0] * 100_000 / constants.Rsun
+            output_solution.y = combined_y
             output_solution.status = sol[-1].status
             output_solution.message = sol[-1].message
             output_solution.t_events = sol[-1].t_events

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -108,12 +108,22 @@ class DoubleCO(detached_step):
             time_sol.append(t0)
             sol.append(res)
 
+
+        class CombinedSolution:
+            pass
         # combine results from multiple solve_ivp calls if needed
         if len(sol) == 1:
-            output_solution = sol[0]
+            output_solution = CombinedSolution()
+            output_solution.t = sol[0].t + t0
+            output_solution.y = sol[0].y
+            output_solution.status = sol[0].status
+            output_solution.message = sol[0].message
+            output_solution.t_events = sol[0].t_events
+            output_solution.y_events = sol[0].y_events
+            output_solution.success = sol[0].success
+            output_solution.sol = lambda t: sol[0].sol(t - t0)
+
         else:
-            class CombinedSolution:
-                pass
             output_solution = CombinedSolution()
             output_solution.t = np.concatenate([t0+t.t for t, t0 in zip(sol, time_sol)])
             output_solution.y = np.hstack([s.y for s in sol])

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -52,10 +52,10 @@ class DoubleCO(detached_step):
 
         super().__call__(binary)
 
-        binary.separation = self.res.y[0][-1] * 100_000 / constants.Rsun
-        binary.orbital_period = orbital_period_from_separation(
-            binary.separation, binary.star_1.mass, binary.star_2.mass
-        )
+        #binary.separation = self.res.y[0][-1] * 100_000 / constants.Rsun
+        ##binary.orbital_period = orbital_period_from_separation(
+        #    binary.separation, binary.star_1.mass, binary.star_2.mass
+        #)
         binary.V_sys = binary.V_sys_history[-1]
 
         #if self.res.status == -1:
@@ -115,13 +115,19 @@ class DoubleCO(detached_step):
         if len(sol) == 1:
             output_solution = CombinedSolution()
             output_solution.t = sol[0].t + t0
-            output_solution.y = sol[0].y
+            output_solution.y = sol[0].y.copy()
+            output_solution.y[0] = output_solution.y[0] * 100_000 / constants.Rsun
             output_solution.status = sol[0].status
             output_solution.message = sol[0].message
             output_solution.t_events = sol[0].t_events
             output_solution.y_events = sol[0].y_events
             output_solution.success = sol[0].success
-            output_solution.sol = lambda t: sol[0].sol(t - t0)
+            # Wrap sol() to convert separation from km to Rsun
+            def wrapped_sol(t):
+                result = sol[0].sol(t - t0)
+                result[0] = result[0] * 100_000 / constants.Rsun
+                return result
+            output_solution.sol = wrapped_sol
 
         else:
             output_solution = CombinedSolution()
@@ -137,7 +143,9 @@ class DoubleCO(detached_step):
             def combined_sol(t):
                 for s, t0 in zip(sol, time_sol):
                     if t0 <= t <= t0 + s.t[-1]:
-                        return s.sol(t - t0)
+                        result = s.sol(t - t0)
+                        result[0] = result[0] * 100_000 / constants.Rsun
+                        return result
                 raise ValueError(f"Time {t} is out of bounds for the combined solution.")
 
             output_solution.sol = combined_sol

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -92,7 +92,7 @@ class DoubleCO(detached_step):
                                 method="BDF",
                                 t_span=(0, self.max_time-t0),
                                 y0=[a, e,
-                                secondary.omega0, primary.omega0],
+                                    secondary.omega0, primary.omega0],
                                 rtol=1e-10,
                                 atol=1e-10,
                                 dense_output=True)

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -88,14 +88,14 @@ class DoubleCO(detached_step):
         while status == -1 and n < 6:
             try:
                 res = solve_ivp(self.evo,
-                            events=self.evo.ev_contact,
-                            method="BDF",
-                            t_span=(0, self.max_time-t0),
-                            y0=[a, e,
-                            secondary.omega0, primary.omega0],
-                            rtol=1e-10,
-                            atol=1e-10,
-                            dense_output=True)
+                                events=self.evo.ev_contact,
+                                method="BDF",
+                                t_span=(0, self.max_time-t0),
+                                y0=[a, e,
+                                secondary.omega0, primary.omega0],
+                                rtol=1e-10,
+                                atol=1e-10,
+                                dense_output=True)
             except Exception as e:
                 set_binary_to_failed(binary)
                 raise NumericalError(f"SciPy encountered termination edge case while solving GR equations: {e}")

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -100,12 +100,12 @@ class DoubleCO(detached_step):
                 set_binary_to_failed(binary)
                 raise NumericalError(f"SciPy encountered termination edge case while solving GR equations: {e}")
 
+            time_sol.append(t0)
             t0 += res.t[-1]
             status = res.status
             n += 1
             a = res.y[0][-1]
             e = res.y[1][-1]
-            time_sol.append(t0)
             sol.append(res)
 
 

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -85,19 +85,17 @@ class DoubleCO(detached_step):
         a = binary.separation * constants.Rsun / 100_000
         e = binary.eccentricity
         status = -1
-
         while status == -1 and n < 6:
             try:
                 res = solve_ivp(self.evo,
-                                events=self.evo.ev_contact,
-                                method="BDF",
-                            t_span=(t0, self.max_time),
+                            events=self.evo.ev_contact,
+                            method="BDF",
+                            t_span=(0, self.max_time-t0),
                             y0=[a, e,
-                                secondary.omega0, primary.omega0],
+                            secondary.omega0, primary.omega0],
                             rtol=1e-10,
                             atol=1e-10,
                             dense_output=True)
-
             except Exception as e:
                 set_binary_to_failed(binary)
                 raise NumericalError(f"SciPy encountered termination edge case while solving GR equations: {e}")
@@ -107,11 +105,34 @@ class DoubleCO(detached_step):
             n += 1
             a = res.y[0][-1]
             e = res.y[1][-1]
-            time_sol.append(res.t)
+            time_sol.append(t0)
             sol.append(res)
 
-        return res
+        # combine results from multiple solve_ivp calls if needed
+        if len(sol) == 1:
+            output_solution = sol[0]
+        else:
+            class CombinedSolution:
+                pass
+            output_solution = CombinedSolution()
+            output_solution.t = np.concatenate([t0+t.t for t, t0 in zip(sol, time_sol)])
+            output_solution.y = np.hstack([s.y for s in sol])
+            output_solution.status = sol[-1].status
+            output_solution.message = sol[-1].message
+            output_solution.t_events = sol[-1].t_events
+            output_solution.y_events = sol[-1].y_events
+            output_solution.success = sol[-1].success
 
+            # dynamically create a combined sol method that can interpolate across the combined solution
+            def combined_sol(t):
+                for s, t0 in zip(sol, time_sol):
+                    if t0 <= t <= t0 + s.t[-1]:
+                        return s.sol(t - t0)
+                raise ValueError(f"Time {t} is out of bounds for the combined solution.")
+
+            output_solution.sol = combined_sol
+
+        return output_solution
 
 
 class double_CO_evolution(detached_evolution):
@@ -171,6 +192,12 @@ class double_CO_evolution(detached_evolution):
                 / (1 - e ** 2) ** (5 / 2) / a ** 4 / c ** 5
                 * (1 + (121 / 304) * e ** 2)
                 * constants.secyer)
+
+        # Sanitize output to prevent propagation of inf/NaN
+        if not np.isfinite(da_gr):
+            da_gr = 0.0
+        if not np.isfinite(de_gr):
+            de_gr = 0.0
 
         self.da += da_gr
         self.de += de_gr

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -52,10 +52,10 @@ class DoubleCO(detached_step):
 
         super().__call__(binary)
 
-        #binary.separation = self.res.y[0][-1] * 100_000 / constants.Rsun
-        ##binary.orbital_period = orbital_period_from_separation(
-        #    binary.separation, binary.star_1.mass, binary.star_2.mass
-        #)
+        binary.separation = self.res.y[0][-1] * 100_000 / constants.Rsun
+        binary.orbital_period = orbital_period_from_separation(
+            binary.separation, binary.star_1.mass, binary.star_2.mass
+        )
         binary.V_sys = binary.V_sys_history[-1]
 
         #if self.res.status == -1:
@@ -115,26 +115,19 @@ class DoubleCO(detached_step):
         if len(sol) == 1:
             output_solution = CombinedSolution()
             output_solution.t = sol[0].t + t0
-            output_solution.y = sol[0].y.copy()
-            output_solution.y[0] = output_solution.y[0] * 100_000 / constants.Rsun
+            output_solution.y = sol[0].y
             output_solution.status = sol[0].status
             output_solution.message = sol[0].message
             output_solution.t_events = sol[0].t_events
             output_solution.y_events = sol[0].y_events
             output_solution.success = sol[0].success
-            # Wrap sol() to convert separation from km to Rsun
-            def wrapped_sol(t):
-                result = sol[0].sol(t - t0)
-                result[0] = result[0] * 100_000 / constants.Rsun
-                return result
-            output_solution.sol = wrapped_sol
+            output_solution.sol = lambda t: sol[0].sol(t-t0)
+
 
         else:
             output_solution = CombinedSolution()
             output_solution.t = np.concatenate([t0+t.t for t, t0 in zip(sol, time_sol)])
-            combined_y = np.hstack([s.y for s in sol])
-            combined_y[0] = combined_y[0] * 100_000 / constants.Rsun
-            output_solution.y = combined_y
+            output_solution.y = np.hstack([s.y for s in sol])
             output_solution.status = sol[-1].status
             output_solution.message = sol[-1].message
             output_solution.t_events = sol[-1].t_events
@@ -145,9 +138,7 @@ class DoubleCO(detached_step):
             def combined_sol(t):
                 for s, t0 in zip(sol, time_sol):
                     if t0 <= t <= t0 + s.t[-1]:
-                        result = s.sol(t - t0)
-                        result[0] = result[0] * 100_000 / constants.Rsun
-                        return result
+                        return s.sol(t - t0)
                 raise ValueError(f"Time {t} is out of bounds for the combined solution.")
 
             output_solution.sol = combined_sol


### PR DESCRIPTION
For DCO we're doing multiple solves. We tried to implement a fix by changing the solver range to correctly account for the evolution time. However, this causes issues due to the scale differences in time that the equations evolve over. 
We were doing multiple iterations of `solve_ivp` to account for this time scale difference. The fix did not account for this and ends up causing systems within the `double_CO` step to fail. 

Here I re-implement the old method of solving the ODE's in multiple steps.
To propagate the changes to after the evolution in `step_detached`, I create a "fake" solution object combines the multiple solves into a single result object with similar attributes/functions as the original `solve_ivp` object.



