### PR TITLE
[fix] Variable assignment for binary star example

### DIFF
--- a/dev-tools/script_data/1Zsun_binaries_suite.py
+++ b/dev-tools/script_data/1Zsun_binaries_suite.py
@@ -766,7 +766,7 @@ def evolve_binaries(verbose):
     star1 = SingleStar(**{'mass': 7.939736047577677,
                         'state': 'H-rich_Core_H_burning',
                         'natal_kick_array': [0.0, 0.0, 0.0, 0.0]})
-    star1 = SingleStar(**{'mass': 6.661421823348241,
+    star2 = SingleStar(**{'mass': 6.661421823348241,
                         'state': 'H-rich_Core_H_burning',
                         'natal_kick_array': [0.0, 0.0, 0.0, 0.0]})
 

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -97,8 +97,8 @@ ONELINE_MIN_ITEMSIZE = {'state_i': 30, 'state_f': 30,
                         'interp_class_CO_HMS_RLO' : 15, 'interp_class_CO_HeMS_RLO' : 15,
                         'mt_history_HMS_HMS' : 40, 'mt_history_CO_HeMS' : 40,
                         'mt_history_CO_HMS_RLO' : 40, 'mt_history_CO_HeMS_RLO' : 40,
-                        'culmulative_mt_case_HMS_HMS': 40, 'culmulative_mt_case_CO_HeMS': 40,
-                        'culmulative_mt_case_CO_HMS_RLO': 40, 'culmulative_mt_case_CO_HeMS_RLO': 40,
+                        'cumulative_mt_case_HMS_HMS': 40, 'cumulative_mt_case_CO_HeMS': 40,
+                        'cumulative_mt_case_CO_HMS_RLO': 40, 'cumulative_mt_case_CO_HeMS_RLO': 40,
                         }
 
 # BinaryPopulation will enforce a constant metallicity accross all steps that

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -97,8 +97,8 @@ ONELINE_MIN_ITEMSIZE = {'state_i': 30, 'state_f': 30,
                         'interp_class_CO_HMS_RLO' : 15, 'interp_class_CO_HeMS_RLO' : 15,
                         'mt_history_HMS_HMS' : 40, 'mt_history_CO_HeMS' : 40,
                         'mt_history_CO_HMS_RLO' : 40, 'mt_history_CO_HeMS_RLO' : 40,
-                        'cumulative_mt_case_HMS_HMS': 40, 'cumulative_mt_case_CO_HeMS': 40,
-                        'cumulative_mt_case_CO_HMS_RLO': 40, 'cumulative_mt_case_CO_HeMS_RLO': 40,
+                        'culmulative_mt_case_HMS_HMS': 40, 'culmulative_mt_case_CO_HeMS': 40,
+                        'culmulative_mt_case_CO_HMS_RLO': 40, 'culmulative_mt_case_CO_HeMS_RLO': 40,
                         }
 
 # BinaryPopulation will enforce a constant metallicity accross all steps that


### PR DESCRIPTION
A typo in star2 was overwriting star1 instead.