### PR TITLE
[fix] CO step solver time handling

### DIFF
--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -50,7 +50,9 @@ class DoubleCO(detached_step):
 
     def __call__(self, binary):
 
+        prior_time_hist = binary.time_history
         super().__call__(binary)
+        time_hist_after_evo = binary.time_history
 
         binary.V_sys = binary.V_sys_history[-1]
 
@@ -62,7 +64,8 @@ class DoubleCO(detached_step):
         # contact event triggered
         if self.res.status == 1:
             binary.time = self.res.t[-1] + self.res.time_sols[-1]
-            binary.time_history[-1] = self.res.t[-1] + self.res.time_sols[-1]
+            if len(time_hist_after_evo) - len(prior_time_hist) > 1:
+                binary.time_history[-1] = self.res.t[-1] + self.res.time_sols[-1]
             binary.eccentricity = 0.0
             binary.state = "contact"
             binary.event = "CO_contact"

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -50,9 +50,9 @@ class DoubleCO(detached_step):
 
     def __call__(self, binary):
 
-        prior_time_hist = binary.time_history
+        prior_tlen = len(binary.time_history)
         super().__call__(binary)
-        time_hist_after_evo = binary.time_history
+        tlen_after_evo = len(binary.time_history)
 
         binary.V_sys = binary.V_sys_history[-1]
 
@@ -64,7 +64,7 @@ class DoubleCO(detached_step):
         # contact event triggered
         if self.res.status == 1:
             binary.time = self.res.t[-1] + self.res.time_sols[-1]
-            if len(time_hist_after_evo) - len(prior_time_hist) > 1:
+            if tlen_after_evo - prior_tlen >= 1:
                 binary.time_history[-1] = self.res.t[-1] + self.res.time_sols[-1]
             binary.eccentricity = 0.0
             binary.state = "contact"

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -132,7 +132,9 @@ class DoubleCO(detached_step):
         else:
             output_solution = CombinedSolution()
             output_solution.t = np.concatenate([t0+t.t for t, t0 in zip(sol, time_sol)])
-            output_solution.y = np.hstack([s.y for s in sol])
+            combined_y = np.hstack([s.y for s in sol])
+            combined_y[0] = combined_y[0] * 100_000 / constants.Rsun
+            output_solution.y = combined_y
             output_solution.status = sol[-1].status
             output_solution.message = sol[-1].message
             output_solution.t_events = sol[-1].t_events

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -22,6 +22,9 @@ from posydon.utils.common_functions import (
 )
 from posydon.utils.posydonerror import NumericalError
 
+from decimal import Decimal
+from mpmath import mp, mpf
+
 
 def event(terminal, direction=0):
     """Return a helper function to set attributes for solve_ivp events."""
@@ -52,10 +55,6 @@ class DoubleCO(detached_step):
 
         super().__call__(binary)
 
-        binary.separation = self.res.y[0][-1] * 100_000 / constants.Rsun
-        binary.orbital_period = orbital_period_from_separation(
-            binary.separation, binary.star_1.mass, binary.star_2.mass
-        )
         binary.V_sys = binary.V_sys_history[-1]
 
         #if self.res.status == -1:
@@ -65,6 +64,8 @@ class DoubleCO(detached_step):
         #                         f"{self.res.message}")
         # contact event triggered
         if self.res.status == 1:
+            binary.time = self.res.t[-1] + self.res.time_sols[-1]
+            binary.time_history[-1] = self.res.t[-1] + self.res.time_sols[-1]
             binary.eccentricity = 0.0
             binary.state = "contact"
             binary.event = "CO_contact"
@@ -112,38 +113,107 @@ class DoubleCO(detached_step):
         class CombinedSolution:
             pass
         # combine results from multiple solve_ivp calls if needed
-        if len(sol) == 1:
-            output_solution = CombinedSolution()
-            output_solution.t = sol[0].t + t0
-            output_solution.y = sol[0].y
-            output_solution.status = sol[0].status
-            output_solution.message = sol[0].message
-            output_solution.t_events = sol[0].t_events
-            output_solution.y_events = sol[0].y_events
-            output_solution.success = sol[0].success
-            output_solution.sol = lambda t: sol[0].sol(t-t0)
 
+        output_solution = CombinedSolution()
+        output_solution.t = np.concatenate([s.t for s in sol])
+        output_solution.y = np.hstack([s.y for s in sol])
+        output_solution.status = sol[-1].status
+        output_solution.message = sol[-1].message
+        output_solution.t_events = sol[-1].t_events
+        output_solution.y_events = sol[-1].y_events
+        output_solution.success = sol[-1].success
+        output_solution.time_sols = time_sol
+        output_solution.time_arrs = [s.t for s in sol]
 
-        else:
-            output_solution = CombinedSolution()
-            output_solution.t = np.concatenate([t0+t.t for t, t0 in zip(sol, time_sol)])
-            output_solution.y = np.hstack([s.y for s in sol])
-            output_solution.status = sol[-1].status
-            output_solution.message = sol[-1].message
-            output_solution.t_events = sol[-1].t_events
-            output_solution.y_events = sol[-1].y_events
-            output_solution.success = sol[-1].success
+        # dynamically create a combined sol method that can interpolate across the combined solution
+        def combined_sol(t):
 
-            # dynamically create a combined sol method that can interpolate across the combined solution
-            def combined_sol(t):
-                for s, t0 in zip(sol, time_sol):
-                    if t0 <= t <= t0 + s.t[-1]:
-                        return s.sol(t - t0)
-                raise ValueError(f"Time {t} is out of bounds for the combined solution.")
+            t = np.array(t)
+            solutions = []
+            for time in t:
+                appended = False
+                for s in sol[::-1]:
+                    if 0 <= time <= s.t[-1]:
+                        solutions.append(s.sol(time))
+                        appended = True
+                        break
+                if not appended:
+                    raise ValueError(f"Time {t} is out of bounds for the combined solution.")
+                
+            solutions = np.array(solutions).T
 
-            output_solution.sol = combined_sol
+            # convert separation back from [km] to [Rsun]
+            solutions[0] *= 100_000 / constants.Rsun
+            
+            return solutions
+
+        output_solution.sol = combined_sol
 
         return output_solution
+    
+    def get_time_after_evo(self, binary):
+        """
+            After detached evolution, this uses the ODESolver result
+        to determine what the current time is.
+
+        Parameters
+        ----------
+        res : ODESolver object
+            This is the ODESolver object produced by SciPy's
+            solve_ivp function that contains calculated values
+            of the stars evolution through the detached step.
+
+        binary: BinaryStar object
+            A binary star object, containing the binary system's properties.
+
+        Returns
+        -------
+        t : float or array[float]
+            This is the time elapsed as a result of detached
+            evolution in years. This is a float unless the
+            user specifies a timestep (see `n_o_steps_history`
+            or `dt`) to use via the simulation properties ini
+            file, in which case it is an array.
+
+        """
+
+        def adjust_timepts(t):
+            # set last element to be same scale as final time point from solve_ivp
+            t[-1] = self.res.t[-1]
+            
+            # adjust each time point to proper scale for interpolants
+            for j, time in enumerate(t[:-1]):
+                #print(time)
+                for k, time_array in enumerate(self.res.time_arrs):
+                    if time <= max(time_array):
+                        # time is at the right scale, go to the next one
+                        t[j] = time
+                        break
+                    else:
+                        # shift to next timescale and search again
+                        time -= max(time_array)
+
+            return t
+
+        if self.dt is not None and self.dt > 0:
+            t = np.arange(0, self.res.t[-1] + self.res.time_sols[-1] - binary.time + self.dt/2.0, self.dt)[1:]
+            if t[-1] < self.res.t[-1] + self.res.time_sols[-1] - binary.time:
+                t = np.hstack([t, self.res.t[-1] + self.res.time_sols[-1] - binary.time])
+            t = adjust_timepts(t)
+                
+        elif (self.n_o_steps_history is not None and self.n_o_steps_history > 0):
+            t_step = (self.res.t[-1] + self.res.time_sols[-1] - binary.time) / self.n_o_steps_history
+            t = np.arange(0, self.res.t[-1] + self.res.time_sols[-1] - binary.time + t_step/2.0, t_step)[1:]
+
+            if t[-1] < self.res.t[-1] + self.res.time_sols[-1] - binary.time:
+                t = np.hstack([t, self.res.t[-1] + self.res.time_sols[-1] - binary.time])
+
+            t = adjust_timepts(t)
+
+        else:  # self.dt is None and self.n_o_steps_history is None
+            t = np.array([self.res.t[-1]])
+
+        return t
 
 
 class double_CO_evolution(detached_evolution):

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -8,7 +8,10 @@ __authors__ = [
 ]
 
 
+from decimal import Decimal
+
 import numpy as np
+from mpmath import mp, mpf
 from scipy.integrate import solve_ivp
 
 import posydon.utils.constants as constants
@@ -21,9 +24,6 @@ from posydon.utils.common_functions import (
     set_binary_to_failed,
 )
 from posydon.utils.posydonerror import NumericalError
-
-from decimal import Decimal
-from mpmath import mp, mpf
 
 
 def event(terminal, direction=0):
@@ -139,18 +139,18 @@ class DoubleCO(detached_step):
                         break
                 if not appended:
                     raise ValueError(f"Time {t} is out of bounds for the combined solution.")
-                
+
             solutions = np.array(solutions).T
 
             # convert separation back from [km] to [Rsun]
             solutions[0] *= 100_000 / constants.Rsun
-            
+
             return solutions
 
         output_solution.sol = combined_sol
 
         return output_solution
-    
+
     def get_time_after_evo(self, binary):
         """
             After detached evolution, this uses the ODESolver result
@@ -180,7 +180,7 @@ class DoubleCO(detached_step):
         def adjust_timepts(t):
             # set last element to be same scale as final time point from solve_ivp
             t[-1] = self.res.t[-1]
-            
+
             # adjust each time point to proper scale for interpolants
             for j, time in enumerate(t[:-1]):
                 #print(time)
@@ -200,7 +200,7 @@ class DoubleCO(detached_step):
             if t[-1] < self.res.t[-1] + self.res.time_sols[-1] - binary.time:
                 t = np.hstack([t, self.res.t[-1] + self.res.time_sols[-1] - binary.time])
             t = adjust_timepts(t)
-                
+
         elif (self.n_o_steps_history is not None and self.n_o_steps_history > 0):
             t_step = (self.res.t[-1] + self.res.time_sols[-1] - binary.time) / self.n_o_steps_history
             t = np.arange(0, self.res.t[-1] + self.res.time_sols[-1] - binary.time + t_step/2.0, t_step)[1:]

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -62,8 +62,9 @@ class DoubleCO(detached_step):
         # contact event triggered
         if self.res.status == 1:
             binary.time = self.res.real_time[-1]
-            for k, real_time in enumerate(self.res.real_time[::-1]):
-                binary.time_history[-(k+1)] = real_time
+            if len(self.res.real_time) > 1:
+                for k, real_time in enumerate(self.res.real_time[::-1]):
+                    binary.time_history[-(k+1)] = real_time
             binary.eccentricity = 0.0
             binary.state = "contact"
             binary.event = "CO_contact"

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -8,8 +8,6 @@ __authors__ = [
 ]
 
 
-from decimal import Decimal
-
 import numpy as np
 from mpmath import mp, mpf
 from scipy.integrate import solve_ivp

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -67,7 +67,7 @@ class DoubleCO(detached_step):
             num_new_times = tlen_after_evo - prior_tlen
             if num_new_times >= 1:
                 for i in range(num_new_times - 1):
-                    binary.time_history[prior_tlen + i] += binary.time_history[prior_tlen-1]
+                    binary.time_history[prior_tlen + i] = self.res.real_time[i]
             binary.time_history[-1] = self.res.t[-1] + self.res.time_sols[-1]
             binary.eccentricity = 0.0
             binary.state = "contact"
@@ -137,6 +137,9 @@ class DoubleCO(detached_step):
                 appended = False
                 for s in sol[::-1]:
                     if 0 <= time <= s.t[-1]:
+                        print("t = ", time)
+                        print("t_final = ", s.t[-1])
+                        print("a [Rsun] = ", s.sol(time)[0] * 100_000 / constants.Rsun)
                         solutions.append(s.sol(time))
                         appended = True
                         break
@@ -180,38 +183,44 @@ class DoubleCO(detached_step):
 
         """
 
-        def adjust_timepts(t):
-            # set last element to be same scale as final time point from solve_ivp
-            t[-1] = self.res.t[-1]
-
-            # adjust each time point to proper scale for interpolants
-            for j, time in enumerate(t[:-1]):
-                #print(time)
-                for k, time_array in enumerate(self.res.time_arrs):
-                    if time <= max(time_array):
-                        # time is at the right scale, go to the next one
-                        t[j] = time
-                        break
-                    else:
-                        # shift to next timescale and search again
-                        time -= max(time_array)
-
-            return t
-
         if self.dt is not None and self.dt > 0:
-            t = np.arange(0, self.res.t[-1] + self.res.time_sols[-1] - binary.time + self.dt/2.0, self.dt)[1:]
-            if t[-1] < self.res.t[-1] + self.res.time_sols[-1] - binary.time:
-                t = np.hstack([t, self.res.t[-1] + self.res.time_sols[-1] - binary.time])
-            t = adjust_timepts(t)
+
+            t = np.array([])
+            real_time = np.array([])
+            for k, time_arr in enumerate(self.res.time_arrs):
+                t_chunk = np.arange(time_arr[0], time_arr[-1] + self.dt/2.0, self.dt)[1:]
+
+                if len(t_chunk) == 0:
+                    continue
+
+                # ensure last element matches (rounding can mess things up for small numbers)
+                if t_chunk[-1] != time_arr[-1]:
+                    t_chunk[-1] = time_arr[-1]
+
+                t = np.hstack([t, t_chunk])
+                real_time = np.hstack([real_time, t_chunk + self.res.time_sols[k]])
+
+            if t[-1] != self.res.t[-1]:
+                t[-1] = self.res.t[-1]
+                real_time[-1] = self.res.t[-1] + self.res.time_sols[-1]
+            # store this for later
+            self.res.real_time = real_time
 
         elif (self.n_o_steps_history is not None and self.n_o_steps_history > 0):
-            t_step = (self.res.t[-1] + self.res.time_sols[-1] - binary.time) / self.n_o_steps_history
-            t = np.arange(0, self.res.t[-1] + self.res.time_sols[-1] - binary.time + t_step/2.0, t_step)[1:]
 
-            if t[-1] < self.res.t[-1] + self.res.time_sols[-1] - binary.time:
-                t = np.hstack([t, self.res.t[-1] + self.res.time_sols[-1] - binary.time])
+            t = np.array([])
+            real_time = np.array([])
+            for k, time_arr in enumerate(self.res.time_arrs):
+                t_step = (time_arr[-1] - time_arr[0]) / self.n_o_steps_history
+                t_chunk = np.arange(time_arr[0], time_arr[-1] + t_step/2.0, t_step)[1:]
 
-            t = adjust_timepts(t)
+                if t_chunk[-1] != time_arr[-1]:
+                    t_chunk[-1] = time_arr[-1]
+
+                t = np.hstack([t, t_chunk])
+                real_time = np.hstack([real_time, t_chunk + self.res.time_sols[k]])
+
+            self.res.real_time = real_time
 
         else:  # self.dt is None and self.n_o_steps_history is None
             t = np.array([self.res.t[-1]])

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -108,12 +108,22 @@ class DoubleCO(detached_step):
             time_sol.append(t0)
             sol.append(res)
 
+
+        class CombinedSolution:
+            pass
         # combine results from multiple solve_ivp calls if needed
         if len(sol) == 1:
-            output_solution = sol[0]
+            output_solution = CombinedSolution()
+            output_solution.t = sol[0].t + t0
+            output_solution.y = sol[0].y
+            output_solution.status = sol[0].status
+            output_solution.message = sol[0].message
+            output_solution.t_events = sol[0].t_events
+            output_solution.y_events = sol[0].y_events
+            output_solution.success = sol[0].success
+            output_solution.sol = lambda t: sol[0].sol(t - t0)
+
         else:
-            class CombinedSolution:
-                pass
             output_solution = CombinedSolution()
             output_solution.t = np.concatenate([t0+t.t for t, t0 in zip(sol, time_sol)])
             output_solution.y = np.hstack([s.y for s in sol])

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -22,9 +22,6 @@ from posydon.utils.common_functions import (
 )
 from posydon.utils.posydonerror import NumericalError
 
-from decimal import Decimal
-from mpmath import mp, mpf
-
 
 def event(terminal, direction=0):
     """Return a helper function to set attributes for solve_ivp events."""

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -52,10 +52,10 @@ class DoubleCO(detached_step):
 
         super().__call__(binary)
 
-        binary.separation = self.res.y[0][-1] * 100_000 / constants.Rsun
-        binary.orbital_period = orbital_period_from_separation(
-            binary.separation, binary.star_1.mass, binary.star_2.mass
-        )
+        #binary.separation = self.res.y[0][-1] * 100_000 / constants.Rsun
+        ##binary.orbital_period = orbital_period_from_separation(
+        #    binary.separation, binary.star_1.mass, binary.star_2.mass
+        #)
         binary.V_sys = binary.V_sys_history[-1]
 
         #if self.res.status == -1:
@@ -115,13 +115,19 @@ class DoubleCO(detached_step):
         if len(sol) == 1:
             output_solution = CombinedSolution()
             output_solution.t = sol[0].t + t0
-            output_solution.y = sol[0].y
+            output_solution.y = sol[0].y.copy()
+            output_solution.y[0] = output_solution.y[0] * 100_000 / constants.Rsun
             output_solution.status = sol[0].status
             output_solution.message = sol[0].message
             output_solution.t_events = sol[0].t_events
             output_solution.y_events = sol[0].y_events
             output_solution.success = sol[0].success
-            output_solution.sol = lambda t: sol[0].sol(t - t0)
+            # Wrap sol() to convert separation from km to Rsun
+            def wrapped_sol(t):
+                result = sol[0].sol(t - t0)
+                result[0] = result[0] * 100_000 / constants.Rsun
+                return result
+            output_solution.sol = wrapped_sol
 
         else:
             output_solution = CombinedSolution()
@@ -137,7 +143,9 @@ class DoubleCO(detached_step):
             def combined_sol(t):
                 for s, t0 in zip(sol, time_sol):
                     if t0 <= t <= t0 + s.t[-1]:
-                        return s.sol(t - t0)
+                        result = s.sol(t - t0)
+                        result[0] = result[0] * 100_000 / constants.Rsun
+                        return result
                 raise ValueError(f"Time {t} is out of bounds for the combined solution.")
 
             output_solution.sol = combined_sol

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -50,9 +50,7 @@ class DoubleCO(detached_step):
 
     def __call__(self, binary):
 
-        prior_tlen = len(binary.time_history)
         super().__call__(binary)
-        tlen_after_evo = len(binary.time_history)
 
         binary.V_sys = binary.V_sys_history[-1]
 
@@ -63,12 +61,9 @@ class DoubleCO(detached_step):
         #                         f"{self.res.message}")
         # contact event triggered
         if self.res.status == 1:
-            binary.time = self.res.t[-1] + self.res.time_sols[-1]
-            num_new_times = tlen_after_evo - prior_tlen
-            if num_new_times >= 1:
-                for i in range(num_new_times - 1):
-                    binary.time_history[prior_tlen + i] = self.res.real_time[i]
-            binary.time_history[-1] = self.res.t[-1] + self.res.time_sols[-1]
+            binary.time = self.res.real_time[-1]
+            for k, real_time in enumerate(self.res.real_time[::-1]):
+                binary.time_history[-(k+1)] = real_time
             binary.eccentricity = 0.0
             binary.state = "contact"
             binary.event = "CO_contact"
@@ -224,6 +219,7 @@ class DoubleCO(detached_step):
 
         else:  # self.dt is None and self.n_o_steps_history is None
             t = np.array([self.res.t[-1]])
+            self.res.real_time = t + self.res.time_sols[-1]
 
         return t
 

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -92,7 +92,7 @@ class DoubleCO(detached_step):
                                 method="BDF",
                                 t_span=(0, self.max_time-t0),
                                 y0=[a, e,
-                                secondary.omega0, primary.omega0],
+                                    secondary.omega0, primary.omega0],
                                 rtol=1e-10,
                                 atol=1e-10,
                                 dense_output=True)

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -64,8 +64,11 @@ class DoubleCO(detached_step):
         # contact event triggered
         if self.res.status == 1:
             binary.time = self.res.t[-1] + self.res.time_sols[-1]
-            if tlen_after_evo - prior_tlen >= 1:
-                binary.time_history[-1] = self.res.t[-1] + self.res.time_sols[-1]
+            num_new_times = tlen_after_evo - prior_tlen
+            if num_new_times >= 1:
+                for i in range(num_new_times - 1):
+                    binary.time_history[prior_tlen + i] += binary.time_history[prior_tlen-1]
+            binary.time_history[-1] = self.res.t[-1] + self.res.time_sols[-1]
             binary.eccentricity = 0.0
             binary.state = "contact"
             binary.event = "CO_contact"

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -88,14 +88,14 @@ class DoubleCO(detached_step):
         while status == -1 and n < 6:
             try:
                 res = solve_ivp(self.evo,
-                            events=self.evo.ev_contact,
-                            method="BDF",
-                            t_span=(0, self.max_time-t0),
-                            y0=[a, e,
-                            secondary.omega0, primary.omega0],
-                            rtol=1e-10,
-                            atol=1e-10,
-                            dense_output=True)
+                                events=self.evo.ev_contact,
+                                method="BDF",
+                                t_span=(0, self.max_time-t0),
+                                y0=[a, e,
+                                secondary.omega0, primary.omega0],
+                                rtol=1e-10,
+                                atol=1e-10,
+                                dense_output=True)
             except Exception as e:
                 set_binary_to_failed(binary)
                 raise NumericalError(f"SciPy encountered termination edge case while solving GR equations: {e}")

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -100,12 +100,12 @@ class DoubleCO(detached_step):
                 set_binary_to_failed(binary)
                 raise NumericalError(f"SciPy encountered termination edge case while solving GR equations: {e}")
 
+            time_sol.append(t0)
             t0 += res.t[-1]
             status = res.status
             n += 1
             a = res.y[0][-1]
             e = res.y[1][-1]
-            time_sol.append(t0)
             sol.append(res)
 
 

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -85,19 +85,17 @@ class DoubleCO(detached_step):
         a = binary.separation * constants.Rsun / 100_000
         e = binary.eccentricity
         status = -1
-
         while status == -1 and n < 6:
             try:
                 res = solve_ivp(self.evo,
-                                events=self.evo.ev_contact,
-                                method="BDF",
-                            t_span=(t0, self.max_time),
+                            events=self.evo.ev_contact,
+                            method="BDF",
+                            t_span=(0, self.max_time-t0),
                             y0=[a, e,
-                                secondary.omega0, primary.omega0],
+                            secondary.omega0, primary.omega0],
                             rtol=1e-10,
                             atol=1e-10,
                             dense_output=True)
-
             except Exception as e:
                 set_binary_to_failed(binary)
                 raise NumericalError(f"SciPy encountered termination edge case while solving GR equations: {e}")
@@ -107,11 +105,34 @@ class DoubleCO(detached_step):
             n += 1
             a = res.y[0][-1]
             e = res.y[1][-1]
-            time_sol.append(res.t)
+            time_sol.append(t0)
             sol.append(res)
 
-        return res
+        # combine results from multiple solve_ivp calls if needed
+        if len(sol) == 1:
+            output_solution = sol[0]
+        else:
+            class CombinedSolution:
+                pass
+            output_solution = CombinedSolution()
+            output_solution.t = np.concatenate([t0+t.t for t, t0 in zip(sol, time_sol)])
+            output_solution.y = np.hstack([s.y for s in sol])
+            output_solution.status = sol[-1].status
+            output_solution.message = sol[-1].message
+            output_solution.t_events = sol[-1].t_events
+            output_solution.y_events = sol[-1].y_events
+            output_solution.success = sol[-1].success
 
+            # dynamically create a combined sol method that can interpolate across the combined solution
+            def combined_sol(t):
+                for s, t0 in zip(sol, time_sol):
+                    if t0 <= t <= t0 + s.t[-1]:
+                        return s.sol(t - t0)
+                raise ValueError(f"Time {t} is out of bounds for the combined solution.")
+
+            output_solution.sol = combined_sol
+
+        return output_solution
 
 
 class double_CO_evolution(detached_evolution):
@@ -171,6 +192,12 @@ class double_CO_evolution(detached_evolution):
                 / (1 - e ** 2) ** (5 / 2) / a ** 4 / c ** 5
                 * (1 + (121 / 304) * e ** 2)
                 * constants.secyer)
+
+        # Sanitize output to prevent propagation of inf/NaN
+        if not np.isfinite(da_gr):
+            da_gr = 0.0
+        if not np.isfinite(de_gr):
+            de_gr = 0.0
 
         self.da += da_gr
         self.de += de_gr

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -52,10 +52,10 @@ class DoubleCO(detached_step):
 
         super().__call__(binary)
 
-        #binary.separation = self.res.y[0][-1] * 100_000 / constants.Rsun
-        ##binary.orbital_period = orbital_period_from_separation(
-        #    binary.separation, binary.star_1.mass, binary.star_2.mass
-        #)
+        binary.separation = self.res.y[0][-1] * 100_000 / constants.Rsun
+        binary.orbital_period = orbital_period_from_separation(
+            binary.separation, binary.star_1.mass, binary.star_2.mass
+        )
         binary.V_sys = binary.V_sys_history[-1]
 
         #if self.res.status == -1:
@@ -115,26 +115,19 @@ class DoubleCO(detached_step):
         if len(sol) == 1:
             output_solution = CombinedSolution()
             output_solution.t = sol[0].t + t0
-            output_solution.y = sol[0].y.copy()
-            output_solution.y[0] = output_solution.y[0] * 100_000 / constants.Rsun
+            output_solution.y = sol[0].y
             output_solution.status = sol[0].status
             output_solution.message = sol[0].message
             output_solution.t_events = sol[0].t_events
             output_solution.y_events = sol[0].y_events
             output_solution.success = sol[0].success
-            # Wrap sol() to convert separation from km to Rsun
-            def wrapped_sol(t):
-                result = sol[0].sol(t - t0)
-                result[0] = result[0] * 100_000 / constants.Rsun
-                return result
-            output_solution.sol = wrapped_sol
+            output_solution.sol = lambda t: sol[0].sol(t-t0)
+
 
         else:
             output_solution = CombinedSolution()
             output_solution.t = np.concatenate([t0+t.t for t, t0 in zip(sol, time_sol)])
-            combined_y = np.hstack([s.y for s in sol])
-            combined_y[0] = combined_y[0] * 100_000 / constants.Rsun
-            output_solution.y = combined_y
+            output_solution.y = np.hstack([s.y for s in sol])
             output_solution.status = sol[-1].status
             output_solution.message = sol[-1].message
             output_solution.t_events = sol[-1].t_events
@@ -145,9 +138,7 @@ class DoubleCO(detached_step):
             def combined_sol(t):
                 for s, t0 in zip(sol, time_sol):
                     if t0 <= t <= t0 + s.t[-1]:
-                        result = s.sol(t - t0)
-                        result[0] = result[0] * 100_000 / constants.Rsun
-                        return result
+                        return s.sol(t - t0)
                 raise ValueError(f"Time {t} is out of bounds for the combined solution.")
 
             output_solution.sol = combined_sol

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -132,9 +132,6 @@ class DoubleCO(detached_step):
                 appended = False
                 for s in sol[::-1]:
                     if 0 <= time <= s.t[-1]:
-                        print("t = ", time)
-                        print("t_final = ", s.t[-1])
-                        print("a [Rsun] = ", s.sol(time)[0] * 100_000 / constants.Rsun)
                         solutions.append(s.sol(time))
                         appended = True
                         break

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -174,14 +174,17 @@ class DoubleCO(detached_step):
             evolution in years. This is a float unless the
             user specifies a timestep (see `n_o_steps_history`
             or `dt`) to use via the simulation properties ini
-            file, in which case it is an array.
+            file, in which case it is an array. For DCO objects,
+            this needs to be on the time scale of the inerpolants
+            from solve_ivp, so does not represent the real binary
+            time. This is corrected later in the __call__ method.
 
         """
 
+        t = np.array([])
+        real_time = np.array([])
         if self.dt is not None and self.dt > 0:
 
-            t = np.array([])
-            real_time = np.array([])
             for k, time_arr in enumerate(self.res.time_arrs):
                 t_chunk = np.arange(time_arr[0], time_arr[-1] + self.dt/2.0, self.dt)[1:]
 
@@ -198,13 +201,9 @@ class DoubleCO(detached_step):
             if t[-1] != self.res.t[-1]:
                 t[-1] = self.res.t[-1]
                 real_time[-1] = self.res.t[-1] + self.res.time_sols[-1]
-            # store this for later
-            self.res.real_time = real_time
 
         elif (self.n_o_steps_history is not None and self.n_o_steps_history > 0):
 
-            t = np.array([])
-            real_time = np.array([])
             for k, time_arr in enumerate(self.res.time_arrs):
                 t_step = (time_arr[-1] - time_arr[0]) / self.n_o_steps_history
                 t_chunk = np.arange(time_arr[0], time_arr[-1] + t_step/2.0, t_step)[1:]
@@ -215,11 +214,12 @@ class DoubleCO(detached_step):
                 t = np.hstack([t, t_chunk])
                 real_time = np.hstack([real_time, t_chunk + self.res.time_sols[k]])
 
-            self.res.real_time = real_time
-
         else:  # self.dt is None and self.n_o_steps_history is None
             t = np.array([self.res.t[-1]])
-            self.res.real_time = t + self.res.time_sols[-1]
+            real_time = t + self.res.time_sols[-1]
+
+        # store this for later to convert time back to real time
+        self.res.real_time = real_time
 
         return t
 

--- a/posydon/binary_evol/DT/double_CO.py
+++ b/posydon/binary_evol/DT/double_CO.py
@@ -9,7 +9,6 @@ __authors__ = [
 
 
 import numpy as np
-from mpmath import mp, mpf
 from scipy.integrate import solve_ivp
 
 import posydon.utils.constants as constants


### PR DESCRIPTION
This builds off of [PR#809](https://github.com/POSYDON-code/POSYDON/pull/809) from @maxbriel.

The primary difference is that this PR contains a new `get_time_after_evo` and altered `combined_sol` function to manage combining the compact object step's multiple `solve_ivp` attempts, which occur at increasingly smaller time resolutions.

The DCO solver currently works by making several `solve_ivp` calls at progressively smaller timescales.

```
        ...

        t0 = binary.time
        n = 0
        status = -1
        while status == -1 and n < 6:
            try:
                res = solve_ivp(self.evo,
                                events=self.evo.ev_contact,
                                method="BDF",
                                t_span=(0, self.max_time-t0),
                                ...)
            except Exception as e:
                ...

            
            t0 += res.t[-1]
            n += 1
            ...

```

The time span `(0, self.max_time-t0)` is reduced on each `while` loop pass. Typically the first iteration spans the greatest interval and subsequent iterations span shorter intervals. The time scale varies widely between intervals, for example it can be on the order of `1e9` yr on the first pass and `1e-8` yr on the final pass as it resolves the DCO inspiral and contact event.

Each iteration produces an interpolant (accessed as `res.sol`) from `solve_ivp` that is valid over the time span `(0, res.t[-1])` that it was solved for. The value `res.t[-1]` represents the final time point in the ODE solution. These interpolants are subsequently used to determine the binary separation and orbital period of the DCO, but each will only provide appropriate solutions for times input in the range `(0, res.t[-1])`.

In principle, to get appropriate solutions, we could offset any time input to these interpolants by the appropriate `t0`. Based on the fact that `res.t + t0` represents the actual age of the binary. So e.g., `res.t[-1] + t0 = t_final` and thus `res.t[-1] = t_final - t0`, inputting some other time (`t_input`) less than `t_final` should translate to the correct age needed for the interpolant. However, the difference `t_input - t0` becomes an issue when the difference needs to be on the scale of `1e-8` and input times are on the scale of `1e9`, which is fairly typical. Due to machine precision, this difference can not be resolved on this scale and the difference `t_input - t0` effectively is rounded to 0 always, always providing the wrong time input for the inteprolant.

This PR attempts to remedy this by shifting the input times to the appropriate timescale before using them with the interpolants.