### PR TITLE
[fix] Typo culmulative to cumulative

### DIFF
--- a/posydon/binary_evol/MESA/step_mesa.py
+++ b/posydon/binary_evol/MESA/step_mesa.py
@@ -696,8 +696,8 @@ class MesaGridStep:
         setattr(binary, 'event', binary_event)
         setattr(binary, 'mass_transfer_case', MT_case)
 
-        culmulative_mt_case = self.termination_flags[1]
-        setattr(self.binary, f'culmulative_mt_case_{self.grid_type}', culmulative_mt_case)
+        cumulative_mt_case = self.termination_flags[1]
+        setattr(self.binary, f'cumulative_mt_case_{self.grid_type}', cumulative_mt_case)
         setattr(self.binary, f'interp_class_{self.grid_type}', interpolation_class)
         mt_history = self.termination_flags[2] # mass transfer history (TF12 plot label)
         setattr(self.binary, f'mt_history_{self.grid_type}', mt_history)
@@ -930,7 +930,7 @@ class MesaGridStep:
         setattr(self.binary, f'mt_history_{self.grid_type}', mt_history)
 
         #TODO: add classifier for tf2
-        #setattr(self.binary, f'culmulative_mt_case', self.classes['termination_flags_2'])
+        #setattr(self.binary, f'cumulative_mt_case', self.classes['termination_flags_2'])
         S1_state_inferred = cf.check_state_of_star(self.binary.star_1,
                                                    star_CO=star_1_CO)
         S2_state_inferred = cf.check_state_of_star(self.binary.star_2,

--- a/posydon/binary_evol/binarystar.py
+++ b/posydon/binary_evol/binarystar.py
@@ -222,8 +222,8 @@ class BinaryStar:
                 setattr(self, f'interp_class_{grid_type}', None)
             if not hasattr(self, f'mt_history_{grid_type}'):
                 setattr(self, f'mt_history_{grid_type}', None)
-            if not hasattr(self, f'culmulative_mt_case_{grid_type}'):
-                setattr(self, f'culmulative_mt_case_{grid_type}', None)
+            if not hasattr(self, f'cumulative_mt_case_{grid_type}'):
+                setattr(self, f'cumulative_mt_case_{grid_type}', None)
 
         # SimulationProperties object - parameters & parameterizations
         if isinstance(properties, SimulationProperties):

--- a/posydon/popsyn/binarypopulation.py
+++ b/posydon/popsyn/binarypopulation.py
@@ -97,8 +97,8 @@ ONELINE_MIN_ITEMSIZE = {'state_i': 30, 'state_f': 30,
                         'interp_class_CO_HMS_RLO' : 15, 'interp_class_CO_HeMS_RLO' : 15,
                         'mt_history_HMS_HMS' : 40, 'mt_history_CO_HeMS' : 40,
                         'mt_history_CO_HMS_RLO' : 40, 'mt_history_CO_HeMS_RLO' : 40,
-                        'culmulative_mt_case_HMS_HMS': 40, 'culmulative_mt_case_CO_HeMS': 40,
-                        'culmulative_mt_case_CO_HMS_RLO': 40, 'culmulative_mt_case_CO_HeMS_RLO': 40,
+                        'cumulative_mt_case_HMS_HMS': 40, 'cumulative_mt_case_CO_HeMS': 40,
+                        'cumulative_mt_case_CO_HMS_RLO': 40, 'cumulative_mt_case_CO_HeMS_RLO': 40,
                         }
 
 # BinaryPopulation will enforce a constant metallicity accross all steps that


### PR DESCRIPTION
Fixes a typo in the BinaryStar property "culmulative" -> "cumulative".

This should only affect the outputted onelines in populations runs, but we don't really advertise this column at the moment anyway.