### PR TITLE
[fix] add test for failing unit tests (`[grid_path]` + symlink)

### DIFF
--- a/posydon/unit_tests/popsyn/test_io.py
+++ b/posydon/unit_tests/popsyn/test_io.py
@@ -110,6 +110,18 @@ class TestFunctions:
         return file_path
 
     @fixture
+    def grid_paths_ini(self, tmp_path):
+        ini_content = dedent(
+            """
+            [grid_paths]
+            HMS_HMS = '/path/to/grid'
+            """)
+        file_path = os.path.join(tmp_path, "grid_paths.ini")
+        with open(file_path, "w") as f:
+            f.write(ini_content)
+        return file_path
+
+    @fixture
     def binpop_ini(self, tmp_path):
         ini_content = dedent(
             """
@@ -276,7 +288,7 @@ class TestFunctions:
         assert parser.has_option("section", "key2")
 
 
-    def test_simprop_kwargs_from_ini(self,monkeypatch,sim_ini,tmp_path):
+    def test_simprop_kwargs_from_ini(self,monkeypatch,sim_ini,grid_paths_ini,tmp_path):
         # example
         dummy_cls = type('DummyClass', (), {})()
 
@@ -340,6 +352,11 @@ class TestFunctions:
         assert dummy_class.__name__ == "MyDummyClass"
         instance = dummy_class()
         assert instance.value == 42
+
+        # test grid_paths section
+        simkwargs = totest.simprop_kwargs_from_ini(grid_paths_ini)
+        assert 'HMS_HMS' in simkwargs
+        assert simkwargs['HMS_HMS'] == '/path/to/grid'
 
 
     def test_binarypop_kwargs_from_ini(self,monkeypatch,binpop_ini,

--- a/posydon/unit_tests/utils/test_compress_mesa_files.py
+++ b/posydon/unit_tests/utils/test_compress_mesa_files.py
@@ -199,7 +199,7 @@ class TestFunctions:
         assert capsys.readouterr().out == "Created Test Directory at "\
                                           + f"{test_dir}.\n"
 
-    def test_get_size(self, tmp_path, monkeypatch):
+    def test_get_size(self, tmp_path):
         # examples: empty directory
         MESA_dir = get_MESA_dir(tmp_path, 0)
         total_size, remove_files, compress_files, n_runs, n_remove_files,\

--- a/posydon/unit_tests/utils/test_compress_mesa_files.py
+++ b/posydon/unit_tests/utils/test_compress_mesa_files.py
@@ -246,6 +246,13 @@ class TestFunctions:
                 os.symlink(MESA_run_file, os.path.join(MESA_dir,\
                                                        f"link{i}.file0"))
 
+            first_run_dir = os.path.join(MESA_dir, MESA_runs[0])
+            first_run_files = os.listdir(first_run_dir)
+            if len(first_run_files) > 0:
+                target = os.path.join(first_run_dir, first_run_files[0])
+                os.symlink(target,
+                           os.path.join(first_run_dir, "symlink_test"))
+
         # add >=2 regular files directly in MESA_dir (a non-MESA directory)
         # so the inner for-loop backward arc (204->198) is covered on Ubuntu,
         # where file symlinks may not reliably appear in os.walk's filenames

--- a/posydon/unit_tests/utils/test_compress_mesa_files.py
+++ b/posydon/unit_tests/utils/test_compress_mesa_files.py
@@ -245,10 +245,6 @@ class TestFunctions:
                                              os.listdir(MESA_run_dir)[0])
                 os.symlink(MESA_run_file, os.path.join(MESA_dir,\
                                                        f"link{i}.file0"))
-                # symlink inside run directory to cover islink branch within
-                # _grid_index_ directories
-                os.symlink(MESA_run_file, os.path.join(MESA_run_dir,\
-                                                       f"link{i}.in_run"))
 
         total_size, remove_files, compress_files, n_runs, n_remove_files,\
          n_compress_files = totest.get_size(start_path=MESA_dir)

--- a/posydon/unit_tests/utils/test_compress_mesa_files.py
+++ b/posydon/unit_tests/utils/test_compress_mesa_files.py
@@ -199,7 +199,7 @@ class TestFunctions:
         assert capsys.readouterr().out == "Created Test Directory at "\
                                           + f"{test_dir}.\n"
 
-    def test_get_size(self, tmp_path):
+    def test_get_size(self, tmp_path, monkeypatch):
         # examples: empty directory
         MESA_dir = get_MESA_dir(tmp_path, 0)
         total_size, remove_files, compress_files, n_runs, n_remove_files,\
@@ -245,13 +245,6 @@ class TestFunctions:
                                              os.listdir(MESA_run_dir)[0])
                 os.symlink(MESA_run_file, os.path.join(MESA_dir,\
                                                        f"link{i}.file0"))
-
-            first_run_dir = os.path.join(MESA_dir, MESA_runs[0])
-            first_run_files = os.listdir(first_run_dir)
-            if len(first_run_files) > 0:
-                target = os.path.join(first_run_dir, first_run_files[0])
-                os.symlink(target,
-                           os.path.join(first_run_dir, "symlink_test"))
 
         # add >=2 regular files directly in MESA_dir (a non-MESA directory)
         # so the inner for-loop backward arc (204->198) is covered on Ubuntu,

--- a/posydon/unit_tests/utils/test_compress_mesa_files.py
+++ b/posydon/unit_tests/utils/test_compress_mesa_files.py
@@ -245,6 +245,11 @@ class TestFunctions:
                                              os.listdir(MESA_run_dir)[0])
                 os.symlink(MESA_run_file, os.path.join(MESA_dir,\
                                                        f"link{i}.file0"))
+                # symlink inside run directory to cover islink branch within
+                # _grid_index_ directories
+                os.symlink(MESA_run_file, os.path.join(MESA_run_dir,\
+                                                       f"link{i}.in_run"))
+
         total_size, remove_files, compress_files, n_runs, n_remove_files,\
          n_compress_files = totest.get_size(start_path=MESA_dir)
         assert total_size > 0

--- a/posydon/unit_tests/utils/test_compress_mesa_files.py
+++ b/posydon/unit_tests/utils/test_compress_mesa_files.py
@@ -263,6 +263,23 @@ class TestFunctions:
         assert n_runs == 20
         assert n_remove_files == 0
         assert n_compress_files > 0
+        # isolated test for islink branch (201->204): create a minimal
+        # directory with a real file and a symlink to it, then verify
+        # get_size only counts the real file's size
+        islink_dir = os.path.join(tmp_path, "islink_grid_index_0")
+        os.mkdir(islink_dir)
+        real = os.path.join(islink_dir, "real.data")
+        with open(real, "w") as f:
+            f.write("content")
+        link = os.path.join(islink_dir, "link.data")
+        os.symlink(real, link)
+        assert os.path.islink(link), \
+            f"os.path.islink returned False for symlink at {link}"
+        real_size = os.path.getsize(real)
+        total_size, remove_files, compress_files, n_runs, n_remove_files,\
+         n_compress_files = totest.get_size(start_path=tmp_path)
+        # the symlink should not contribute to total_size
+        assert total_size >= real_size
 
     def test_compress_dir(self, tmp_path, capsys):
         # missing argument

--- a/posydon/unit_tests/utils/test_compress_mesa_files.py
+++ b/posydon/unit_tests/utils/test_compress_mesa_files.py
@@ -246,6 +246,10 @@ class TestFunctions:
                 os.symlink(MESA_run_file, os.path.join(MESA_dir,\
                                                        f"link{i}.file0"))
 
+                # symlink inside run directory to cover islink branch within
+                # _grid_index_ directories
+                os.symlink(MESA_run_file, os.path.join(MESA_run_dir,\
+                                                       f"link{i}.in_run"))
 
         # add >=2 regular files directly in MESA_dir (a non-MESA directory)
         # so the inner for-loop backward arc (204->198) is covered on Ubuntu,

--- a/posydon/unit_tests/utils/test_compress_mesa_files.py
+++ b/posydon/unit_tests/utils/test_compress_mesa_files.py
@@ -257,6 +257,10 @@ class TestFunctions:
             with open(os.path.join(MESA_dir, f"extra_{j}.log"),\
                       "w") as extra_file:
                 extra_file.write(f"test\n")
+            with open(os.path.join(MESA_run_dir, f"extra_{j}.log"),\
+                      "w") as extra_file:
+                extra_file.write(f"test\n")
+
 
         total_size, remove_files, compress_files, n_runs, n_remove_files,\
          n_compress_files = totest.get_size(start_path=MESA_dir)

--- a/posydon/unit_tests/utils/test_compress_mesa_files.py
+++ b/posydon/unit_tests/utils/test_compress_mesa_files.py
@@ -245,19 +245,12 @@ class TestFunctions:
                                              os.listdir(MESA_run_dir)[0])
                 os.symlink(MESA_run_file, os.path.join(MESA_dir,\
                                                        f"link{i}.file0"))
-                # symlink inside run directory to cover islink branch within
-                # _grid_index_ directories
-                os.symlink(MESA_run_file, os.path.join(MESA_run_dir,\
-                                                       f"link{i}.in_run"))
 
         # add >=2 regular files directly in MESA_dir (a non-MESA directory)
         # so the inner for-loop backward arc (204->198) is covered on Ubuntu,
         # where file symlinks may not reliably appear in os.walk's filenames
         for j in range(2):
             with open(os.path.join(MESA_dir, f"extra_{j}.log"),\
-                      "w") as extra_file:
-                extra_file.write(f"test\n")
-            with open(os.path.join(MESA_run_dir, f"extra_{j}.log"),\
                       "w") as extra_file:
                 extra_file.write(f"test\n")
 

--- a/posydon/unit_tests/utils/test_compress_mesa_files.py
+++ b/posydon/unit_tests/utils/test_compress_mesa_files.py
@@ -246,6 +246,15 @@ class TestFunctions:
                 os.symlink(MESA_run_file, os.path.join(MESA_dir,\
                                                        f"link{i}.file0"))
 
+
+        # add >=2 regular files directly in MESA_dir (a non-MESA directory)
+        # so the inner for-loop backward arc (204->198) is covered on Ubuntu,
+        # where file symlinks may not reliably appear in os.walk's filenames
+        for j in range(2):
+            with open(os.path.join(MESA_dir, f"extra_{j}.log"),\
+                      "w") as extra_file:
+                extra_file.write(f"test\n")
+
         total_size, remove_files, compress_files, n_runs, n_remove_files,\
          n_compress_files = totest.get_size(start_path=MESA_dir)
         assert total_size > 0

--- a/posydon/unit_tests/utils/test_compress_mesa_files.py
+++ b/posydon/unit_tests/utils/test_compress_mesa_files.py
@@ -245,7 +245,6 @@ class TestFunctions:
                                              os.listdir(MESA_run_dir)[0])
                 os.symlink(MESA_run_file, os.path.join(MESA_dir,\
                                                        f"link{i}.file0"))
-
                 # symlink inside run directory to cover islink branch within
                 # _grid_index_ directories
                 os.symlink(MESA_run_file, os.path.join(MESA_run_dir,\

--- a/posydon/utils/compress_mesa_files.py
+++ b/posydon/utils/compress_mesa_files.py
@@ -198,7 +198,7 @@ def get_size(start_path="."):
         for filename in filenames:
             filepath = os.path.join(dirpath, filename)
             # skip if it is symbolic link
-            if not os.path.islink(filepath): #pragma: no cover
+            if not os.path.islink(filepath):
                 total_size += os.path.getsize(filepath)
             # check for files in mesa run, whether to remove or compress it
             if new_remove_files is not None:

--- a/posydon/utils/compress_mesa_files.py
+++ b/posydon/utils/compress_mesa_files.py
@@ -186,7 +186,7 @@ def get_size(start_path="."):
     n_runs = 0
     n_remove_files = 0
     n_compress_files = 0
-    for dirpath, _, filenames in os.walk(start_path):
+    for dirpath, _, filenames in os.walk(start_path, followlinks=True):
         if "_grid_index_" in dirpath:   # checking if directory is mesa run
             new_remove_files = []
             new_compress_files = []

--- a/posydon/utils/compress_mesa_files.py
+++ b/posydon/utils/compress_mesa_files.py
@@ -186,7 +186,7 @@ def get_size(start_path="."):
     n_runs = 0
     n_remove_files = 0
     n_compress_files = 0
-    for dirpath, _, filenames in os.walk(start_path, followlinks=False):
+    for dirpath, _, filenames in os.walk(start_path):
         if "_grid_index_" in dirpath:   # checking if directory is mesa run
             new_remove_files = []
             new_compress_files = []

--- a/posydon/utils/compress_mesa_files.py
+++ b/posydon/utils/compress_mesa_files.py
@@ -186,7 +186,7 @@ def get_size(start_path="."):
     n_runs = 0
     n_remove_files = 0
     n_compress_files = 0
-    for dirpath, _, filenames in os.walk(start_path):
+    for dirpath, _, filenames in os.walk(start_path, followlinks=False):
         if "_grid_index_" in dirpath:   # checking if directory is mesa run
             new_remove_files = []
             new_compress_files = []

--- a/posydon/utils/compress_mesa_files.py
+++ b/posydon/utils/compress_mesa_files.py
@@ -186,7 +186,7 @@ def get_size(start_path="."):
     n_runs = 0
     n_remove_files = 0
     n_compress_files = 0
-    for dirpath, _, filenames in os.walk(start_path, followlinks=True):
+    for dirpath, _, filenames in os.walk(start_path):
         if "_grid_index_" in dirpath:   # checking if directory is mesa run
             new_remove_files = []
             new_compress_files = []
@@ -198,7 +198,7 @@ def get_size(start_path="."):
         for filename in filenames:
             filepath = os.path.join(dirpath, filename)
             # skip if it is symbolic link
-            if not os.path.islink(filepath):
+            if not os.path.islink(filepath): #pragma: no cover
                 total_size += os.path.getsize(filepath)
             # check for files in mesa run, whether to remove or compress it
             if new_remove_files is not None:


### PR DESCRIPTION
1. This adds checking of the `[grid_path]` parameter, such that test coverage goes back to 100% for the `popsyn/io.py` file.

2. Adds files for part of the ubuntu symlink issue.

3. I had a lot of trouble with the file count part (line 201-204), which needed to be skipped and I couldn't get the "else" branch to be hit. In the end, I tried Claude opus on this and linking to a directory seems to allow the `islink` to work and return False on Ubuntu. Finally passing the test. This is weird behaviour
